### PR TITLE
Fix crashes, and add some enhancement to windows tasks

### DIFF
--- a/client/command/bind-commands.go
+++ b/client/command/bind-commands.go
@@ -435,6 +435,7 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 			f.String("o", "os", "windows", "operating system")
 			f.String("a", "arch", "amd64", "cpu architecture")
 			f.Bool("d", "debug", false, "enable debug features")
+			f.Bool("e", "evasion", false, "enable evasion features")
 			f.Bool("s", "skip-symbols", false, "skip symbol obfuscation")
 
 			f.String("m", "mtls", "", "mtls domain(s)")

--- a/client/command/bind-commands.go
+++ b/client/command/bind-commands.go
@@ -981,8 +981,8 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 		},
 		Flags: func(f *grumble.Flags) {
 			f.String("p", "process", "notepad.exe", "hosting process to inject into")
-			f.Bool("a", "amsi", true, "use AMSI bypass (enabled by default)")
-			f.Bool("e", "etw", true, "patch EtwEventWrite function to avoid detection (enabled by default)")
+			f.Bool("a", "amsi", false, "use AMSI bypass (disabled by default)")
+			f.Bool("e", "etw", false, "patch EtwEventWrite function to avoid detection (disabled by default)")
 			f.Bool("s", "save", false, "save output to file")
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
 		},

--- a/client/command/bind-commands.go
+++ b/client/command/bind-commands.go
@@ -1003,6 +1003,7 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 		Flags: func(f *grumble.Flags) {
 			f.Bool("r", "rwx-pages", false, "Use RWX permissions for memory pages")
 			f.Uint("p", "pid", 0, "Pid of process to inject into (0 means injection into ourselves)")
+			f.String("n", "process", `c:\windows\system32\notepad.exe`, "Process to inject into when running in interactive mode")
 			f.Bool("i", "interactive", false, "Inject into a new process and interact with it")
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
 		},

--- a/client/command/extensions.go
+++ b/client/command/extensions.go
@@ -165,6 +165,10 @@ func load(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 				return nil
 			},
 			Flags: func(f *grumble.Flags) {
+				if extCmd.IsAssembly {
+					f.Bool("a", "amsi", false, "use AMSI bypass (disabled by default)")
+					f.Bool("e", "etw", false, "patch EtwEventWrite function to avoid detection (disabled by default)")
+				}
 				f.String("p", "process", "", "Path to process to host the shared object")
 				f.Bool("s", "save", false, "Save output to disk")
 				f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
@@ -234,7 +238,8 @@ func runExtensionCommand(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 		go spin.Until(msg, ctrl)
 		executeAssemblyResp, err := rpc.ExecuteAssembly(context.Background(), &sliverpb.ExecuteAssemblyReq{
 			Request:    ActiveSession.Request(ctx),
-			AmsiBypass: true,
+			AmsiBypass: ctx.Flags.Bool("amsi"),
+			EtwBypass:  ctx.Flags.Bool("etw"),
 			Arguments:  args,
 			Assembly:   binData,
 			Process:    processName,

--- a/client/command/tasks.go
+++ b/client/command/tasks.go
@@ -66,7 +66,7 @@ func executeShellcode(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 		return
 	}
 	if interactive {
-		executeInteractive(ctx, `c:\windows\system32\notepad.exe`, shellcodeBin, ctx.Flags.Bool("rwx-pages"), rpc)
+		executeInteractive(ctx, ctx.Flags.String("process"), shellcodeBin, ctx.Flags.Bool("rwx-pages"), rpc)
 		return
 	}
 	ctrl := make(chan bool)

--- a/sliver/taskrunner/task_windows.go
+++ b/sliver/taskrunner/task_windows.go
@@ -260,7 +260,11 @@ func ExecuteAssembly(hostingDll, assembly []byte, process, params string, amsi b
 	if err != nil {
 		return "", err
 	}
-	cmd.Process.Kill()
+	err = cmd.Process.Kill()
+	if err != nil {
+		log.Println("Error kill: %v", err)
+		return "", err
+	}
 	return stdoutBuf.String() + stderrBuf.String(), nil
 }
 

--- a/sliver/taskrunner/task_windows.go
+++ b/sliver/taskrunner/task_windows.go
@@ -197,7 +197,7 @@ func ExecuteAssembly(hostingDll, assembly []byte, process, params string, amsi b
 	log.Println("[*] Hosting dll size:", len(hostingDll))
 	// {{end}}
 	var stdoutBuf, stderrBuf bytes.Buffer
-	cmd, err := startProcess(process, &stdoutBuf, &stderrBuf)
+	cmd, err := startProcess(process, &stdoutBuf, &stderrBuf, true)
 	if err != nil {
 		//{{if .Debug}}
 		log.Println("Could not start process:", process)
@@ -278,7 +278,7 @@ func SpawnDll(procName string, data []byte, offset uint32, args string) (string,
 	var stdoutBuff bytes.Buffer
 	var stderrBuff bytes.Buffer
 	// 1 - Start process
-	cmd, err := startProcess(procName, &stdoutBuff, &stderrBuff)
+	cmd, err := startProcess(procName, &stdoutBuff, &stderrBuff, true)
 	if err != nil {
 		return "", err
 	}
@@ -354,7 +354,7 @@ func refresh() error {
 	return nil
 }
 
-func startProcess(proc string, stdout *bytes.Buffer, stderr *bytes.Buffer) (*exec.Cmd, error) {
+func startProcess(proc string, stdout *bytes.Buffer, stderr *bytes.Buffer, suspended bool) (*exec.Cmd, error) {
 	cmd := exec.Command(proc)
 	cmd.SysProcAttr = &windows.SysProcAttr{
 		Token: syscall.Token(CurrentToken),
@@ -363,6 +363,9 @@ func startProcess(proc string, stdout *bytes.Buffer, stderr *bytes.Buffer) (*exe
 	cmd.Stderr = stderr
 	cmd.SysProcAttr = &windows.SysProcAttr{
 		HideWindow: true,
+	}
+	if suspended {
+		cmd.SysProcAttr.CreationFlags = windows.CREATE_SUSPENDED
 	}
 	err := cmd.Start()
 	if err != nil {

--- a/sliver/taskrunner/task_windows.go
+++ b/sliver/taskrunner/task_windows.go
@@ -262,7 +262,9 @@ func ExecuteAssembly(hostingDll, assembly []byte, process, params string, amsi b
 	}
 	err = cmd.Process.Kill()
 	if err != nil {
-		log.Println("Error kill: %v", err)
+		// {{if .Debug}}
+		log.Println("Error kill: %v\n", err)
+		// {{end}}
 		return "", err
 	}
 	return stdoutBuf.String() + stderrBuf.String(), nil


### PR DESCRIPTION
These commits fix a bunch of issues:

- we forgot to add the `evasion` flag to `new-profile`, which made it crash
- better error handling on `execute-assembly` when `Process.Kill()` is called
- start processes in suspended mode
- disable ETW and AMSI bypasses by default, leave it to the operator to enable them (fixes an issue with old systems that don't have these protections)
- add `--process` flag to `execute-shellcode`: it know uses that process has host when running with the `--interactive` flag