### PR TITLE
optional evasion

### DIFF
--- a/client/command/bind-commands.go
+++ b/client/command/bind-commands.go
@@ -352,6 +352,7 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 			f.String("o", "os", "windows", "operating system")
 			f.String("a", "arch", "amd64", "cpu architecture")
 			f.Bool("d", "debug", false, "enable debug features")
+			f.Bool("e", "evasion", false, "enable evasion features")
 			f.Bool("b", "skip-symbols", false, "skip symbol obfuscation")
 
 			f.String("c", "canary", "", "canary domain(s)")

--- a/client/command/generate.go
+++ b/client/command/generate.go
@@ -330,6 +330,7 @@ func parseCompileFlags(ctx *grumble.Context) *clientpb.ImplantConfig {
 		GOOS:             targetOS,
 		GOARCH:           arch,
 		Debug:            ctx.Flags.Bool("debug"),
+		Evasion:          ctx.Flags.Bool("evasion"),
 		ObfuscateSymbols: symbolObfuscation,
 		C2:               c2s,
 		CanaryDomains:    canaryDomains,

--- a/client/command/tasks.go
+++ b/client/command/tasks.go
@@ -404,10 +404,11 @@ func getActiveSliverConfig() *clientpb.ImplantConfig {
 		Priority: uint32(0),
 	})
 	config := &clientpb.ImplantConfig{
-		Name:   session.GetName(),
-		GOOS:   session.GetOS(),
-		GOARCH: session.GetArch(),
-		Debug:  true,
+		Name:    session.GetName(),
+		GOOS:    session.GetOS(),
+		GOARCH:  session.GetArch(),
+		Debug:   true,
+		Evasion: session.GetEvasion(),
 
 		MaxConnectionErrors: uint32(1000),
 		ReconnectInterval:   uint32(60),

--- a/protobuf/clientpb/client.proto
+++ b/protobuf/clientpb/client.proto
@@ -36,6 +36,7 @@ message Session {
   string LastCheckin = 13;
   string ActiveC2 = 14;
   string Version = 15;
+  bool Evasion = 16;
 }
 
 message ImplantC2 {

--- a/protobuf/clientpb/client.proto
+++ b/protobuf/clientpb/client.proto
@@ -52,6 +52,7 @@ message ImplantConfig {
   string Cert = 5;
   string Key = 6;
   bool Debug = 7;
+  bool Evasion = 31;
   bool ObfuscateSymbols = 30;
 
   uint32 ReconnectInterval = 8;

--- a/server/generate/binaries.go
+++ b/server/generate/binaries.go
@@ -93,6 +93,7 @@ type ImplantConfig struct {
 	Cert                string `json:"cert"`
 	Key                 string `json:"key"`
 	Debug               bool   `json:"debug"`
+	Evasion             bool   `json:"evasion"`
 	ObfuscateSymbols    bool   `json:"obfuscate_symbols"`
 	ReconnectInterval   int    `json:"reconnect_interval"`
 	MaxConnectionErrors int    `json:"max_connection_errors"`
@@ -131,6 +132,7 @@ func (c *ImplantConfig) ToProtobuf() *clientpb.ImplantConfig {
 		Cert:             c.Cert,
 		Key:              c.Key,
 		Debug:            c.Debug,
+		Evasion:          c.Evasion,
 		ObfuscateSymbols: c.ObfuscateSymbols,
 		CanaryDomains:    c.CanaryDomains,
 
@@ -166,6 +168,7 @@ func ImplantConfigFromProtobuf(pbConfig *clientpb.ImplantConfig) *ImplantConfig 
 	cfg.Cert = pbConfig.Cert
 	cfg.Key = pbConfig.Key
 	cfg.Debug = pbConfig.Debug
+	cfg.Evasion = pbConfig.Evasion
 	cfg.ObfuscateSymbols = pbConfig.ObfuscateSymbols
 	cfg.CanaryDomains = pbConfig.CanaryDomains
 

--- a/sliver/procdump/dump_windows.go
+++ b/sliver/procdump/dump_windows.go
@@ -26,13 +26,16 @@ import (
 	"log"
 	//{{end}}
 
+	// {{if .Evasion}}
 	// {{if eq .GOARCH "amd64"}}
 	"github.com/bishopfox/sliver/sliver/evasion"
 	// {{end}}
-	"github.com/bishopfox/sliver/sliver/syscalls"
-	"github.com/bishopfox/sliver/sliver/priv"
-	"golang.org/x/sys/windows"
+	// {{end}}
 	"os"
+
+	"github.com/bishopfox/sliver/sliver/priv"
+	"github.com/bishopfox/sliver/sliver/syscalls"
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -67,6 +70,7 @@ func minidump(pid uint32, proc windows.Handle) (ProcessDump, error) {
 	dump := &WindowsDump{}
 	// {{if eq .GOARCH "amd64"}}
 	// Hotfix for #66 - need to dig deeper
+	// {{if .Evasion}}
 	err := evasion.RefreshPE(`c:\windows\system32\ntdll.dll`)
 	if err != nil {
 		//{{if .Debug}}
@@ -74,6 +78,7 @@ func minidump(pid uint32, proc windows.Handle) (ProcessDump, error) {
 		//{{end}}
 		return dump, err
 	}
+	// {{end}}
 	// {{end}}
 	// TODO: find a better place to store the dump file
 	f, err := ioutil.TempFile("", "")

--- a/sliver/taskrunner/task_windows.go
+++ b/sliver/taskrunner/task_windows.go
@@ -34,10 +34,13 @@ import (
 	"unsafe"
 
 	"syscall"
-
+	// {{if .Evasion}}
 	"github.com/bishopfox/sliver/sliver/evasion"
-	"github.com/bishopfox/sliver/sliver/syscalls"
 	"github.com/bishopfox/sliver/sliver/version"
+
+	// {{end}}
+
+	"github.com/bishopfox/sliver/sliver/syscalls"
 	"golang.org/x/sys/windows"
 )
 
@@ -320,11 +323,11 @@ func Sideload(procName string, data []byte, args string) (string, error) {
 }
 
 // Util functions
-
 func refresh() error {
 	// Hotfix for #114
 	// Somehow this fucks up everything on Windows 8.1
 	// so we're skipping the RefreshPE calls.
+	// {{if .Evasion}}
 	if version.GetVersion() != "6.3 build 9600" {
 		err := evasion.RefreshPE(ntdllPath)
 		if err != nil {
@@ -341,6 +344,7 @@ func refresh() error {
 			return err
 		}
 	}
+	// {{end}}
 	return nil
 }
 


### PR DESCRIPTION
#### Card
This should resolve the crashes when agents try to do things like refreshPE. Evasion is now opt in.

#### Details

I don't feel good about adding this to the protobuf struct, but doing so means that it's an agent build config option, and agents that *dont* use evasion won't have that logic in the binary (so if the reason you're not doing evasion is that it's getting you caught (ironic), this is a step that might help...)