### PR TITLE
Fixed folder download with symlinks

### DIFF
--- a/sliver/handlers/generic-rpc-handlers.go
+++ b/sliver/handlers/generic-rpc-handlers.go
@@ -316,6 +316,9 @@ func downloadHandler(data []byte, resp RPCResponse) {
 	if fi.IsDir() {
 		var dirData bytes.Buffer
 		err = compressDir(target, &dirData)
+		// {{if .Debug}}
+		log.Printf("error creating the archive: %v", err)
+		// {{end}}
 		rawData = dirData.Bytes()
 	} else {
 		rawData, err = ioutil.ReadFile(target)
@@ -676,11 +679,25 @@ func compressDir(path string, buf io.Writer) error {
 	tarWriter := tar.NewWriter(zipWriter)
 
 	filepath.Walk(path, func(file string, fi os.FileInfo, err error) error {
+		fileName := file
+		// If the file is a SymLink replace fileInfo and path with the symlink destination.
+		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+			file, err = filepath.EvalSymlinks(file)
+			if err != nil {
+				return err
+			}
+
+			fi, err = os.Lstat(file)
+			if err != nil {
+				return err
+			}
+		}
 		header, err := tar.FileInfoHeader(fi, file)
 		if err != nil {
 			return err
 		}
-		header.Name = filepath.ToSlash(file)
+		// Keep the symlink file path for the header name.
+		header.Name = filepath.ToSlash(fileName)
 		if err := tarWriter.WriteHeader(header); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Card

#### Details
Fix #226

Added an initial check to verify if the file is a symlink. If that's the case replace the fileinfo and path with the symlink destination to create the tar header and read the file content. 
We keep the symlink file name as the tar Header name so the resulting compressed folder will maintain the same structure.