### PR TITLE
Return early if the job failed to start to avoid a nil pointer deref Fixes #313

### DIFF
--- a/server/rpc/rpc-stager.go
+++ b/server/rpc/rpc-stager.go
@@ -34,7 +34,10 @@ func (rpc *Server) StartTCPStagerListener(ctx context.Context, req *clientpb.Sta
 		host = "0.0.0.0"
 	}
 	job, err := c2.StartTCPStagerListenerJob(host, uint16(req.GetPort()), req.GetData())
-	return &clientpb.StagerListener{JobID: uint32(job.ID)}, err
+	if err != nil {
+		return nil, err
+	}
+	return &clientpb.StagerListener{JobID: uint32(job.ID)}, nil
 }
 
 // StartHTTPStagerListener starts a HTTP(S) stager listener


### PR DESCRIPTION
Ensure the TCP staging listener successfully started and return early if that's not the case.

Fix #313.
