### PR TITLE
Add support for a File Exists Limit.

### DIFF
--- a/client/command/bind-commands.go
+++ b/client/command/bind-commands.go
@@ -372,6 +372,7 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 			f.Bool("x", "limit-domainjoined", false, "limit execution to domain joined machines")
 			f.String("y", "limit-username", "", "limit execution to specified username")
 			f.String("z", "limit-hostname", "", "limit execution to specified hostname")
+			f.String("f", "limit-fileexists", "", "limit execution to hosts with this file in the filesystem")
 
 			f.String("r", "format", "exe", "Specifies the output formats, valid values are: 'exe', 'shared' (for dynamic libraries), 'service' (see `psexec` for more info) and 'shellcode' (windows only)")
 
@@ -458,6 +459,7 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 			f.Bool("x", "limit-domainjoined", false, "limit execution to domain joined machines")
 			f.String("y", "limit-username", "", "limit execution to specified username")
 			f.String("z", "limit-hostname", "", "limit execution to specified hostname")
+			f.String("f", "limit-fileexists", "", "limit execution to hosts with this file in the filesystem")
 
 			f.String("r", "format", "exe", "Specifies the output formats, valid values are: 'exe', 'shared' (for dynamic libraries), 'service' (see `psexec` for more info) and 'shellcode' (windows only)")
 

--- a/client/command/generate.go
+++ b/client/command/generate.go
@@ -307,6 +307,7 @@ func parseCompileFlags(ctx *grumble.Context) *clientpb.ImplantConfig {
 	limitHostname := ctx.Flags.String("limit-hostname")
 	limitUsername := ctx.Flags.String("limit-username")
 	limitDatetime := ctx.Flags.String("limit-datetime")
+	limitFileExists := ctx.Flags.String("limit-fileexists")
 
 	isSharedLib := false
 	isService := false
@@ -369,6 +370,7 @@ func parseCompileFlags(ctx *grumble.Context) *clientpb.ImplantConfig {
 		LimitHostname:     limitHostname,
 		LimitUsername:     limitUsername,
 		LimitDatetime:     limitDatetime,
+		LimitFileExists:   limitFileExists,
 
 		Format:      configFormat,
 		IsSharedLib: isSharedLib,
@@ -637,6 +639,9 @@ func getLimitsString(config *clientpb.ImplantConfig) string {
 	}
 	if config.LimitHostname != "" {
 		limits = append(limits, fmt.Sprintf("hostname=%s", config.LimitHostname))
+	}
+	if config.LimitFileExists != "" {
+		limits = append(limits, fmt.Sprintf("fileexists=%s", config.LimitFileExists))
 	}
 	return strings.Join(limits, "; ")
 }

--- a/protobuf/clientpb/client.proto
+++ b/protobuf/clientpb/client.proto
@@ -69,6 +69,7 @@ message ImplantConfig {
   string LimitDatetime = 21;
   string LimitHostname = 22;
   string LimitUsername = 23;
+  string LimitFileExists = 32;
 
   enum OutputFormat {
     SHARED_LIB = 0;

--- a/server/generate/binaries.go
+++ b/server/generate/binaries.go
@@ -111,6 +111,7 @@ type ImplantConfig struct {
 	LimitHostname     string `json:"limit_hostname"`
 	LimitUsername     string `json:"limit_username"`
 	LimitDatetime     string `json:"limit_datetime"`
+	LimitFileExists   string `json:"limit_fileexists"`
 
 	// Output Format
 	Format clientpb.ImplantConfig_OutputFormat `json:"format"`
@@ -144,6 +145,7 @@ func (c *ImplantConfig) ToProtobuf() *clientpb.ImplantConfig {
 		LimitDomainJoined: c.LimitDomainJoined,
 		LimitHostname:     c.LimitHostname,
 		LimitUsername:     c.LimitUsername,
+		LimitFileExists:   c.LimitFileExists,
 
 		IsSharedLib: c.IsSharedLib,
 		IsService:   c.IsService,
@@ -181,6 +183,7 @@ func ImplantConfigFromProtobuf(pbConfig *clientpb.ImplantConfig) *ImplantConfig 
 	cfg.LimitDatetime = pbConfig.LimitDatetime
 	cfg.LimitUsername = pbConfig.LimitUsername
 	cfg.LimitHostname = pbConfig.LimitHostname
+	cfg.LimitFileExists = pbConfig.LimitFileExists
 
 	cfg.Format = pbConfig.Format
 	cfg.IsSharedLib = pbConfig.IsSharedLib

--- a/sliver/limits/limits.go
+++ b/sliver/limits/limits.go
@@ -92,6 +92,15 @@ func ExecLimits() {
 	}
 	// {{end}}
 
+	// {{if .LimitFileExists}}
+	if _, err := os.Stat("{{.LimitFileExists}}"); err != nil {
+		// {{if .Debug}}
+		log.Printf("Error statting %s: %s", "{{.LimitFileExists}}" , err)
+		// {{end}}
+		os.Exit(1)
+	}
+	// {{end}}
+
 	// {{if .Debug}}
 	log.Printf("Limit checks completed")
 	// {{end}}

--- a/sliver/limits/limits.go
+++ b/sliver/limits/limits.go
@@ -93,9 +93,9 @@ func ExecLimits() {
 	// {{end}}
 
 	// {{if .LimitFileExists}}
-	if _, err := os.Stat("{{.LimitFileExists}}"); err != nil {
+	if _, err := os.Stat(`{{.LimitFileExists}}`); err != nil {
 		// {{if .Debug}}
-		log.Printf("Error statting %s: %s", "{{.LimitFileExists}}" , err)
+		log.Printf("Error statting %s: %s", `{{.LimitFileExists}}` , err)
 		// {{end}}
 		os.Exit(1)
 	}


### PR DESCRIPTION
This checks if a given file exists in the filesystem of the target
when running the implant.  This can be used to limit the implant to
targets with particular software installed.  This was described in
issue #257.
