### PR TITLE
Fix #176: Crash on namedpipe pivot

### DIFF
--- a/sliver/handlers/handlers_windows.go
+++ b/sliver/handlers/handlers_windows.go
@@ -309,7 +309,7 @@ func nampedPipeConnectionHandler(conn *net.Conn, connection *transports.Connecti
 
 	defer func() {
 		// {{if .Debug}}
-		log.Println("Cleaning up for pivot %d", pivotID)
+		log.Printf("Cleaning up for pivot %d\n", pivotID)
 		// {{end}}
 		(*conn).Close()
 		pivotClose := &pb.PivotClose{
@@ -320,10 +320,13 @@ func nampedPipeConnectionHandler(conn *net.Conn, connection *transports.Connecti
 			// {{if .Debug}}
 			log.Println(err)
 			// {{end}}
+			return
 		}
-		connection.Send <- &pb.Envelope{
-			Type: pb.MsgPivotClose,
-			Data: data,
+		if connection.IsOpen {
+			connection.Send <- &pb.Envelope{
+				Type: pb.MsgPivotClose,
+				Data: data,
+			}
 		}
 	}()
 
@@ -353,9 +356,11 @@ func nampedPipeConnectionHandler(conn *net.Conn, connection *transports.Connecti
 			// {{end}}
 			return
 		}
-		connection.Send <- &pb.Envelope{
-			Type: pb.MsgPivotData,
-			Data: data2,
+		if connection.IsOpen {
+			connection.Send <- &pb.Envelope{
+				Type: pb.MsgPivotData,
+				Data: data2,
+			}
 		}
 	}
 }

--- a/sliver/transports/transports.go
+++ b/sliver/transports/transports.go
@@ -61,6 +61,7 @@ var (
 type Connection struct {
 	Send    chan *pb.Envelope
 	Recv    chan *pb.Envelope
+	IsOpen  bool
 	ctrl    chan bool
 	cleanup func()
 	once    *sync.Once
@@ -70,6 +71,7 @@ type Connection struct {
 
 // Cleanup - Execute cleanup once
 func (c *Connection) Cleanup() {
+	c.IsOpen = false
 	c.once.Do(c.cleanup)
 }
 
@@ -255,6 +257,7 @@ func mtlsConnect(uri *url.URL) (*Connection, error) {
 		tunnels: &map[uint64]*Tunnel{},
 		mutex:   &sync.RWMutex{},
 		once:    &sync.Once{},
+		IsOpen:  true,
 		cleanup: func() {
 			// {{if .Debug}}
 			log.Printf("[mtls] lost connection, cleanup...")
@@ -314,6 +317,7 @@ func httpConnect(uri *url.URL) (*Connection, error) {
 		tunnels: &map[uint64]*Tunnel{},
 		mutex:   &sync.RWMutex{},
 		once:    &sync.Once{},
+		IsOpen:  true,
 		cleanup: func() {
 			// {{if .Debug}}
 			log.Printf("[http] lost connection, cleanup...")
@@ -406,6 +410,7 @@ func dnsConnect(uri *url.URL) (*Connection, error) {
 		tunnels: &map[uint64]*Tunnel{},
 		mutex:   &sync.RWMutex{},
 		once:    &sync.Once{},
+		IsOpen:  true,
 		cleanup: func() {
 			// {{if .Debug}}
 			log.Printf("[dns] lost connection, cleanup...")
@@ -449,6 +454,7 @@ func namedPipeConnect(uri *url.URL) (*Connection, error) {
 		tunnels: &map[uint64]*Tunnel{},
 		mutex:   &sync.RWMutex{},
 		once:    &sync.Once{},
+		IsOpen:  true,
 		cleanup: func() {
 			// {{if .Debug}}
 			log.Printf("[namedpipe] lost connection, cleanup...")


### PR DESCRIPTION
Fix #176: Crash on namedpipe pivot. I added a new IsOpen boolean var in the connection which is set to true on the initialization process and to false in the Cleanup function before calling the custom handler. This var is checked before sending anything to connection.Send. 