### PR TITLE
Show the current ProxyURL being used by an HTTP/HTTPS sliver

### DIFF
--- a/client/command/info.go
+++ b/client/command/info.go
@@ -53,6 +53,7 @@ func info(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 		fmt.Printf(bold+"       Version: %s%s\n", normal, session.Version)
 		fmt.Printf(bold+"          Arch: %s%s\n", normal, session.Arch)
 		fmt.Printf(bold+"Remote Address: %s%s\n", normal, session.RemoteAddress)
+		fmt.Printf(bold+"     Proxy URL: %s%s\n", normal, session.ProxyURL)
 	} else {
 		fmt.Printf(Warn+"No target session, see `help %s`\n", consts.InfoStr)
 	}

--- a/protobuf/clientpb/client.proto
+++ b/protobuf/clientpb/client.proto
@@ -39,6 +39,7 @@ message Session {
   bool Evasion = 16;
   bool IsDead = 17;
   uint32 ReconnectInterval = 18;
+  string ProxyURL = 19;
 }
 
 message ImplantC2 {

--- a/protobuf/sliverpb/sliver.proto
+++ b/protobuf/sliverpb/sliver.proto
@@ -44,6 +44,7 @@ message Register {
   string ActiveC2 = 10;
   string Version = 11;
   uint32 ReconnectInterval = 12;
+  string ProxyURL = 13;
 }
 
 // Ping - Not ICMP, just sends a rount trip message to an implant to

--- a/server/core/sessions.go
+++ b/server/core/sessions.go
@@ -68,6 +68,7 @@ type Session struct {
 	ActiveC2          string
 	IsDead            bool
 	ReconnectInterval uint32
+	ProxyURL          string
 }
 
 // ToProtobuf - Get the protobuf version of the object
@@ -109,6 +110,7 @@ func (s *Session) ToProtobuf() *clientpb.Session {
 		ActiveC2:          s.ActiveC2,
 		IsDead:            isDead,
 		ReconnectInterval: s.ReconnectInterval,
+		ProxyURL:          s.ProxyURL,
 	}
 }
 

--- a/server/handlers/sessions.go
+++ b/server/handlers/sessions.go
@@ -84,6 +84,7 @@ func registerSessionHandler(session *core.Session, data []byte) {
 	session.ActiveC2 = register.ActiveC2
 	session.Version = register.Version
 	session.ReconnectInterval = register.ReconnectInterval
+	session.ProxyURL = register.ProxyURL
 	core.Sessions.Add(session)
 }
 

--- a/sliver/sliver.go
+++ b/sliver/sliver.go
@@ -277,6 +277,7 @@ func getRegisterSliver() *sliverpb.Envelope {
 		Filename:          filename,
 		ActiveC2:          transports.GetActiveC2(),
 		ReconnectInterval: uint32(transports.GetReconnectInterval() / time.Second),
+		ProxyURL:          transports.GetProxyURL(),
 	})
 	if err != nil {
 		// {{if .Config.Debug}}

--- a/sliver/transports/tcp-http.go
+++ b/sliver/transports/tcp-http.go
@@ -86,6 +86,7 @@ func HTTPStartSession(address string) (*SliverHTTPClient, error) {
 type SliverHTTPClient struct {
 	Origin     string
 	Client     *http.Client
+	ProxyURL   string
 	SessionKey *AESKey
 	SessionID  string
 }
@@ -361,6 +362,7 @@ func httpClient(address string, useProxy bool) *SliverHTTPClient {
 			log.Printf("Proxy URL = '%s'\n", proxyURL)
 			// {{end}}
 			httpTransport.Proxy = http.ProxyURL(proxyURL)
+			client.ProxyURL = proxyURL.String()
 		}
 	}
 	return client
@@ -396,6 +398,7 @@ func httpsClient(address string, useProxy bool) *SliverHTTPClient {
 			log.Printf("Proxy URL = '%s'\n", proxyURL)
 			// {{end}}
 			netTransport.Proxy = http.ProxyURL(proxyURL)
+			client.ProxyURL = proxyURL.String()
 		}
 	}
 	return client

--- a/sliver/transports/transports.go
+++ b/sliver/transports/transports.go
@@ -60,6 +60,7 @@ var (
 
 	activeC2         string
 	activeConnection *Connection
+	proxyURL         string
 )
 
 // Connection - Abstract connection to the server
@@ -240,6 +241,14 @@ func GetActiveC2() string {
 	return activeC2
 }
 
+// GetProxyURL return the URL of the current proxy in use
+func GetProxyURL() string {
+	if proxyURL == "" {
+		return "none"
+	}
+	return proxyURL
+}
+
 // GetActiveConnection returns the Connection of the C2 in use
 func GetActiveConnection() *Connection {
 	return activeConnection
@@ -344,6 +353,7 @@ func httpConnect(uri *url.URL) (*Connection, error) {
 		// {{end}}
 		return nil, err
 	}
+	proxyURL = client.ProxyURL
 
 	send := make(chan *pb.Envelope)
 	recv := make(chan *pb.Envelope)


### PR DESCRIPTION
#### Card

No card 😬 

#### Details

For HTTP/HTTPS slivers, display the current proxy in use by the sliver when the `info` command is used.

Thought this would be useful information to have in case there is some ambiguity regarding which proxy the victim is using.

This seemed like the simplest way to surface this information, happy to modify it as need be.

*Windows Screenshot*

![image](https://user-images.githubusercontent.com/11132774/105627013-fd0f8b80-5e6e-11eb-9725-7f10c8db7d1b.png)

*macOS Screenshot*

![image](https://user-images.githubusercontent.com/11132774/105627029-1284b580-5e6f-11eb-9b21-197fd273923f.png)

