### PR TITLE
Issue #238 - Session Health Check

### DIFF
--- a/client/command/bind-commands.go
+++ b/client/command/bind-commands.go
@@ -226,6 +226,7 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 			f.String("i", "interact", "", "interact with a sliver")
 			f.String("k", "kill", "", "Kill the designated session")
 			f.Bool("K", "kill-all", false, "Kill all the sessions")
+			f.Bool("C", "clean", false, "Clean out any sessions marked as [DEAD]")
 
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
 		},

--- a/client/command/sessions.go
+++ b/client/command/sessions.go
@@ -40,6 +40,7 @@ func sessions(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 	interact := ctx.Flags.String("interact")
 	kill := ctx.Flags.String("kill")
 	killAll := ctx.Flags.Bool("kill-all")
+	clean := ctx.Flags.Bool("clean")
 
 	sessions, err := rpc.GetSessions(context.Background(), &commonpb.Empty{})
 	if err != nil {
@@ -55,6 +56,20 @@ func sessions(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 				fmt.Printf(Warn+"%s\n", err)
 			}
 			fmt.Printf(Info+"\nKilled %s (%d)\n", session.Name, session.ID)
+		}
+		return
+	}
+
+	if clean {
+		ActiveSession.Background()
+		for _, session := range sessions.Sessions {
+			if session.IsDead {
+				err := killSession(session, rpc)
+				if err != nil {
+					fmt.Printf(Warn+"%s\n", err)
+				}
+				fmt.Printf(Info+"\nKilled %s (%d)\n", session.Name, session.ID)
+			}
 		}
 		return
 	}
@@ -106,8 +121,8 @@ func printSessions(sessions map[uint32]*clientpb.Session) {
 	table := tabwriter.NewWriter(outputBuf, 0, 2, 2, ' ', 0)
 
 	// Column Headers
-	fmt.Fprintln(table, "ID\tName\tTransport\tRemote Address\tHostname\tUsername\tOperating System\tLast Check-in\t")
-	fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
+	fmt.Fprintln(table, "ID\tName\tTransport\tRemote Address\tHostname\tUsername\tOperating System\tLast Check-in\tHealth\t")
+	fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
 		strings.Repeat("=", len("ID")),
 		strings.Repeat("=", len("Name")),
 		strings.Repeat("=", len("Transport")),
@@ -115,7 +130,8 @@ func printSessions(sessions map[uint32]*clientpb.Session) {
 		strings.Repeat("=", len("Hostname")),
 		strings.Repeat("=", len("Username")),
 		strings.Repeat("=", len("Operating System")),
-		strings.Repeat("=", len("Last Check-in")))
+		strings.Repeat("=", len("Last Check-in")),
+		strings.Repeat("=", len("Health")))
 
 	// Sort the keys because maps have a randomized order
 	var keys []int
@@ -130,7 +146,15 @@ func printSessions(sessions map[uint32]*clientpb.Session) {
 		if ActiveSession.Get() != nil && ActiveSession.Get().ID == session.ID {
 			activeIndex = index + 2 // Two lines for the headers
 		}
-		fmt.Fprintf(table, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
+
+		var SessionHealth string
+		if session.IsDead{
+			SessionHealth = "[DEAD]"
+		} else {
+			SessionHealth = "[ALIVE]"
+		}
+
+		fmt.Fprintf(table, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
 			session.ID,
 			session.Name,
 			session.Transport,
@@ -139,6 +163,7 @@ func printSessions(sessions map[uint32]*clientpb.Session) {
 			session.Username,
 			fmt.Sprintf("%s/%s", session.OS, session.Arch),
 			session.LastCheckin,
+			SessionHealth,
 		)
 	}
 	table.Flush()

--- a/client/command/sessions.go
+++ b/client/command/sessions.go
@@ -148,10 +148,10 @@ func printSessions(sessions map[uint32]*clientpb.Session) {
 		}
 
 		var SessionHealth string
-		if session.IsDead{
-			SessionHealth = "[DEAD]"
+		if session.IsDead {
+			SessionHealth = bold + red + "[DEAD]" + normal
 		} else {
-			SessionHealth = "[ALIVE]"
+			SessionHealth = bold + green + "[ALIVE]" + normal
 		}
 
 		fmt.Fprintf(table, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",

--- a/protobuf/clientpb/client.proto
+++ b/protobuf/clientpb/client.proto
@@ -37,6 +37,8 @@ message Session {
   string ActiveC2 = 14;
   string Version = 15;
   bool Evasion = 16;
+  bool IsDead = 17;
+  uint32 ReconnectInterval = 18;
 }
 
 message ImplantC2 {

--- a/protobuf/sliverpb/sliver.proto
+++ b/protobuf/sliverpb/sliver.proto
@@ -43,6 +43,7 @@ message Register {
   string Filename = 9;
   string ActiveC2 = 10;
   string Version = 11;
+  uint32 ReconnectInterval = 12;
 }
 
 // Ping - Not ICMP, just sends a rount trip message to an implant to

--- a/server/core/sessions.go
+++ b/server/core/sessions.go
@@ -20,9 +20,9 @@ package core
 
 import (
 	"errors"
+	"math"
 	"sync"
 	"time"
-	"math"
 
 	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
@@ -48,25 +48,25 @@ var (
 
 // Session - Represents a connection to an implant
 type Session struct {
-	ID            uint32
-	Name          string
-	Hostname      string
-	Username      string
-	UID           string
-	GID           string
-	Os            string
-	Version       string
-	Arch          string
-	Transport     string
-	RemoteAddress string
-	PID           int32
-	Filename      string
-	LastCheckin   *time.Time
-	Send          chan *sliverpb.Envelope
-	Resp          map[uint64]chan *sliverpb.Envelope
-	RespMutex     *sync.RWMutex
-	ActiveC2      string
-	IsDead		  bool
+	ID                uint32
+	Name              string
+	Hostname          string
+	Username          string
+	UID               string
+	GID               string
+	Os                string
+	Version           string
+	Arch              string
+	Transport         string
+	RemoteAddress     string
+	PID               int32
+	Filename          string
+	LastCheckin       *time.Time
+	Send              chan *sliverpb.Envelope
+	Resp              map[uint64]chan *sliverpb.Envelope
+	RespMutex         *sync.RWMutex
+	ActiveC2          string
+	IsDead            bool
 	ReconnectInterval uint32
 }
 
@@ -79,34 +79,35 @@ func (s *Session) ToProtobuf() *clientpb.Session {
 		lastCheckin = s.LastCheckin.Format(time.RFC1123)
 	}
 
-	// WIP Need to get actual Implant reconnect value to accurately determine status, otherwise it works.
-	// Currently statically checks default reconnect value of 60 seconds by calculating difference between now and last check in time.
+	// Calculates how much time has passed in seconds and compares that to the ReconnectInterval+10 of the Implant.
+	// (ReconnectInterval+10 seconds is just abitrary padding to account for potential delays)
+	// If it hasn't checked in, flag it as DEAD.
 	var isDead bool
 	var timePassed = uint32(math.Abs(s.LastCheckin.Sub(time.Now()).Seconds()))
 
-	if timePassed > s.ReconnectInterval { 
+	if timePassed > (s.ReconnectInterval + 10) {
 		isDead = true
 	} else {
 		isDead = false
 	}
 
 	return &clientpb.Session{
-		ID:            uint32(s.ID),
-		Name:          s.Name,
-		Hostname:      s.Hostname,
-		Username:      s.Username,
-		UID:           s.UID,
-		GID:           s.GID,
-		OS:            s.Os,
-		Version:       s.Version,
-		Arch:          s.Arch,
-		Transport:     s.Transport,
-		RemoteAddress: s.RemoteAddress,
-		PID:           int32(s.PID),
-		Filename:      s.Filename,
-		LastCheckin:   lastCheckin,
-		ActiveC2:      s.ActiveC2,
-		IsDead:        isDead,
+		ID:                uint32(s.ID),
+		Name:              s.Name,
+		Hostname:          s.Hostname,
+		Username:          s.Username,
+		UID:               s.UID,
+		GID:               s.GID,
+		OS:                s.Os,
+		Version:           s.Version,
+		Arch:              s.Arch,
+		Transport:         s.Transport,
+		RemoteAddress:     s.RemoteAddress,
+		PID:               int32(s.PID),
+		Filename:          s.Filename,
+		LastCheckin:       lastCheckin,
+		ActiveC2:          s.ActiveC2,
+		IsDead:            isDead,
 		ReconnectInterval: s.ReconnectInterval,
 	}
 }

--- a/server/handlers/sessions.go
+++ b/server/handlers/sessions.go
@@ -79,6 +79,7 @@ func registerSessionHandler(session *core.Session, data []byte) {
 	session.Filename = register.Filename
 	session.ActiveC2 = register.ActiveC2
 	session.Version = register.Version
+	session.ReconnectInterval = register.ReconnectInterval
 	core.Sessions.Add(session)
 }
 

--- a/sliver/sliver.go
+++ b/sliver/sliver.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/user"
 	"runtime"
+	"time"
 
 	// {{if .Debug}}{{else}}
 	"io/ioutil"
@@ -251,6 +252,7 @@ func getRegisterSliver() *sliverpb.Envelope {
 		Pid:      int32(os.Getpid()),
 		Filename: filename,
 		ActiveC2: transports.GetActiveC2(),
+		ReconnectInterval: uint32(transports.GetReconnectInterval()/time.Second),
 	})
 	if err != nil {
 		// {{if .Debug}}

--- a/sliver/sliver.go
+++ b/sliver/sliver.go
@@ -241,18 +241,18 @@ func getRegisterSliver() *sliverpb.Envelope {
 		}
 	}
 	data, err := proto.Marshal(&sliverpb.Register{
-		Name:     consts.SliverName,
-		Hostname: hostname,
-		Username: currentUser.Username,
-		Uid:      currentUser.Uid,
-		Gid:      currentUser.Gid,
-		Os:       runtime.GOOS,
-		Version:  version.GetVersion(),
-		Arch:     runtime.GOARCH,
-		Pid:      int32(os.Getpid()),
-		Filename: filename,
-		ActiveC2: transports.GetActiveC2(),
-		ReconnectInterval: uint32(transports.GetReconnectInterval()/time.Second),
+		Name:              consts.SliverName,
+		Hostname:          hostname,
+		Username:          currentUser.Username,
+		Uid:               currentUser.Uid,
+		Gid:               currentUser.Gid,
+		Os:                runtime.GOOS,
+		Version:           version.GetVersion(),
+		Arch:              runtime.GOARCH,
+		Pid:               int32(os.Getpid()),
+		Filename:          filename,
+		ActiveC2:          transports.GetActiveC2(),
+		ReconnectInterval: uint32(transports.GetReconnectInterval() / time.Second),
 	})
 	if err != nil {
 		// {{if .Debug}}

--- a/sliver/transports/transports.go
+++ b/sliver/transports/transports.go
@@ -54,7 +54,7 @@ var (
 
 	readBufSize       = 16 * 1024 // 16kb
 	maxErrors         = getMaxConnectionErrors()
-	reconnectInterval = getReconnectInterval()
+	reconnectInterval = GetReconnectInterval()
 
 	ccCounter = new(int)
 
@@ -249,7 +249,7 @@ func nextCCServer() *url.URL {
 	return uri
 }
 
-func getReconnectInterval() time.Duration {
+func GetReconnectInterval() time.Duration {
 	reconnect, err := strconv.Atoi(`{{.ReconnectInterval}}`)
 	if err != nil {
 		return 60 * time.Second


### PR DESCRIPTION
#### Card
This is a proposed solution for issue #238 
#### Details
This PR adds in support for a `--clean` flag in the `kill` command which takes advantage of the newly introduced `IsDead` attribute that keeps track of the "health" of a given session.

Session "health" is calculated by exposing an implant's `ReconnectInterval` and passing it to the session handler. The session handler simply calculates the difference in time since last check in and compares that to the `ReconnectInterval` (plus 10 seconds as a general padding in case there is a natural delay).

If the `Last Check-in` exceeds the value of the ReconnectInterval (+10 seconds) the session is marked as `[DEAD]` and indicated as a meta field in the output of the `sessions` command. This is updated if the shell eventually does reconnect which helps an operator effectively keep track of active and healthy sessions (and of course clean up any permanently dead sessions quickly without impacting active sessions).

#### Sample Output:
##### Alive Status
![alive](https://user-images.githubusercontent.com/14339392/90196156-1b8a3a80-dd99-11ea-94da-bbc62f755a32.png)
##### Dead Status
![dead](https://user-images.githubusercontent.com/14339392/90196165-2349df00-dd99-11ea-9299-4ee472eac192.png)
##### Session Clean
![clean](https://user-images.githubusercontent.com/14339392/90196183-2c3ab080-dd99-11ea-887d-39b7feb5e7d5.png)


