### PR TITLE
Stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 #
 # Version Information
 #
-VERSION = 1.0.7
+VERSION = 1.0.8
 COMPILED_AT = $(shell date +%s)
 RELEASES_URL = https://api.github.com/repos/BishopFox/sliver/releases
 PKG = github.com/bishopfox/sliver/client/version

--- a/client/command/psexec.go
+++ b/client/command/psexec.go
@@ -106,7 +106,7 @@ func psExec(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 		Request:            ActiveSession.Request(ctx),
 		ServiceDescription: serviceDesc,
 		ServiceName:        serviceName,
-		Arguments:          serviceName,
+		Arguments:          "",
 	})
 	serviceCtrl <- true
 	<-serviceCtrl


### PR DESCRIPTION
Remove service argument for `psexec`. No need to leak the service name as an argument.
