### PR TITLE
Stage

### DIFF
--- a/server/rpc/rpc-priv.go
+++ b/server/rpc/rpc-priv.go
@@ -72,7 +72,13 @@ func (rpc *Server) GetSystem(ctx context.Context, req *clientpb.GetSystemReq) (*
 	name := path.Base(req.Config.GetName())
 	shellcode, err := getSliverShellcode(name)
 	if err != nil {
-		_, config := generate.ImplantConfigFromProtobuf(req.Config)
+		name, config := generate.ImplantConfigFromProtobuf(req.Config)
+		if name == "" {
+			name, err = generate.GetCodename()
+			if err != nil {
+				return nil, err
+			}
+		}
 		config.Format = clientpb.ImplantConfig_SHELLCODE
 		config.ObfuscateSymbols = false
 		shellcodePath, err := generate.SliverShellcode(name, config)

--- a/server/rpc/rpc-tasks.go
+++ b/server/rpc/rpc-tasks.go
@@ -60,7 +60,13 @@ func (rpc *Server) Migrate(ctx context.Context, req *clientpb.MigrateReq) (*sliv
 	name := path.Base(req.Config.GetName())
 	shellcode, err := getSliverShellcode(name)
 	if err != nil {
-		_, config := generate.ImplantConfigFromProtobuf(req.Config)
+		name, config := generate.ImplantConfigFromProtobuf(req.Config)
+		if name == "" {
+			name, err = generate.GetCodename()
+			if err != nil {
+				return nil, err
+			}
+		}
 		config.Format = clientpb.ImplantConfig_SHELLCODE
 		config.ObfuscateSymbols = false
 		shellcodePath, err := generate.SliverShellcode(name, config)


### PR DESCRIPTION
The `getsystem` and `migrate` command were buggy, which cause the command to fail if the Sliver config had the `skip-symbols` flag on.
This pull request fixes that.