### PR TITLE
server: sideload: print usage error if no arguments are provided

### DIFF
--- a/client/command/tasks.go
+++ b/client/command/tasks.go
@@ -289,6 +289,12 @@ func sideload(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 	if session == nil {
 		return
 	}
+
+	if len(ctx.Args) < 1 {
+		fmt.Printf(Warn + "You must provide a shared object to load")
+		return
+	}
+
 	binPath := ctx.Args[0]
 
 	entryPoint := ctx.Flags.String("entry-point")


### PR DESCRIPTION
Hello! Just a small patch to prevent the server from crashing if a user mistypes "sideload"

Typing `sideoad` with no arguments will cause a panic in the Sliver
server. This patch fixes that and prints an error message.

#### Card

#### Details
