### PR TITLE
Add getenv command

### DIFF
--- a/client/command/bind-commands.go
+++ b/client/command/bind-commands.go
@@ -1266,4 +1266,21 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 		},
 		HelpGroup: consts.SliverHelpGroup,
 	})
+
+	app.AddCommand(&grumble.Command{
+		Name:      consts.GetEnvStr,
+		Help:      "List environment variables",
+		LongHelp:  help.GetHelpFor(consts.GetEnvStr),
+		AllowArgs: true,
+		Flags: func(f *grumble.Flags) {
+			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
+		},
+		Run: func(ctx *grumble.Context) error {
+			fmt.Println()
+			getEnv(ctx, rpc)
+			fmt.Println()
+			return nil
+		},
+		HelpGroup: consts.GenericHelpGroup,
+	})
 }

--- a/client/command/env.go
+++ b/client/command/env.go
@@ -1,0 +1,36 @@
+package command
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bishopfox/sliver/protobuf/rpcpb"
+	"github.com/bishopfox/sliver/protobuf/sliverpb"
+	"github.com/desertbit/grumble"
+)
+
+func getEnv(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
+	session := ActiveSession.Get()
+	if session == nil {
+		return
+	}
+
+	var name string
+	if len(ctx.Args) > 0 {
+		name = ctx.Args[0]
+	}
+
+	envInfo, err := rpc.GetEnv(context.Background(), &sliverpb.EnvReq{
+		Name:    name,
+		Request: ActiveSession.Request(ctx),
+	})
+
+	if err != nil {
+		fmt.Printf(Warn+"Error: %v", err)
+		return
+	}
+
+	for _, envVar := range envInfo.Variables {
+		fmt.Printf("%s=%s\n", envVar.Key, envVar.Value)
+	}
+}

--- a/client/command/generate.go
+++ b/client/command/generate.go
@@ -41,7 +41,6 @@ import (
 	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/bishopfox/sliver/protobuf/commonpb"
 	"github.com/bishopfox/sliver/protobuf/rpcpb"
-	server "github.com/bishopfox/sliver/server/generate"
 	"github.com/desertbit/grumble"
 )
 
@@ -246,19 +245,6 @@ func parseCompileFlags(ctx *grumble.Context) *clientpb.ImplantConfig {
 			if !isAlphanumeric(name) {
 				fmt.Printf(Warn + "Agent's name must be in alphanumeric only\n")
 				return nil
-			}
-
-			sliversDir := server.GetSliversDir() // ~/.sliver/slivers
-			projectGoPathDir := path.Join(sliversDir, targetOS, arch, name)
-
-			if _, err := os.Stat(projectGoPathDir); !os.IsNotExist(err) {
-				prompt := &survey.Confirm{Message: "Agent already exists with this name. Overwrite existing file?"}
-				var confirm bool
-				survey.AskOne(prompt, &confirm)
-				if !confirm {
-					fmt.Printf(Warn + "File exists\n")
-					return nil
-				}
 			}
 		}
 	}

--- a/client/constants/constants.go
+++ b/client/constants/constants.go
@@ -131,6 +131,7 @@ const (
 	PsExecStr     = "psexec"
 	BackdoorStr   = "backdoor"
 	MakeTokenStr  = "make-token"
+	GetEnvStr     = "getenv"
 )
 
 // Groups

--- a/client/help/console-help.go
+++ b/client/help/console-help.go
@@ -71,6 +71,7 @@ var (
 		consts.WebsitesStr:   websitesHelp,
 		consts.ScreenshotStr: screenshotHelp,
 		consts.MakeTokenStr:  makeTokenHelp,
+		consts.GetEnvStr:     getEnvHelp,
 	}
 
 	jobsHelp = `[[.Bold]]Command:[[.Normal]] jobs <options>
@@ -384,6 +385,11 @@ The [[.Bold]]psexec[[.Normal]] command will use the credentials of the Windows u
 	makeTokenHelp = `[[.Bold]]Command:[[.Normal]] make-token -u USERNAME -d DOMAIN -p PASSWORD
 [[.Bold]]About:[[.Normal]] Creates a new Logon Session from the specified credentials and impersonate the resulting token.
 `
+
+	getEnvHelp = `[[.Bold]]Command:[[.Normal]] getenv [name]
+[[.Bold]]About:[[.Normal]] Retrieve the environment variables for the current session. If no variable name is provided, lists all the environment variables.
+[[.Bold]]Example:[[.Normal]] getenv SHELL
+	`
 )
 
 const (

--- a/protobuf/clientpb/client.proto
+++ b/protobuf/clientpb/client.proto
@@ -214,6 +214,11 @@ message Sessions {
   repeated Session Sessions = 1;
 }
 
+message UpdateSession {
+  uint32 SessionID = 1;
+  string Name = 2;
+}
+
 message GenerateReq {
   ImplantConfig Config = 1;
 }

--- a/protobuf/commonpb/common.proto
+++ b/protobuf/commonpb/common.proto
@@ -36,3 +36,9 @@ message Process {
   string Executable = 3;
   string Owner = 4;
 }
+
+// EnvVar - Environment variable K/V
+message EnvVar {
+  string Key = 1;
+  string Value = 2;
+}

--- a/protobuf/rpcpb/services.proto
+++ b/protobuf/rpcpb/services.proto
@@ -18,6 +18,7 @@ service SliverRPC {
     // *** Sessions ***
     rpc GetSessions(commonpb.Empty) returns (clientpb.Sessions);
     rpc KillSession(sliverpb.KillSessionReq) returns (commonpb.Empty);
+    rpc UpdateSession(clientpb.UpdateSession) returns (clientpb.Session);
     
     // *** Jobs ***
     rpc GetJobs(commonpb.Empty) returns (clientpb.Jobs);

--- a/protobuf/rpcpb/services.proto
+++ b/protobuf/rpcpb/services.proto
@@ -83,6 +83,7 @@ service SliverRPC {
     rpc StopService(sliverpb.StopServiceReq) returns (sliverpb.ServiceInfo);
     rpc RemoveService(sliverpb.RemoveServiceReq) returns (sliverpb.ServiceInfo);
     rpc MakeToken(sliverpb.MakeTokenReq) returns (sliverpb.MakeToken);
+    rpc GetEnv(sliverpb.EnvReq) returns (sliverpb.EnvInfo);
 
     // *** Realtime Commands ***
     rpc Shell(sliverpb.ShellReq) returns (sliverpb.Shell);

--- a/protobuf/sliverpb/constants.go
+++ b/protobuf/sliverpb/constants.go
@@ -174,6 +174,10 @@ const (
 	MsgMakeTokenReq
 	// MsgMakeToken - Response for MakeToken
 	MsgMakeToken
+	// MsgEnvReq - Request to get environment variables
+	MsgEnvReq
+	// MsgEnvInfo - Response to environment variable request
+	MsgEnvInfo
 )
 
 // MsgNumber - Get a message number of type
@@ -326,6 +330,10 @@ func MsgNumber(request proto.Message) uint32 {
 		return MsgMakeTokenReq
 	case *MakeToken:
 		return MsgMakeToken
+	case *EnvReq:
+		return MsgEnvReq
+	case *EnvInfo:
+		return MsgEnvInfo
 
 	}
 	return uint32(0)

--- a/protobuf/sliverpb/sliver.proto
+++ b/protobuf/sliverpb/sliver.proto
@@ -384,6 +384,16 @@ message Netstat {
   commonpb.Response Response = 9;
 }
 
+message EnvReq {
+  string Name = 1;
+  commonpb.Request Request = 9;
+}
+
+message EnvInfo {
+  repeated commonpb.EnvVar Variables = 1;
+  commonpb.Response Response = 9;
+}
+
 // DNS Specific messages
 message DNSSessionInit {
   bytes Key = 1;

--- a/server/rpc/rpc-env.go
+++ b/server/rpc/rpc-env.go
@@ -1,0 +1,17 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/bishopfox/sliver/protobuf/sliverpb"
+)
+
+// GetEnv - Retrieve the environment variables list from the current session
+func (rpc *Server) GetEnv(ctx context.Context, req *sliverpb.EnvReq) (*sliverpb.EnvInfo, error) {
+	resp := &sliverpb.EnvInfo{}
+	err := rpc.GenericHandler(req, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/server/rpc/rpc-sessions.go
+++ b/server/rpc/rpc-sessions.go
@@ -55,3 +55,16 @@ func (rpc *Server) KillSession(ctx context.Context, kill *sliverpb.KillSessionRe
 	session.Request(sliverpb.MsgNumber(kill), timeout, data)
 	return &commonpb.Empty{}, nil
 }
+
+// UpdateSession - Update a session
+func (rpc *Server) UpdateSession(ctx context.Context, update *clientpb.UpdateSession) (*clientpb.Session, error) {
+	resp := &clientpb.Session{}
+	session := core.Sessions.Get(update.SessionID)
+	if session == nil {
+		return resp, ErrInvalidSessionID
+	}
+	session.Name = update.Name
+	core.Sessions.UpdateSession(session)
+	resp = session.ToProtobuf()
+	return resp, nil
+}

--- a/sliver/handlers/handlers_darwin.go
+++ b/sliver/handlers/handlers_darwin.go
@@ -24,6 +24,7 @@ import (
 	// {{else}}
 	// {{end}}
 
+	"github.com/bishopfox/sliver/protobuf/sliverpb"
 	pb "github.com/bishopfox/sliver/protobuf/sliverpb"
 )
 
@@ -41,14 +42,14 @@ var (
 		pb.MsgMkdirReq:     mkdirHandler,
 		pb.MsgIfconfigReq:  ifconfigHandler,
 		pb.MsgExecuteReq:   executeHandler,
+		sliverpb.MsgEnvReq: getEnvHandler,
 
 		pb.MsgScreenshotReq: screenshotHandler,
 
 		pb.MsgSideloadReq: sideloadHandler,
 	}
 
-	darwinPivotHandlers = map[uint32]PivotHandler{
-	}
+	darwinPivotHandlers = map[uint32]PivotHandler{}
 )
 
 // GetSystemHandlers - Returns a map of the darwin system handlers

--- a/sliver/handlers/handlers_linux.go
+++ b/sliver/handlers/handlers_linux.go
@@ -37,6 +37,7 @@ var (
 		sliverpb.MsgTaskReq:      taskHandler,
 		sliverpb.MsgIfconfigReq:  ifconfigHandler,
 		sliverpb.MsgExecuteReq:   executeHandler,
+		sliverpb.MsgEnvReq:       getEnvHandler,
 
 		sliverpb.MsgScreenshotReq: screenshotHandler,
 
@@ -44,8 +45,7 @@ var (
 		sliverpb.MsgSideloadReq: sideloadHandler,
 	}
 
-	linuxPivotHandlers = map[uint32]PivotHandler{
-	}
+	linuxPivotHandlers = map[uint32]PivotHandler{}
 )
 
 // GetSystemHandlers - Returns a map of the linux system handlers

--- a/sliver/handlers/handlers_windows.go
+++ b/sliver/handlers/handlers_windows.go
@@ -50,6 +50,7 @@ var (
 		sliverpb.MsgStartServiceReq:    startService,
 		sliverpb.MsgStopServiceReq:     stopService,
 		sliverpb.MsgRemoveServiceReq:   removeService,
+		sliverpb.MsgEnvReq:             getEnvHandler,
 
 		// Generic
 		sliverpb.MsgPsReq:        psHandler,


### PR DESCRIPTION
This PR adds a `getenv` command to print environment variables set to the current Sliver session.
It adds a new RPC called `GetEnv` to do that.