### PR TITLE
Allow specifying a port for DNS listeners.

### DIFF
--- a/client/command/bind-commands.go
+++ b/client/command/bind-commands.go
@@ -47,6 +47,7 @@ const (
 	defaultMTLSLPort    = 8888
 	defaultHTTPLPort    = 80
 	defaultHTTPSLPort   = 443
+	defaultDNSLPort     = 53
 	defaultTCPPort      = 4444
 	defaultTCPPivotPort = 9898
 
@@ -144,6 +145,7 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 		Flags: func(f *grumble.Flags) {
 			f.String("d", "domains", "", "parent domain(s) to use for DNS c2")
 			f.Bool("c", "no-canaries", false, "disable dns canary detection")
+			f.Int("l", "lport", defaultDNSLPort, "udp listen port")
 
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
 			f.Bool("p", "persistent", false, "make persistent across restarts")

--- a/client/command/job.go
+++ b/client/command/job.go
@@ -132,9 +132,12 @@ func startDNSListener(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 		}
 	}
 
+	lport := uint16(ctx.Flags.Int("lport"))
+
 	fmt.Printf(Info+"Starting DNS listener with parent domain(s) %v ...\n", domains)
 	dns, err := rpc.StartDNSListener(context.Background(), &clientpb.DNSListenerReq{
 		Domains:    domains,
+		Port:       uint32(lport),
 		Canaries:   !ctx.Flags.Bool("no-canaries"),
 		Persistent: ctx.Flags.Bool("persistent"),
 	})


### PR DESCRIPTION
This provides an lport option for DNS listeners as well.  53, of course,
is the default value.

Fixes #270.