### PR TITLE
Use correct transport protocol in log message.

### DIFF
--- a/sliver/transports/transports.go
+++ b/sliver/transports/transports.go
@@ -157,7 +157,7 @@ func StartConnectionLoop() *Connection {
 				return connection
 			}
 			// {{if .Debug}}
-			log.Printf("[mtls] Connection failed %s", err)
+			log.Printf("[%s] Connection failed %s", uri.Scheme, err)
 			// {{end}}
 			connectionAttempts++
 			// {{end}} - HTTPc2Enabled


### PR DESCRIPTION
Minor nit, but http/https connection failed error message currently says `[mtls]`.  This uses the correct `uri.Scheme` value in the error message.
