### PR TITLE
Add some features to facilitate implants debugging

### DIFF
--- a/server/generate/binaries.go
+++ b/server/generate/binaries.go
@@ -339,8 +339,15 @@ func SliverExecutable(name string, config *models.ImplantConfig) (string, error)
 	}
 	gcflags := fmt.Sprintf("")
 	asmflags := fmt.Sprintf("")
+	if config.Debug {
+		gcflags = "all=-N -l"
+		ldflags = []string{}
+	}
 	// trimpath is now a separate flag since Go 1.13
-	trimpath := "-trimpath"
+	trimpath := ""
+	if !config.Debug {
+		trimpath = "-trimpath"
+	}
 	_, err = gogo.GoBuild(*goConfig, pkgPath, dest, "", tags, ldflags, gcflags, asmflags, trimpath)
 	config.FileName = path.Base(dest)
 

--- a/sliver/limits/limits.go
+++ b/sliver/limits/limits.go
@@ -45,7 +45,10 @@ import (
 // ExecLimits - Checks for execution limitations (domain, hostname, etc)
 func ExecLimits() {
 
+	// {{if not .Config.Debug}}
+	// Disable debugger check in debug mode, so we can attach to the process
 	PlatformLimits() // Anti-debug & other platform specific evasion
+	// {{end}}
 
 	// {{if .Config.LimitDomainJoined}}
 	ok, err := isDomainJoined()


### PR DESCRIPTION
This PR modifies the implant build process when building in debug mode to allow the use of the delve debugger.

- Change some compilation flags to facilitate debugging
- Disable the debugger check when in debug mode
