### PR TITLE
Fix https stage listener issues

### DIFF
--- a/client/command/bind-commands.go
+++ b/client/command/bind-commands.go
@@ -417,6 +417,9 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 		Flags: func(f *grumble.Flags) {
 			f.String("p", "profile", "", "Implant profile to link with the listener")
 			f.String("u", "url", "", "URL to which the stager will call back to")
+			f.String("c", "cert", "", "path to PEM encoded certificate file (HTTPS only)")
+			f.String("k", "key", "", "path to PEM encoded private key file (HTTPS only)")
+			f.Bool("e", "lets-encrypt", false, "attempt to provision a let's encrypt certificate (HTTPS only)")
 		},
 		Run: func(ctx *grumble.Context) error {
 			fmt.Println()

--- a/protobuf/clientpb/client.proto
+++ b/protobuf/clientpb/client.proto
@@ -248,6 +248,9 @@ message StagerListenerReq {
   string Host = 2;
   uint32 Port = 3;
   bytes Data = 4;
+  bytes Cert = 5;
+  bytes Key = 6;
+  bool ACME = 7;
 }
 
 message StagerListener {

--- a/server/rpc/rpc-stager.go
+++ b/server/rpc/rpc-stager.go
@@ -42,10 +42,6 @@ func (rpc *Server) StartTCPStagerListener(ctx context.Context, req *clientpb.Sta
 
 // StartHTTPStagerListener starts a HTTP(S) stager listener
 func (rpc *Server) StartHTTPStagerListener(ctx context.Context, req *clientpb.StagerListenerReq) (*clientpb.StagerListener, error) {
-	var secure bool = false
-	if req.GetProtocol() == clientpb.StageProtocol_HTTPS {
-		secure = true
-	}
 	host := req.GetHost()
 	if !checkInterface(req.GetHost()) {
 		host = "0.0.0.0"
@@ -54,8 +50,13 @@ func (rpc *Server) StartHTTPStagerListener(ctx context.Context, req *clientpb.St
 		Addr:   fmt.Sprintf("%s:%d", host, req.Port),
 		LPort:  uint16(req.Port),
 		Domain: req.Host,
-		Secure: secure,
-		ACME:   false,
+		Secure: false,
+	}
+	if req.GetProtocol() == clientpb.StageProtocol_HTTPS {
+		conf.Secure = true
+		conf.Key = req.Key
+		conf.Cert = req.Cert
+		conf.ACME = req.ACME
 	}
 	job, err := jobStartHTTPStagerListener(conf, req.Data)
 	return &clientpb.StagerListener{JobID: uint32(job.ID)}, err


### PR DESCRIPTION
Add 3 flags to the `stage-listener` command to properly support HTTPS staging:

- `cert`: path to PEM encoded certificate on disk
- `key`: path to PEM encoded key on disk
- `lets-encrypt`: use let's encrypt to get a certificate
