### PR TITLE
Add process owner info to the ps command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,80 +2,123 @@
 
 
 [[projects]]
+  branch = "master"
+  digest = "1:534bfc1a194affafadc94be31ac3e221de127e47c0c28b3fe8eddc7ca1656f2f"
+  name = "github.com/chzyer/readline"
+  packages = ["."]
+  pruneopts = ""
+  revision = "2972be24d48e78746da79ba8e24e8b488c9880de"
+
+[[projects]]
+  digest = "1:3522d0cc6a8f41d4a91b757b1042bb89dc261a36aebfb47ae81bf37aeade2768"
   name = "github.com/gobuffalo/envy"
   packages = ["."]
+  pruneopts = ""
   revision = "f3b98d4da2fa434517f47f615e217fa72ff2c51e"
   version = "v1.6.12"
 
 [[projects]]
   branch = "master"
+  digest = "1:3637ea23c1d8720d62f8400f4b3b5750b11c35baa093a97856bc6295c77cf372"
   name = "github.com/gobuffalo/packd"
   packages = ["."]
+  pruneopts = ""
   revision = "eca3b8fd66872a76119b189bbe0f58f776a2a39f"
 
 [[projects]]
+  digest = "1:82c8a32555836303cadb66876d39e3adae68c969cf9de02dd6cf989ddd8823b3"
   name = "github.com/gobuffalo/packr"
   packages = ["."]
+  pruneopts = ""
   revision = "679459352e18b4c74274a979d695fe13b68730c1"
   version = "v1.21.9"
 
 [[projects]]
   branch = "master"
+  digest = "1:6098f692e043c3ee2612f47f214d169a3bdeb13ee37f946d10353b5e37aa702b"
   name = "github.com/gobuffalo/syncx"
   packages = ["."]
+  pruneopts = ""
   revision = "558ac7de985fc4f4057bff27c7bdf99e92fe0750"
 
 [[projects]]
+  digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = ""
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:7df5a9695a743c3e1626b28bb8741602c8c15527e1efaeaec48ab2ff9a23f74c"
   name = "github.com/joho/godotenv"
   packages = ["."]
+  pruneopts = ""
   revision = "23d116af351c84513e1946b527c88823e476be13"
   version = "v1.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:ff3d3a7e367bf58b25e3c9203b7e82a02b2bfa220eacb2b362c0dbc3fcffa15b"
   name = "github.com/markbates/oncer"
   packages = ["."]
+  pruneopts = ""
   revision = "bf2de49a0be218916e69a11d22866e6cd0a560f2"
 
 [[projects]]
+  digest = "1:1d7e1867c49a6dd9856598ef7c3123604ea3daabf5b83f303ff457bcbc410b1d"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = ""
   revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
   version = "v0.8.1"
 
 [[projects]]
+  digest = "1:8709094ab0fc13daac9566f27afeea57885e16525b8709074260176f69396c31"
   name = "github.com/rogpeppe/go-internal"
-  packages = ["modfile","module","semver"]
+  packages = [
+    "modfile",
+    "module",
+    "semver",
+  ]
+  pruneopts = ""
   revision = "68d1cb014f030acd0f10ac553801e43c0e5da629"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
-  revision = "057139ce5d2bdbe6fe73c53679e24e9cf007f637"
-
-[[projects]]
-  branch = "master"
+  digest = "1:7e3b61f51ebcb58b3894928ed7c63aae68820dec1dd57166e5d6e65ef2868f40"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
-  revision = "c6b37f3e92850b723493d63fd35aad34e19e048d"
+  packages = ["unix"]
+  pruneopts = ""
+  revision = "b90733256f2e882e81d52f9126de08df5615afd9"
 
 [[projects]]
   branch = "master"
+  digest = "1:01262b632bd8f6f360ef56c6746d90360972093be07268a44c5841d468e22480"
   name = "golang.org/x/tools"
-  packages = ["go/ast/astutil","go/buildutil","go/internal/cgo","go/loader","go/types/typeutil","refactor/importgraph","refactor/rename","refactor/satisfy"]
+  packages = [
+    "go/ast/astutil",
+    "go/buildutil",
+    "go/internal/cgo",
+    "go/loader",
+    "go/types/typeutil",
+    "refactor/importgraph",
+    "refactor/rename",
+    "refactor/satisfy",
+  ]
+  pruneopts = ""
   revision = "0c44af741bb7ee876f4c02a8205654b087b73f51"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6f00187507e7ef8a2ca91137be5a20cadc801d79c2d78b24b776c2b0e795b7cf"
+  input-imports = [
+    "github.com/chzyer/readline",
+    "github.com/gobuffalo/packr",
+    "github.com/golang/protobuf/proto",
+    "golang.org/x/tools/refactor/importgraph",
+    "golang.org/x/tools/refactor/rename",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,3 +13,7 @@
 [[constraint]]
   branch = "master"
   name = "golang.org/x/tools"
+
+[[override]]
+  branch = "master"
+  name = "github.com/chzyer/readline"

--- a/protobuf/sliver.proto
+++ b/protobuf/sliver.proto
@@ -49,6 +49,7 @@ message Process {
   int32 pid = 1;
   int32 ppid = 2;
   string executable = 3;
+  string owner = 4;
 }
 
 message ProcessList {

--- a/server/console-cmd.go
+++ b/server/console-cmd.go
@@ -383,7 +383,7 @@ func psCmd(term *readline.Instance, args []string) {
 		return
 	}
 
-	header := fmt.Sprintf("\n% 6s | % 6s | %s\n", "pid", "ppid", "executable")
+	header := fmt.Sprintf("\n% 6s | % 6s | % 40s | %s\n", "pid", "ppid", "executable", "owner")
 	fmt.Fprintf(term, header)
 	fmt.Fprintf(term, "%s\n", strings.Repeat("=", len(header)))
 	for _, proc := range psList.Processes {
@@ -414,8 +414,8 @@ func printProcInfo(term *readline.Instance, proc *pb.Process) {
 	if proc.Pid == activeSliver.Pid {
 		color = green
 	}
-	fmt.Fprintf(term, "%s%s% 6d%s%s | % 6d | %s%s\n",
-		color, bold, proc.Pid, normal, color, proc.Ppid, proc.Executable, normal)
+	fmt.Fprintf(term, "%s%s% 6d%s%s | % 6d | % 40s%s | %s%s%s\n",
+		color, bold, proc.Pid, normal, color, proc.Ppid, proc.Executable, normal, color, proc.Owner, normal)
 }
 
 func pingCmd(term *readline.Instance, args []string) {

--- a/sliver/handlers.go
+++ b/sliver/handlers.go
@@ -57,6 +57,7 @@ func psHandler(send chan pb.Envelope, data []byte) {
 			Pid:        int32(proc.Pid()),
 			Ppid:       int32(proc.PPid()),
 			Executable: proc.Executable(),
+			Owner:      proc.Owner(),
 		})
 	}
 	data, _ = proto.Marshal(psList)

--- a/sliver/ps.go
+++ b/sliver/ps.go
@@ -20,6 +20,9 @@ type Process interface {
 	// Executable name running this process. This is not a path to the
 	// executable.
 	Executable() string
+
+	// Owner is the account name of the process owner.
+	Owner() string
 }
 
 // Processes returns all processes.

--- a/sliver/sliver.go
+++ b/sliver/sliver.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+
 	"log"
 	"os"
 	"os/user"


### PR DESCRIPTION
This PR adds the process owner info for the ps command. Currently only supported on windows.

It also fixes the `Gopkg.toml` dep for readline.