### PR TITLE
Improve session management

### DIFF
--- a/client/console/console.go
+++ b/client/console/console.go
@@ -142,9 +142,15 @@ func eventLoop(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 
 		case consts.SessionOpenedEvent:
 			session := event.Session
-			currentTime := time.Now().Format(time.RFC1123)
-			fmt.Printf(clearln+Info+"Session #%d %s - %s (%s) - %s/%s - %v\n\n",
-				session.ID, session.Name, session.RemoteAddress, session.Hostname, session.OS, session.Arch, currentTime)
+			// The HTTP session handling is performed in two steps:
+			// - first we add an "empty" session
+			// - then we complete the session info when we receive the Register message from the Sliver
+			// This check is here to avoid displaying two sessions events for the same session
+			if session.OS != "" {
+				currentTime := time.Now().Format(time.RFC1123)
+				fmt.Printf(clearln+Info+"Session #%d %s - %s (%s) - %s/%s - %v\n\n",
+					session.ID, session.Name, session.RemoteAddress, session.Hostname, session.OS, session.Arch, currentTime)
+			}
 
 		case consts.SessionClosedEvent:
 			session := event.Session

--- a/server/c2/tcp-mtls.go
+++ b/server/c2/tcp-mtls.go
@@ -87,7 +87,7 @@ func handleSliverConnection(conn net.Conn) {
 	mtlsLog.Infof("Accepted incoming connection: %s", conn.RemoteAddr())
 
 	session := &core.Session{
-		ID:            core.NextSessionID(),
+		// ID:            core.NextSessionID(),
 		Transport:     "mtls",
 		RemoteAddress: fmt.Sprintf("%s", conn.RemoteAddr()),
 		Send:          make(chan *sliverpb.Envelope),

--- a/server/c2/tcp-mtls.go
+++ b/server/c2/tcp-mtls.go
@@ -87,7 +87,6 @@ func handleSliverConnection(conn net.Conn) {
 	mtlsLog.Infof("Accepted incoming connection: %s", conn.RemoteAddr())
 
 	session := &core.Session{
-		// ID:            core.NextSessionID(),
 		Transport:     "mtls",
 		RemoteAddress: fmt.Sprintf("%s", conn.RemoteAddr()),
 		Send:          make(chan *sliverpb.Envelope),

--- a/server/core/sessions.go
+++ b/server/core/sessions.go
@@ -167,11 +167,13 @@ func (s *sessions) Remove(sessionID uint32) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	session := (*s.sessions)[sessionID]
-	delete((*s.sessions), sessionID)
-	EventBroker.Publish(Event{
-		EventType: consts.SessionClosedEvent,
-		Session:   session,
-	})
+	if session != nil {
+		delete((*s.sessions), sessionID)
+		EventBroker.Publish(Event{
+			EventType: consts.SessionClosedEvent,
+			Session:   session,
+		})
+	}
 }
 
 // NextSessionID - Returns an incremental nonce as an id

--- a/server/handlers/sessions.go
+++ b/server/handlers/sessions.go
@@ -50,7 +50,6 @@ func AddSessionHandlers(key uint32, value interface{}) {
 	sessionHandlers[key] = value
 }
 
-
 func registerSessionHandler(session *core.Session, data []byte) {
 	register := &sliverpb.Register{}
 	err := proto.Unmarshal(data, register)
@@ -63,10 +62,12 @@ func registerSessionHandler(session *core.Session, data []byte) {
 		return
 	}
 
-
 	handlerLog.Warnf("%v", session)
 	handlerLog.Warnf("%v", register)
 
+	if session.ID == 0 {
+		session.ID = core.NextSessionID()
+	}
 	session.Name = register.Name
 	session.Hostname = register.Hostname
 	session.Username = register.Username


### PR DESCRIPTION
This PR is an attempt at improving session management, and in particular, fixes the following issues:

- skipped session numbers when a connection is received on a listener from a non sliver payload
- duplicate new session events displayed on the client