### PR TITLE
Add error check

### DIFF
--- a/server/rpc/rpc-stager.go
+++ b/server/rpc/rpc-stager.go
@@ -59,6 +59,12 @@ func (rpc *Server) StartHTTPStagerListener(ctx context.Context, req *clientpb.St
 		conf.ACME = req.ACME
 	}
 	job, err := jobStartHTTPStagerListener(conf, req.Data)
+	if err != nil {
+		return nil, err
+	}
+	if job == nil {
+		return nil, fmt.Errorf("job is nil")
+	}
 	return &clientpb.StagerListener{JobID: uint32(job.ID)}, err
 }
 


### PR DESCRIPTION
Add error check to rpc-stager, in case `jobStartHTTPStagerListener()` fails and returns a `nil` pointer.
It should be a rare case, but this could have provoked a crash via a `nil` pointer dereference in the return statement.