### PR TITLE
Improve Last Check-In for Sessions

### DIFF
--- a/server/c2/tcp-mtls.go
+++ b/server/c2/tcp-mtls.go
@@ -93,6 +93,7 @@ func handleSliverConnection(conn net.Conn) {
 		RespMutex:     &sync.RWMutex{},
 		Resp:          map[uint64]chan *sliverpb.Envelope{},
 	}
+	session.UpdateCheckin()
 
 	defer func() {
 		mtlsLog.Debugf("Cleaning up for %s", session.Name)
@@ -108,6 +109,7 @@ func handleSliverConnection(conn net.Conn) {
 				mtlsLog.Errorf("Socket read error %v", err)
 				return
 			}
+			session.UpdateCheckin()
 			if envelope.ID != 0 {
 				session.RespMutex.RLock()
 				if resp, ok := session.Resp[envelope.ID]; ok {


### PR DESCRIPTION
As described in #197, there are issues with how LastCheckin is updated.

This adds a helper method to update LastCheckin to ensure it's done in
a consistent fashion, and calls it on all successful commands as well as
pings via the HTTP and DNS listeners.  Persistent connections (e.g.,
mtls) only update on commands, so will appear stale otherwise.

It no longer fills in LastCheckin for persistent connections when
someone runs the `sessions` command (or other grpc requests), so we
don't get overly-optimistic versions of the LastCheckin.
