### PR TITLE
Fix macos shared build failure due to missing stdlib.h compiler error

### DIFF
--- a/sliver/sliver.c
+++ b/sliver/sliver.c
@@ -50,6 +50,7 @@ static void init(int argc, char **argv, char **envp)
 }
 __attribute__((section(".init_array"), used)) static typeof(init) *init_p = init;
 #elif __APPLE__
+#include <stdlib.h>
 void RunSliver();
 
 __attribute__((constructor)) static void init(int argc, char **argv, char **envp)


### PR DESCRIPTION
Newer versions of clang treat the implicit declaration of unsetenv as an error and therefore building a shared dylib agent fails. This one line change includes the missing header dependency.