### PR TITLE
Allow Persisting Listeners Over Restart

### DIFF
--- a/client/command/bind-commands.go
+++ b/client/command/bind-commands.go
@@ -126,6 +126,7 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 			f.Int("l", "lport", defaultMTLSLPort, "tcp listen port")
 
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
+			f.Bool("p", "persistent", false, "make persistent across restarts")
 		},
 		Run: func(ctx *grumble.Context) error {
 			fmt.Println()
@@ -145,6 +146,7 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 			f.Bool("c", "no-canaries", false, "disable dns canary detection")
 
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
+			f.Bool("p", "persistent", false, "make persistent across restarts")
 		},
 		Run: func(ctx *grumble.Context) error {
 			fmt.Println()
@@ -165,6 +167,7 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 			f.Int("l", "lport", defaultHTTPLPort, "tcp listen port")
 
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
+			f.Bool("p", "persistent", false, "make persistent across restarts")
 		},
 		Run: func(ctx *grumble.Context) error {
 			fmt.Println()
@@ -190,6 +193,7 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 			f.Bool("e", "lets-encrypt", false, "attempt to provision a let's encrypt certificate")
 
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
+			f.Bool("p", "persistent", false, "make persistent across restarts")
 		},
 		Run: func(ctx *grumble.Context) error {
 			fmt.Println()

--- a/client/command/job.go
+++ b/client/command/job.go
@@ -112,8 +112,9 @@ func startMTLSListener(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 
 	fmt.Printf(Info + "Starting mTLS listener ...\n")
 	mtls, err := rpc.StartMTLSListener(context.Background(), &clientpb.MTLSListenerReq{
-		Host: server,
-		Port: uint32(lport),
+		Host:       server,
+		Port:       uint32(lport),
+		Persistent: ctx.Flags.Bool("persistent"),
 	})
 	if err != nil {
 		fmt.Printf("\n"+Warn+"%s\n", err)
@@ -133,8 +134,9 @@ func startDNSListener(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 
 	fmt.Printf(Info+"Starting DNS listener with parent domain(s) %v ...\n", domains)
 	dns, err := rpc.StartDNSListener(context.Background(), &clientpb.DNSListenerReq{
-		Domains:  domains,
-		Canaries: !ctx.Flags.Bool("no-canaries"),
+		Domains:    domains,
+		Canaries:   !ctx.Flags.Bool("no-canaries"),
+		Persistent: ctx.Flags.Bool("persistent"),
 	})
 	if err != nil {
 		fmt.Printf("\n"+Warn+"%s\n", err)
@@ -156,13 +158,14 @@ func startHTTPSListener(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 
 	fmt.Printf(Info+"Starting HTTPS %s:%d listener ...\n", domain, lport)
 	https, err := rpc.StartHTTPSListener(context.Background(), &clientpb.HTTPListenerReq{
-		Domain:  domain,
-		Website: website,
-		Port:    uint32(lport),
-		Secure:  true,
-		Cert:    cert,
-		Key:     key,
-		ACME:    ctx.Flags.Bool("lets-encrypt"),
+		Domain:     domain,
+		Website:    website,
+		Port:       uint32(lport),
+		Secure:     true,
+		Cert:       cert,
+		Key:        key,
+		ACME:       ctx.Flags.Bool("lets-encrypt"),
+		Persistent: ctx.Flags.Bool("persistent"),
 	})
 	if err != nil {
 		fmt.Printf("\n"+Warn+"%s\n", err)
@@ -192,10 +195,11 @@ func startHTTPListener(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 
 	fmt.Printf(Info+"Starting HTTP %s:%d listener ...\n", domain, lport)
 	http, err := rpc.StartHTTPListener(context.Background(), &clientpb.HTTPListenerReq{
-		Domain:  domain,
-		Website: ctx.Flags.String("website"),
-		Port:    uint32(lport),
-		Secure:  false,
+		Domain:     domain,
+		Website:    ctx.Flags.String("website"),
+		Port:       uint32(lport),
+		Secure:     false,
+		Persistent: ctx.Flags.Bool("persistent"),
 	})
 	if err != nil {
 		fmt.Printf(Warn+"%s\n", err)

--- a/protobuf/clientpb/client.proto
+++ b/protobuf/clientpb/client.proto
@@ -146,7 +146,7 @@ message KillJob {
 message MTLSListenerReq {
   string Host = 1;
   uint32 Port = 2;
-
+  bool Persistent = 3;
 }
 
 message MTLSListener {
@@ -158,6 +158,7 @@ message DNSListenerReq {
   bool Canaries = 2;
   string Host = 3;
   uint32 Port = 4;
+  bool Persistent = 5;
 }
 
 message DNSListener {
@@ -173,12 +174,13 @@ message HTTPListenerReq {
   bytes Cert = 6;
   bytes Key = 7;
   bool ACME = 8;
+  bool Persistent = 9;
 }
 
 // Named Pipes Messages for pivoting
 message NamedPipesReq {
   string PipeName = 16;
-  
+
   commonpb.Request Request = 9;
 }
 

--- a/server/c2/jobs.go
+++ b/server/c2/jobs.go
@@ -1,0 +1,330 @@
+package c2
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2019  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	consts "github.com/bishopfox/sliver/client/constants"
+	"github.com/bishopfox/sliver/server/core"
+	"github.com/bishopfox/sliver/server/log"
+)
+
+var (
+	jobLog = log.NamedLogger("c2", "jobs")
+)
+
+func StartMTLSListenerJob(host string, listenPort uint16) (int, error) {
+	bind := fmt.Sprintf("%s:%d", host, listenPort)
+	ln, err := StartMutualTLSListener(host, listenPort)
+	if err != nil {
+		return 0, err // If we fail to bind don't setup the Job
+	}
+
+	job := &core.Job{
+		ID:          core.NextJobID(),
+		Name:        "mtls",
+		Description: fmt.Sprintf("mutual tls listener %s", bind),
+		Protocol:    "tcp",
+		Port:        listenPort,
+		JobCtrl:     make(chan bool),
+	}
+
+	go func() {
+		<-job.JobCtrl
+		jobLog.Infof("Stopping mTLS listener (%d) ...", job.ID)
+		ln.Close() // Kills listener GoRoutines in StartMutualTLSListener() but NOT connections
+		core.Jobs.Remove(job)
+	}()
+	core.Jobs.Add(job)
+
+	return job.ID, nil
+}
+
+func StartDNSListenerJob(domains []string, canaries bool, listenPort uint16) (int, error) {
+	server := StartDNSListener(domains, canaries)
+	description := fmt.Sprintf("%s (canaries %v)", strings.Join(domains, " "), canaries)
+	job := &core.Job{
+		ID:          core.NextJobID(),
+		Name:        "dns",
+		Description: description,
+		Protocol:    "udp",
+		Port:        listenPort,
+		JobCtrl:     make(chan bool),
+		Domains:     domains,
+	}
+
+	go func() {
+		<-job.JobCtrl
+		jobLog.Infof("Stopping DNS listener (%d) ...", job.ID)
+		server.Shutdown()
+		core.Jobs.Remove(job)
+		core.EventBroker.Publish(core.Event{
+			Job:       job,
+			EventType: consts.JobStoppedEvent,
+		})
+	}()
+
+	core.Jobs.Add(job)
+
+	// There is no way to call DNS' ListenAndServe() without blocking
+	// but we also need to check the error in the case the server
+	// fails to start at all, so we setup all the Job mechanics
+	// then kick off the server and if it fails we kill the job
+	// ourselves.
+	go func() {
+		err := server.ListenAndServe()
+		if err != nil {
+			jobLog.Errorf("DNS listener error %v", err)
+			job.JobCtrl <- true
+		}
+	}()
+
+	return job.ID, nil
+}
+
+func StartHTTPListenerJob(conf *HTTPServerConfig) (*core.Job, error) {
+	server, err := StartHTTPSListener(conf)
+	if err != nil {
+		return nil, err
+	}
+	name := "http"
+	if conf.Secure {
+		name = "https"
+	}
+
+	job := &core.Job{
+		ID:          core.NextJobID(),
+		Name:        name,
+		Description: fmt.Sprintf("%s for domain %s", name, conf.Domain),
+		Protocol:    "tcp",
+		Port:        uint16(conf.LPort),
+		JobCtrl:     make(chan bool),
+		Domains:     []string{conf.Domain},
+	}
+	core.Jobs.Add(job)
+
+	cleanup := func(err error) {
+		server.Cleanup()
+		core.Jobs.Remove(job)
+		core.EventBroker.Publish(core.Event{
+			Job:       job,
+			EventType: consts.JobStoppedEvent,
+			Err:       err,
+		})
+	}
+	once := &sync.Once{}
+
+	go func() {
+		var err error
+		if server.Conf.Secure {
+			if server.Conf.ACME {
+				err = server.HTTPServer.ListenAndServeTLS("", "") // ACME manager pulls the certs under the hood
+			} else {
+				err = listenAndServeTLS(server.HTTPServer, conf.Cert, conf.Key)
+			}
+		} else {
+			err = server.HTTPServer.ListenAndServe()
+		}
+		if err != nil {
+			jobLog.Errorf("%s listener error %v", name, err)
+			once.Do(func() { cleanup(err) })
+			job.JobCtrl <- true // Cleanup other goroutine
+		}
+	}()
+
+	go func() {
+		<-job.JobCtrl
+		once.Do(func() { cleanup(nil) })
+	}()
+
+	return job, nil
+}
+
+// Start a TCP staging payload listener
+func StartTCPStagerListenerJob(host string, port uint16, shellcode []byte) (int, error) {
+	ln, err := StartTCPListener(host, port, shellcode)
+	if err != nil {
+		return -1, err // If we fail to bind don't setup the Job
+	}
+
+	job := &core.Job{
+		ID:          core.NextJobID(),
+		Name:        "TCP",
+		Description: "Raw TCP listener (stager only)",
+		Protocol:    "tcp",
+		Port:        port,
+		JobCtrl:     make(chan bool),
+	}
+
+	go func() {
+		<-job.JobCtrl
+		jobLog.Infof("Stopping TCP listener (%d) ...", job.ID)
+		ln.Close() // Kills listener GoRoutines in startMutualTLSListener() but NOT connections
+
+		core.Jobs.Remove(job)
+
+		core.EventBroker.Publish(core.Event{
+			Job:       job,
+			EventType: consts.JobStoppedEvent,
+		})
+	}()
+
+	core.Jobs.Add(job)
+
+	return job.ID, nil
+}
+
+// StartHTTPStagerListener - Start an HTTP(S) stager payload listener
+func StartHTTPStagerListenerJob(conf *HTTPServerConfig, data []byte) (*core.Job, error) {
+	server, err := StartHTTPSListener(conf)
+	if err != nil {
+		return nil, err
+	}
+	name := "http"
+	if conf.Secure {
+		name = "https"
+	}
+	server.SliverStage = data
+	job := &core.Job{
+		ID:          core.NextJobID(),
+		Name:        name,
+		Description: fmt.Sprintf("Stager handler %s for domain %s", name, conf.Domain),
+		Protocol:    "tcp",
+		Port:        uint16(conf.LPort),
+		JobCtrl:     make(chan bool),
+	}
+	core.Jobs.Add(job)
+
+	cleanup := func(err error) {
+		server.Cleanup()
+		core.Jobs.Remove(job)
+		core.EventBroker.Publish(core.Event{
+			Job:       job,
+			EventType: consts.JobStoppedEvent,
+			Err:       err,
+		})
+	}
+	once := &sync.Once{}
+
+	go func() {
+		var err error
+		if server.Conf.Secure {
+			if server.Conf.ACME {
+				err = server.HTTPServer.ListenAndServeTLS("", "") // ACME manager pulls the certs under the hood
+			} else {
+				err = listenAndServeTLS(server.HTTPServer, conf.Cert, conf.Key)
+			}
+		} else {
+			err = server.HTTPServer.ListenAndServe()
+		}
+		if err != nil {
+			jobLog.Errorf("%s listener error %v", name, err)
+			once.Do(func() { cleanup(err) })
+			job.JobCtrl <- true // Cleanup other goroutine
+		}
+	}()
+
+	go func() {
+		<-job.JobCtrl
+		once.Do(func() { cleanup(nil) })
+	}()
+
+	return job, nil
+}
+
+// checkInterface verifies if an IP address
+// is attached to an existing network interface
+func checkInterface(a string) bool {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return false
+	}
+	for _, i := range interfaces {
+		addresses, err := i.Addrs()
+		if err != nil {
+			return false
+		}
+		for _, netAddr := range addresses {
+			addr, err := net.ResolveTCPAddr("tcp", netAddr.String())
+			if err != nil {
+				return false
+			}
+			if addr.IP.String() == a {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Fuck'in Go - https://stackoverflow.com/questions/30815244/golang-https-server-passing-certfile-and-kyefile-in-terms-of-byte-array
+// basically the same as server.ListenAndServerTLS() but we can pass in byte slices instead of file paths
+func listenAndServeTLS(srv *http.Server, certPEMBlock, keyPEMBlock []byte) error {
+	addr := srv.Addr
+	if addr == "" {
+		addr = ":https"
+	}
+	config := &tls.Config{}
+	if srv.TLSConfig != nil {
+		*config = *srv.TLSConfig
+	}
+	if config.NextProtos == nil {
+		config.NextProtos = []string{"http/1.1"}
+	}
+
+	var err error
+	config.Certificates = make([]tls.Certificate, 1)
+	config.Certificates[0], err = tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+	if err != nil {
+		return err
+	}
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	tlsListener := tls.NewListener(tcpKeepAliveListener{ln.(*net.TCPListener)}, config)
+	return srv.Serve(tlsListener)
+}
+
+// tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
+// connections. It's used by ListenAndServe and ListenAndServeTLS so
+// dead TCP connections (e.g. closing laptop mid-download) eventually
+// go away.
+type tcpKeepAliveListener struct {
+	*net.TCPListener
+}
+
+func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		return
+	}
+	tc.SetKeepAlive(true)
+	tc.SetKeepAlivePeriod(3 * time.Minute)
+	return tc, nil
+}

--- a/server/cli/cli.go
+++ b/server/cli/cli.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/bishopfox/sliver/client/version"
 	"github.com/bishopfox/sliver/server/assets"
+	"github.com/bishopfox/sliver/server/c2"
 	"github.com/bishopfox/sliver/server/certs"
 	"github.com/bishopfox/sliver/server/configs"
 	"github.com/bishopfox/sliver/server/console"
@@ -112,6 +113,7 @@ var rootCmd = &cobra.Command{
 		certs.SetupCAs()
 
 		serverConfig := configs.GetServerConfig()
+		c2.StartPersistentJobs(serverConfig)
 		if serverConfig.DaemonMode {
 			daemon.Start()
 		} else {

--- a/server/configs/server.go
+++ b/server/configs/server.go
@@ -19,10 +19,13 @@ package configs
 */
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"io/ioutil"
+	insecureRand "math/rand"
 	"os"
 	"path"
+	"time"
 
 	"github.com/bishopfox/sliver/server/assets"
 	"github.com/bishopfox/sliver/server/log"
@@ -58,11 +61,46 @@ type DaemonConfig struct {
 	Port int    `json:"port"`
 }
 
+// JobConfig - Restart Jobs on Load
+type JobConfig struct {
+	MTLS []*MTLSJobConfig `json:"mtls,omitempty"`
+	DNS  []*DNSJobConfig  `json:"dns,omitempty"`
+	HTTP []*HTTPJobConfig `json:"http,omitempty"`
+}
+
+// Per-type job configs
+type MTLSJobConfig struct {
+	Host  string `json:"host"`
+	Port  uint16 `json:"port"`
+	JobID string `json:"jobid"`
+}
+
+type DNSJobConfig struct {
+	Domains  []string `json:"domains"`
+	Canaries bool     `json:"canaries"`
+	Host     string   `json:"host"`
+	Port     uint16   `json:"port"`
+	JobID    string   `json:"jobid"`
+}
+
+type HTTPJobConfig struct {
+	Domain  string `json:"domain"`
+	Host    string `json:"host"`
+	Port    uint16 `json:"port"`
+	Secure  bool   `json:"secure"`
+	Website string `json:"website"`
+	Cert    []byte `json:"cert"`
+	Key     []byte `json:"key"`
+	ACME    bool   `json:"acme"`
+	JobID   string `json:"jobid"`
+}
+
 // ServerConfig - Server config
 type ServerConfig struct {
 	DaemonMode   bool          `json:"daemon_mode"`
 	DaemonConfig *DaemonConfig `json:"daemon"`
 	Logs         *LogConfig    `json:"logs"`
+	Jobs         *JobConfig    `json:"jobs,omitempty"`
 }
 
 // Save - Save config file to disk
@@ -86,6 +124,60 @@ func (c *ServerConfig) Save() error {
 		serverConfigLog.Errorf("Failed to write config %s", err)
 	}
 	return nil
+}
+
+// Add Job Configs
+func (c *ServerConfig) AddMTLSJob(config *MTLSJobConfig) error {
+	if c.Jobs == nil {
+		c.Jobs = &JobConfig{}
+	}
+	config.JobID = getRandomID()
+	c.Jobs.MTLS = append(c.Jobs.MTLS, config)
+	return c.Save()
+}
+
+func (c *ServerConfig) AddDNSJob(config *DNSJobConfig) error {
+	if c.Jobs == nil {
+		c.Jobs = &JobConfig{}
+	}
+	config.JobID = getRandomID()
+	c.Jobs.DNS = append(c.Jobs.DNS, config)
+	return c.Save()
+}
+
+func (c *ServerConfig) AddHTTPJob(config *HTTPJobConfig) error {
+	if c.Jobs == nil {
+		c.Jobs = &JobConfig{}
+	}
+	config.JobID = getRandomID()
+	c.Jobs.HTTP = append(c.Jobs.HTTP, config)
+	return c.Save()
+}
+
+// Remove Job by ID
+func (c *ServerConfig) RemoveJob(jobID string) {
+	if c.Jobs == nil {
+		return
+	}
+	defer c.Save()
+	for i, j := range c.Jobs.MTLS {
+		if j.JobID == jobID {
+			c.Jobs.MTLS = append(c.Jobs.MTLS[:i], c.Jobs.MTLS[i+1:]...)
+			return
+		}
+	}
+	for i, j := range c.Jobs.DNS {
+		if j.JobID == jobID {
+			c.Jobs.DNS = append(c.Jobs.DNS[:i], c.Jobs.DNS[i+1:]...)
+			return
+		}
+	}
+	for i, j := range c.Jobs.HTTP {
+		if j.JobID == jobID {
+			c.Jobs.HTTP = append(c.Jobs.HTTP[:i], c.Jobs.HTTP[i+1:]...)
+			return
+		}
+	}
 }
 
 // GetServerConfig - Get config value
@@ -125,5 +217,13 @@ func getDefaultServerConfig() *ServerConfig {
 			GRPCUnaryPayloads:  true,
 			GRPCStreamPayloads: true,
 		},
+		Jobs: &JobConfig{},
 	}
+}
+
+func getRandomID() string {
+	seededRand := insecureRand.New(insecureRand.NewSource(time.Now().UnixNano()))
+	buf := make([]byte, 32)
+	seededRand.Read(buf)
+	return hex.EncodeToString(buf)
 }

--- a/server/core/jobs.go
+++ b/server/core/jobs.go
@@ -37,13 +37,14 @@ var (
 
 // Job - Manages background jobs
 type Job struct {
-	ID          int
-	Name        string
-	Description string
-	Protocol    string
-	Port        uint16
-	Domains     []string
-	JobCtrl     chan bool
+	ID           int
+	Name         string
+	Description  string
+	Protocol     string
+	Port         uint16
+	Domains      []string
+	JobCtrl      chan bool
+	PersistentID string
 }
 
 // ToProtobuf - Get the protobuf version of the object

--- a/server/rpc/rpc-jobs.go
+++ b/server/rpc/rpc-jobs.go
@@ -20,16 +20,9 @@ package rpc
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
-	"net"
-	"net/http"
-	"strings"
-	"sync"
-	"time"
 
-	consts "github.com/bishopfox/sliver/client/constants"
 	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/bishopfox/sliver/protobuf/commonpb"
 	"github.com/bishopfox/sliver/server/c2"
@@ -94,29 +87,12 @@ func (rpc *Server) StartMTLSListener(ctx context.Context, req *clientpb.MTLSList
 		listenPort = uint16(req.Port)
 	}
 
-	bind := fmt.Sprintf("%s:%d", req.Host, listenPort)
-	ln, err := c2.StartMutualTLSListener(req.Host, listenPort)
+	jobID, err := c2.StartMTLSListenerJob(req.Host, listenPort)
 	if err != nil {
-		return nil, err // If we fail to bind don't setup the Job
+		return nil, err
 	}
 
-	job := &core.Job{
-		ID:          core.NextJobID(),
-		Name:        "mtls",
-		Description: fmt.Sprintf("mutual tls listener %s", bind),
-		Protocol:    "tcp",
-		Port:        listenPort,
-		JobCtrl:     make(chan bool),
-	}
-
-	go func() {
-		<-job.JobCtrl
-		rpcLog.Infof("Stopping mTLS listener (%d) ...", job.ID)
-		ln.Close() // Kills listener GoRoutines in StartMutualTLSListener() but NOT connections
-		core.Jobs.Remove(job)
-	}()
-	core.Jobs.Add(job)
-	return &clientpb.MTLSListener{JobID: uint32(job.ID)}, nil
+	return &clientpb.MTLSListener{JobID: uint32(jobID)}, nil
 }
 
 // StartDNSListener - Start a DNS listener TODO: respect request's Host specification
@@ -128,54 +104,11 @@ func (rpc *Server) StartDNSListener(ctx context.Context, req *clientpb.DNSListen
 	if req.Port != 0 {
 		listenPort = uint16(req.Port)
 	}
-	jobID, err := jobStartDNSListener(req.Domains, req.Canaries, listenPort)
+	jobID, err := c2.StartDNSListenerJob(req.Domains, req.Canaries, listenPort)
 	if err != nil {
 		return nil, err
 	}
 	return &clientpb.DNSListener{JobID: uint32(jobID)}, nil
-}
-
-func jobStartDNSListener(domains []string, canaries bool, listenPort uint16) (int, error) {
-
-	server := c2.StartDNSListener(domains, canaries)
-	description := fmt.Sprintf("%s (canaries %v)", strings.Join(domains, " "), canaries)
-	job := &core.Job{
-		ID:          core.NextJobID(),
-		Name:        "dns",
-		Description: description,
-		Protocol:    "udp",
-		Port:        listenPort,
-		JobCtrl:     make(chan bool),
-		Domains:     domains,
-	}
-
-	go func() {
-		<-job.JobCtrl
-		rpcLog.Infof("Stopping DNS listener (%d) ...", job.ID)
-		server.Shutdown()
-		core.Jobs.Remove(job)
-		core.EventBroker.Publish(core.Event{
-			Job:       job,
-			EventType: consts.JobStoppedEvent,
-		})
-	}()
-
-	core.Jobs.Add(job)
-
-	// There is no way to call DNS' ListenAndServe() without blocking
-	// but we also need to check the error in the case the server
-	// fails to start at all, so we setup all the Job mechanics
-	// then kick off the server and if it fails we kill the job
-	// ourselves.
-	go func() {
-		err := server.ListenAndServe()
-		if err != nil {
-			rpcLog.Errorf("DNS listener error %v", err)
-			job.JobCtrl <- true
-		}
-	}()
-
-	return job.ID, nil
 }
 
 // StartHTTPSListener - Start an HTTPS listener
@@ -199,7 +132,7 @@ func (rpc *Server) StartHTTPSListener(ctx context.Context, req *clientpb.HTTPLis
 		Key:     req.Key,
 		ACME:    req.ACME,
 	}
-	job, err := jobStartHTTPListener(conf)
+	job, err := c2.StartHTTPListenerJob(conf)
 	if err != nil {
 		return nil, err
 	}
@@ -224,116 +157,9 @@ func (rpc *Server) StartHTTPListener(ctx context.Context, req *clientpb.HTTPList
 		Secure:  false,
 		ACME:    false,
 	}
-	job, err := jobStartHTTPListener(conf)
+	job, err := c2.StartHTTPListenerJob(conf)
 	if err != nil {
 		return nil, err
 	}
 	return &clientpb.HTTPListener{JobID: uint32(job.ID)}, nil
-}
-
-func jobStartHTTPListener(conf *c2.HTTPServerConfig) (*core.Job, error) {
-	server, err := c2.StartHTTPSListener(conf)
-	if err != nil {
-		return nil, err
-	}
-	name := "http"
-	if conf.Secure {
-		name = "https"
-	}
-
-	job := &core.Job{
-		ID:          core.NextJobID(),
-		Name:        name,
-		Description: fmt.Sprintf("%s for domain %s", name, conf.Domain),
-		Protocol:    "tcp",
-		Port:        uint16(conf.LPort),
-		JobCtrl:     make(chan bool),
-		Domains:     []string{conf.Domain},
-	}
-	core.Jobs.Add(job)
-
-	cleanup := func(err error) {
-		server.Cleanup()
-		core.Jobs.Remove(job)
-		core.EventBroker.Publish(core.Event{
-			Job:       job,
-			EventType: consts.JobStoppedEvent,
-			Err:       err,
-		})
-	}
-	once := &sync.Once{}
-
-	go func() {
-		var err error
-		if server.Conf.Secure {
-			if server.Conf.ACME {
-				err = server.HTTPServer.ListenAndServeTLS("", "") // ACME manager pulls the certs under the hood
-			} else {
-				err = listenAndServeTLS(server.HTTPServer, conf.Cert, conf.Key)
-			}
-		} else {
-			err = server.HTTPServer.ListenAndServe()
-		}
-		if err != nil {
-			rpcLog.Errorf("%s listener error %v", name, err)
-			once.Do(func() { cleanup(err) })
-			job.JobCtrl <- true // Cleanup other goroutine
-		}
-	}()
-
-	go func() {
-		<-job.JobCtrl
-		once.Do(func() { cleanup(nil) })
-	}()
-
-	return job, nil
-}
-
-// Fuck'in Go - https://stackoverflow.com/questions/30815244/golang-https-server-passing-certfile-and-kyefile-in-terms-of-byte-array
-// basically the same as server.ListenAndServerTLS() but we can pass in byte slices instead of file paths
-func listenAndServeTLS(srv *http.Server, certPEMBlock, keyPEMBlock []byte) error {
-	addr := srv.Addr
-	if addr == "" {
-		addr = ":https"
-	}
-	config := &tls.Config{}
-	if srv.TLSConfig != nil {
-		*config = *srv.TLSConfig
-	}
-	if config.NextProtos == nil {
-		config.NextProtos = []string{"http/1.1"}
-	}
-
-	var err error
-	config.Certificates = make([]tls.Certificate, 1)
-	config.Certificates[0], err = tls.X509KeyPair(certPEMBlock, keyPEMBlock)
-	if err != nil {
-		return err
-	}
-
-	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		return err
-	}
-
-	tlsListener := tls.NewListener(tcpKeepAliveListener{ln.(*net.TCPListener)}, config)
-	return srv.Serve(tlsListener)
-}
-
-// tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
-// connections. It's used by ListenAndServe and ListenAndServeTLS so
-// dead TCP connections (e.g. closing laptop mid-download) eventually
-// go away.
-type tcpKeepAliveListener struct {
-	*net.TCPListener
-}
-
-func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
-	tc, err := ln.AcceptTCP()
-	if err != nil {
-		return
-	}
-	tc.SetKeepAlive(true)
-	tc.SetKeepAlivePeriod(3 * time.Minute)
-	return tc, nil
 }

--- a/server/rpc/rpc-stager.go
+++ b/server/rpc/rpc-stager.go
@@ -22,12 +22,9 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"sync"
 
-	consts "github.com/bishopfox/sliver/client/constants"
 	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/bishopfox/sliver/server/c2"
-	"github.com/bishopfox/sliver/server/core"
 )
 
 // StartTCPStagerListener starts a TCP stager listener
@@ -36,7 +33,7 @@ func (rpc *Server) StartTCPStagerListener(ctx context.Context, req *clientpb.Sta
 	if !checkInterface(req.GetHost()) {
 		host = "0.0.0.0"
 	}
-	jobID, err := jobStartTCPStagerListener(host, uint16(req.GetPort()), req.GetData())
+	jobID, err := c2.StartTCPStagerListenerJob(host, uint16(req.GetPort()), req.GetData())
 	return &clientpb.StagerListener{JobID: uint32(jobID)}, err
 }
 
@@ -58,7 +55,7 @@ func (rpc *Server) StartHTTPStagerListener(ctx context.Context, req *clientpb.St
 		conf.Cert = req.Cert
 		conf.ACME = req.ACME
 	}
-	job, err := jobStartHTTPStagerListener(conf, req.Data)
+	job, err := c2.StartHTTPStagerListenerJob(conf, req.Data)
 	if err != nil {
 		return nil, err
 	}
@@ -66,98 +63,6 @@ func (rpc *Server) StartHTTPStagerListener(ctx context.Context, req *clientpb.St
 		return nil, fmt.Errorf("job is nil")
 	}
 	return &clientpb.StagerListener{JobID: uint32(job.ID)}, err
-}
-
-// jobStartTCPStagerListener - Start a TCP staging payload listener
-func jobStartTCPStagerListener(host string, port uint16, shellcode []byte) (int, error) {
-	ln, err := c2.StartTCPListener(host, port, shellcode)
-	if err != nil {
-		return -1, err // If we fail to bind don't setup the Job
-	}
-
-	job := &core.Job{
-		ID:          core.NextJobID(),
-		Name:        "TCP",
-		Description: "Raw TCP listener (stager only)",
-		Protocol:    "tcp",
-		Port:        port,
-		JobCtrl:     make(chan bool),
-	}
-
-	go func() {
-		<-job.JobCtrl
-		rpcLog.Infof("Stopping TCP listener (%d) ...", job.ID)
-		ln.Close() // Kills listener GoRoutines in startMutualTLSListener() but NOT connections
-
-		core.Jobs.Remove(job)
-
-		core.EventBroker.Publish(core.Event{
-			Job:       job,
-			EventType: consts.JobStoppedEvent,
-		})
-	}()
-
-	core.Jobs.Add(job)
-
-	return job.ID, nil
-}
-
-// jobStartHTTPStagerListener - Start an HTTP(S) stager payload listener
-func jobStartHTTPStagerListener(conf *c2.HTTPServerConfig, data []byte) (*core.Job, error) {
-	server, err := c2.StartHTTPSListener(conf)
-	if err != nil {
-		return nil, err
-	}
-	name := "http"
-	if conf.Secure {
-		name = "https"
-	}
-	server.SliverStage = data
-	job := &core.Job{
-		ID:          core.NextJobID(),
-		Name:        name,
-		Description: fmt.Sprintf("Stager handler %s for domain %s", name, conf.Domain),
-		Protocol:    "tcp",
-		Port:        uint16(conf.LPort),
-		JobCtrl:     make(chan bool),
-	}
-	core.Jobs.Add(job)
-
-	cleanup := func(err error) {
-		server.Cleanup()
-		core.Jobs.Remove(job)
-		core.EventBroker.Publish(core.Event{
-			Job:       job,
-			EventType: consts.JobStoppedEvent,
-			Err:       err,
-		})
-	}
-	once := &sync.Once{}
-
-	go func() {
-		var err error
-		if server.Conf.Secure {
-			if server.Conf.ACME {
-				err = server.HTTPServer.ListenAndServeTLS("", "") // ACME manager pulls the certs under the hood
-			} else {
-				err = listenAndServeTLS(server.HTTPServer, conf.Cert, conf.Key)
-			}
-		} else {
-			err = server.HTTPServer.ListenAndServe()
-		}
-		if err != nil {
-			rpcLog.Errorf("%s listener error %v", name, err)
-			once.Do(func() { cleanup(err) })
-			job.JobCtrl <- true // Cleanup other goroutine
-		}
-	}()
-
-	go func() {
-		<-job.JobCtrl
-		once.Do(func() { cleanup(nil) })
-	}()
-
-	return job, nil
 }
 
 // checkInterface verifies if an IP address

--- a/server/rpc/rpc-stager.go
+++ b/server/rpc/rpc-stager.go
@@ -33,8 +33,8 @@ func (rpc *Server) StartTCPStagerListener(ctx context.Context, req *clientpb.Sta
 	if !checkInterface(req.GetHost()) {
 		host = "0.0.0.0"
 	}
-	jobID, err := c2.StartTCPStagerListenerJob(host, uint16(req.GetPort()), req.GetData())
-	return &clientpb.StagerListener{JobID: uint32(jobID)}, err
+	job, err := c2.StartTCPStagerListenerJob(host, uint16(req.GetPort()), req.GetData())
+	return &clientpb.StagerListener{JobID: uint32(job.ID)}, err
 }
 
 // StartHTTPStagerListener starts a HTTP(S) stager listener


### PR DESCRIPTION
As described in #254, this is useful for daemonizing the server so clients can reconnect if the server reboots/crashes/etc.

Each listener with the `-p`/`--persistent` flag specified will be serialized to the `server.json` file.  On start, the jobs are restarted.  If a job is killed, it is removed from the persistent configuration.

I'm sorry the change looks so large, but it made sense to refactor the code that actually starts jobs out of the RPC package since they can now be started both by persistence and by RPCs.

Fixes #254.
