### PR TITLE
Implemet kick-player functionality and client certificate verification

### DIFF
--- a/server/certs/certs.go
+++ b/server/certs/certs.go
@@ -131,7 +131,7 @@ func GetCertificate(caType string, keyType string, commonName string) ([]byte, [
 }
 
 // RemoveCertificate - Remove a certificate from the cert store
-func RemoveCertificate(caType string, commonName string, keyType string) error {
+func RemoveCertificate(caType string, keyType string, commonName string) error {
 	if keyType != ECCKey && keyType != RSAKey {
 		return fmt.Errorf("Invalid key type '%s'", keyType)
 	}

--- a/server/certs/operators.go
+++ b/server/certs/operators.go
@@ -47,6 +47,11 @@ func OperatorClientGetCertificate(operator string) ([]byte, []byte, error) {
 	return GetCertificate(OperatorCA, ECCKey, fmt.Sprintf("%s.%s", clientNamespace, operator))
 }
 
+// OperatorClientRemoveCertificate - Helper function to remove a client cert
+func OperatorClientRemoveCertificate(operator string) error {
+	return RemoveCertificate(OperatorCA, ECCKey, fmt.Sprintf("%s.%s", clientNamespace, operator))
+}
+
 // OperatorServerGetCertificate - Helper function to fetch a client cert
 func OperatorServerGetCertificate(operator string) ([]byte, []byte, error) {
 	return GetCertificate(OperatorCA, ECCKey, fmt.Sprintf("%s.%s", serverNamespace, operator))

--- a/server/console/console-players.go
+++ b/server/console/console-players.go
@@ -130,7 +130,22 @@ func newPlayerCmd(ctx *grumble.Context) {
 }
 
 func kickPlayerCmd(ctx *grumble.Context) {
+	operator := ctx.Flags.String("operator")
 
+	regex, _ := regexp.Compile("[^A-Za-z0-9]+") // Only allow alphanumeric chars
+	operator = regex.ReplaceAllString(operator, "")
+
+	if operator == "" {
+		fmt.Printf(Warn + "Operator name required (--operator) \n")
+		return
+	}
+	fmt.Printf(Info+"Removing client certificate for operator %s, please wait ... \n", operator)
+	err := certs.OperatorClientRemoveCertificate(operator)
+	if err != nil {
+		fmt.Printf(Warn+"Failed to remove the operator certificate: %v \n", err)
+		return
+	}
+	fmt.Printf(Info+"Operator %s kicked out. \n", operator)
 }
 
 func startMultiplayerModeCmd(ctx *grumble.Context) {


### PR DESCRIPTION
Implementing #157 
- Implemented kick-player functionality  
- Implemented client certificate verification
- Changed RemoveCertificate function declaration to be consistent with others func in the same package (parameters order)

#### Details
It is now possible to kick a player out from the server through:
- removing the certificate from the server DB;
- checking if the client certificate is present in the DB before fully establishing the connection;

Initially the server would only validate the certificate chain and verify that the cert was issued by the correct CA (e.g. OperatorCA). With this code change the server verify if the client public key is in the server DB and refuse the connection if not.