### PR TITLE
Added blank default argument to execute-assembly.

### DIFF
--- a/client/command/tasks.go
+++ b/client/command/tasks.go
@@ -247,6 +247,8 @@ func executeAssembly(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 	assemblyArgs := ""
 	if len(ctx.Args) == 2 {
 		assemblyArgs = ctx.Args[1]
+	} else if len(ctx.Args) < 2 {
+		assemblyArgs = " "
 	}
 	process := ctx.Flags.String("process")
 


### PR DESCRIPTION
#### Details
Added blank default argument to execute-assembly. This avoids the need to pass dummy arguments to executables that don't need any parameters.