### PR TITLE
Spawndll fix

### DIFF
--- a/client/command/extensions.go
+++ b/client/command/extensions.go
@@ -256,20 +256,15 @@ func runExtensionCommand(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 			fmt.Printf(Info+"Output saved to %s\n", outFilePath.Name())
 		}
 	} else if c.IsReflective {
-		offset, err := getExportOffset(binPath, c.Entrypoint)
-		if err != nil {
-			fmt.Printf(Warn+"Error: %v\n", err)
-			return
-		}
 		ctrl := make(chan bool)
 		msg := fmt.Sprintf("Executing %s %s ...", ctx.Command.Name, args)
 		go spin.Until(msg, ctrl)
-		spawnDllResp, err := rpc.SpawnDll(context.Background(), &sliverpb.SpawnDllReq{
+		spawnDllResp, err := rpc.SpawnDll(context.Background(), &sliverpb.InvokeSpawnDllReq{
 			Request:     ActiveSession.Request(ctx),
 			Args:        strings.Trim(args, " "),
 			Data:        binData,
 			ProcessName: processName,
-			Offset:      offset,
+			EntryPoint:  c.Entrypoint,
 		})
 		ctrl <- true
 		<-ctrl

--- a/client/command/tasks.go
+++ b/client/command/tasks.go
@@ -20,10 +20,7 @@ package command
 
 import (
 	"bufio"
-	"bytes"
 	"context"
-	"debug/pe"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -31,7 +28,6 @@ import (
 	"os"
 	"path"
 	"strconv"
-	"strings"
 
 	"github.com/bishopfox/sliver/client/core"
 	"github.com/bishopfox/sliver/client/spin"
@@ -356,11 +352,6 @@ func spawnDll(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 	binPath := ctx.Args[0]
 	processName := ctx.Flags.String("process")
 	exportName := ctx.Flags.String("export")
-	offset, err := getExportOffset(binPath, exportName)
-	if err != nil {
-		fmt.Printf(Warn+"%s", err.Error())
-		return
-	}
 
 	binData, err := ioutil.ReadFile(binPath)
 	if err != nil {
@@ -369,12 +360,12 @@ func spawnDll(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 	}
 	ctrl := make(chan bool)
 	go spin.Until(fmt.Sprintf("Executing reflective dll %s", binPath), ctrl)
-	spawndll, err := rpc.SpawnDll(context.Background(), &sliverpb.SpawnDllReq{
-		Request:     ActiveSession.Request(ctx),
-		Args:        args,
+	spawndll, err := rpc.SpawnDll(context.Background(), &sliverpb.InvokeSpawnDllReq{
 		Data:        binData,
 		ProcessName: processName,
-		Offset:      offset,
+		Args:        args,
+		EntryPoint:  exportName,
+		Request:     ActiveSession.Request(ctx),
 	})
 
 	if err != nil {
@@ -426,87 +417,4 @@ func getActiveSliverConfig() *clientpb.ImplantConfig {
 		C2:          c2s,
 	}
 	return config
-}
-
-// ExportDirectory - stores the Export data
-type ExportDirectory struct {
-	Characteristics       uint32
-	TimeDateStamp         uint32
-	MajorVersion          uint16
-	MinorVersion          uint16
-	Name                  uint32
-	Base                  uint32
-	NumberOfFunctions     uint32
-	NumberOfNames         uint32
-	AddressOfFunctions    uint32 // RVA from base of image
-	AddressOfNames        uint32 // RVA from base of image
-	AddressOfNameOrdinals uint32 // RVA from base of image
-}
-
-func rvaToFoa(rva uint32, pefile *pe.File) uint32 {
-	var offset uint32
-	for _, section := range pefile.Sections {
-		if rva >= section.SectionHeader.VirtualAddress && rva <= section.SectionHeader.VirtualAddress+section.SectionHeader.Size {
-			offset = section.SectionHeader.Offset + (rva - section.SectionHeader.VirtualAddress)
-		}
-	}
-	return offset
-}
-
-func getFuncName(index uint32, rawData []byte, fpe *pe.File) string {
-	nameRva := binary.LittleEndian.Uint32(rawData[index:])
-	nameFOA := rvaToFoa(nameRva, fpe)
-	funcNameBytes, err := bytes.NewBuffer(rawData[nameFOA:]).ReadBytes(0)
-	if err != nil {
-		log.Fatal(err)
-		return ""
-	}
-	funcName := string(funcNameBytes[:len(funcNameBytes)-1])
-	return funcName
-}
-
-func getOrdinal(index uint32, rawData []byte, fpe *pe.File, funcArrayFoa uint32) uint32 {
-	ordRva := binary.LittleEndian.Uint16(rawData[index:])
-	funcArrayIndex := funcArrayFoa + uint32(ordRva)*8
-	funcRVA := binary.LittleEndian.Uint32(rawData[funcArrayIndex:])
-	funcOffset := rvaToFoa(funcRVA, fpe)
-	return funcOffset
-}
-
-func getExportOffset(filepath string, exportName string) (funcOffset uint32, err error) {
-	rawData, err := ioutil.ReadFile(filepath)
-	if err != nil {
-		return 0, err
-	}
-	handle, err := os.Open(filepath)
-	if err != nil {
-		return 0, err
-	}
-	defer handle.Close()
-	fpe, _ := pe.NewFile(handle)
-	exportDirectoryRVA := fpe.OptionalHeader.(*pe.OptionalHeader64).DataDirectory[pe.IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress
-	var offset = rvaToFoa(exportDirectoryRVA, fpe)
-	exportDir := ExportDirectory{}
-	buff := &bytes.Buffer{}
-	buff.Write(rawData[offset:])
-	err = binary.Read(buff, binary.LittleEndian, &exportDir)
-	if err != nil {
-		return 0, err
-	}
-	current := exportDir.AddressOfNames
-	nameArrayFOA := rvaToFoa(exportDir.AddressOfNames, fpe)
-	ordinalArrayFOA := rvaToFoa(exportDir.AddressOfNameOrdinals, fpe)
-	funcArrayFoa := rvaToFoa(exportDir.AddressOfFunctions, fpe)
-
-	for i := uint32(0); i < exportDir.NumberOfNames; i++ {
-		index := nameArrayFOA + i*8
-		name := getFuncName(index, rawData, fpe)
-		if strings.Contains(name, exportName) {
-			ordIndex := ordinalArrayFOA + i*2
-			funcOffset = getOrdinal(ordIndex, rawData, fpe, funcArrayFoa)
-		}
-		current += uint32(binary.Size(i))
-	}
-
-	return
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.2
 	github.com/Binject/binjection v0.0.0-20200705191933-da1a50d7013d
-	github.com/Binject/debug v0.0.0-20201108185608-2b8504217eb5 // indirect
+	github.com/Binject/debug v0.0.0-20201108185608-2b8504217eb5
 	github.com/BurntSushi/xgb v0.0.0-20201008132610-5f9e7b3c49cd
 	github.com/Microsoft/go-winio v0.4.15
 	github.com/alecthomas/chroma v0.8.1

--- a/protobuf/rpcpb/services.proto
+++ b/protobuf/rpcpb/services.proto
@@ -79,7 +79,7 @@ service SliverRPC {
     rpc Migrate(clientpb.MigrateReq) returns (sliverpb.Migrate);
     rpc Execute(sliverpb.ExecuteReq) returns (sliverpb.Execute);
     rpc Sideload(sliverpb.SideloadReq) returns (sliverpb.Sideload);
-    rpc SpawnDll(sliverpb.SpawnDllReq) returns (sliverpb.SpawnDll);
+    rpc SpawnDll(sliverpb.InvokeSpawnDllReq) returns (sliverpb.SpawnDll);
     rpc Screenshot(sliverpb.ScreenshotReq) returns (sliverpb.Screenshot);
     rpc NamedPipes(sliverpb.NamedPipesReq) returns (sliverpb.NamedPipes);
     rpc TCPListener(sliverpb.TCPPivotReq) returns (sliverpb.TCPPivot);

--- a/protobuf/sliverpb/sliver.proto
+++ b/protobuf/sliverpb/sliver.proto
@@ -341,6 +341,15 @@ message Sideload {
   commonpb.Response Response = 9;
 }
 
+message InvokeSpawnDllReq {
+  bytes Data = 1;
+  string ProcessName = 2;
+  string Args = 3;
+  string EntryPoint = 4;
+
+  commonpb.Request Request = 9;
+}
+
 message SpawnDllReq {
   bytes Data = 1;
   string ProcessName = 2;

--- a/server/rpc/rpc-tasks.go
+++ b/server/rpc/rpc-tasks.go
@@ -21,7 +21,6 @@ package rpc
 import (
 	"bytes"
 	"context"
-	"debug/pe"
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
@@ -29,6 +28,8 @@ import (
 	"os"
 	"path"
 	"strings"
+
+	"github.com/Binject/debug/pe"
 
 	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
@@ -109,7 +110,7 @@ func (rpc *Server) ExecuteAssembly(ctx context.Context, req *sliverpb.ExecuteAss
 	if err != nil {
 		return nil, err
 	}
-	offset, err := getExportOffset(hostingDllPath, "ReflectiveLoader")
+	offset, err := getExportOffsetFromFile(hostingDllPath, "ReflectiveLoader")
 	if err != nil {
 		return nil, err
 	}
@@ -190,13 +191,31 @@ func (rpc *Server) Sideload(ctx context.Context, req *sliverpb.SideloadReq) (*sl
 }
 
 // SpawnDll - Spawn a DLL on the remote system (Windows only)
-func (rpc *Server) SpawnDll(ctx context.Context, req *sliverpb.SpawnDllReq) (*sliverpb.SpawnDll, error) {
+func (rpc *Server) SpawnDll(ctx context.Context, req *sliverpb.InvokeSpawnDllReq) (*sliverpb.SpawnDll, error) {
+	session := core.Sessions.Get(req.Request.SessionID)
+	if session == nil {
+		return nil, ErrInvalidSessionID
+	}
+
 	resp := &sliverpb.SpawnDll{}
-	err := rpc.GenericHandler(req, resp)
+	offset, err := getExportOffsetFromMemory(req.Data, req.EntryPoint)
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+	timeout := rpc.getTimeout(req)
+	data, err := proto.Marshal(&sliverpb.SpawnDllReq{
+		Data:        req.Data,
+		Offset:      offset,
+		ProcessName: req.ProcessName,
+		Args:        req.Args,
+		Request:     req.Request,
+	})
+	if err != nil {
+		return nil, err
+	}
+	respData, err := session.Request(sliverpb.MsgSpawnDllReq, timeout, data)
+	err = proto.Unmarshal(respData, resp)
+	return resp, err
 }
 
 // Utility functions
@@ -261,7 +280,7 @@ func getOrdinal(index uint32, rawData []byte, fpe *pe.File, funcArrayFoa uint32)
 	return funcOffset
 }
 
-func getExportOffset(filepath string, exportName string) (funcOffset uint32, err error) {
+func getExportOffsetFromFile(filepath string, exportName string) (funcOffset uint32, err error) {
 	rawData, err := ioutil.ReadFile(filepath)
 	if err != nil {
 		return 0, err
@@ -272,6 +291,40 @@ func getExportOffset(filepath string, exportName string) (funcOffset uint32, err
 	}
 	defer handle.Close()
 	fpe, _ := pe.NewFile(handle)
+	exportDirectoryRVA := fpe.OptionalHeader.(*pe.OptionalHeader64).DataDirectory[pe.IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress
+	var offset = rvaToFoa(exportDirectoryRVA, fpe)
+	exportDir := ExportDirectory{}
+	buff := &bytes.Buffer{}
+	buff.Write(rawData[offset:])
+	err = binary.Read(buff, binary.LittleEndian, &exportDir)
+	if err != nil {
+		return 0, err
+	}
+	current := exportDir.AddressOfNames
+	nameArrayFOA := rvaToFoa(exportDir.AddressOfNames, fpe)
+	ordinalArrayFOA := rvaToFoa(exportDir.AddressOfNameOrdinals, fpe)
+	funcArrayFoa := rvaToFoa(exportDir.AddressOfFunctions, fpe)
+
+	for i := uint32(0); i < exportDir.NumberOfNames; i++ {
+		index := nameArrayFOA + i*8
+		name := getFuncName(index, rawData, fpe)
+		if strings.Contains(name, exportName) {
+			ordIndex := ordinalArrayFOA + i*2
+			funcOffset = getOrdinal(ordIndex, rawData, fpe, funcArrayFoa)
+		}
+		current += uint32(binary.Size(i))
+	}
+
+	return
+}
+
+func getExportOffsetFromMemory(rawData []byte, exportName string) (funcOffset uint32, err error) {
+	peReader := bytes.NewReader(rawData)
+	fpe, err := pe.NewFileFromMemory(peReader)
+	if err != nil {
+		return 0, err
+	}
+
 	exportDirectoryRVA := fpe.OptionalHeader.(*pe.OptionalHeader64).DataDirectory[pe.IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress
 	var offset = rvaToFoa(exportDirectoryRVA, fpe)
 	exportDir := ExportDirectory{}


### PR DESCRIPTION
Move the address resolution server-side, to make it easier for third party clients (and sliver-gui) to use the `SpawnDLL` RPC.
