### PR TITLE
Fix typo in generateEgg

### DIFF
--- a/client/command/bind-commands.go
+++ b/client/command/bind-commands.go
@@ -344,7 +344,7 @@ func BindCommands(app *grumble.App, server *core.SliverServer) {
 			f.String("c", "listener-url", "", "URL to fetch the stage from (tcp://SLIVER_SERVER:PORT or http(s)://SLIVER_SERVER:PORT")
 			f.String("v", "output-format", "raw", "Output format (msfvenom's style). All msfvenom's transform formats are supported")
 			f.String("x", "canary", "", "canary domain(s)")
-			f.Bool("s", "skip-symbols", false, "skip symbol obfuscation")
+			f.Bool("b", "skip-symbols", false, "skip symbol obfuscation")
 		},
 		Run: func(ctx *grumble.Context) error {
 			fmt.Println()


### PR DESCRIPTION
The bool value `skip-symbols` had the short flag set to `s`.
The string value `save` also had the short flag set to `s`.
I changed the short flag on `skip-symbols` to `b` to match the generate command.
