### PR TITLE
Canaries / Windows Garble Unpack

### DIFF
--- a/implant/sliver/constants/constants.go
+++ b/implant/sliver/constants/constants.go
@@ -1,5 +1,7 @@
 package constants
 
+import "reflect"
+
 // Ironically not consts, becuase our string obfuscator only works on `var`s
 
 /*
@@ -20,6 +22,15 @@ package constants
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+// Do not use an actual `const` or the string won't be obfuscated
 var (
 	SliverName = `{{.Name}}`
 )
+
+// Message - Fake message for embedding canaries
+type Message struct {
+	Command string `c2:"[[GenerateCanary]]"`
+}
+
+// never obfuscate the Message type
+var _ = reflect.TypeOf(Message{})

--- a/implant/sliver/constants/constants.go
+++ b/implant/sliver/constants/constants.go
@@ -2,8 +2,6 @@ package constants
 
 import "reflect"
 
-// Ironically not consts, becuase our string obfuscator only works on `var`s
-
 /*
 	Sliver Implant Framework
 	Copyright (C) 2019  Bishop Fox
@@ -22,7 +20,7 @@ import "reflect"
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-// Do not use an actual `const` or the string won't be obfuscated
+// Ironically not consts to ensure the string obfuscator hits this value
 var (
 	SliverName = `{{.Name}}`
 )

--- a/implant/sliver/encoders/english-words.go
+++ b/implant/sliver/encoders/english-words.go
@@ -1,5 +1,23 @@
 package encoders
 
+/*
+	Sliver Implant Framework
+	Copyright (C) 2021  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 func getEnglishDictionary() []string {
 	return []string{
 

--- a/implant/sliver/encoders/gzip.go
+++ b/implant/sliver/encoders/gzip.go
@@ -1,10 +1,5 @@
 package encoders
 
-import (
-	"bytes"
-	"compress/gzip"
-)
-
 /*
 	Sliver Implant Framework
 	Copyright (C) 2019  Bishop Fox
@@ -22,6 +17,11 @@ import (
 	You should have received a copy of the GNU General Public License
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
+
+import (
+	"bytes"
+	"compress/gzip"
+)
 
 // GzipEncoderID - EncoderID
 const GzipEncoderID = 49

--- a/implant/sliver/evasion/evasion.go
+++ b/implant/sliver/evasion/evasion.go
@@ -1,1 +1,19 @@
 package evasion
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2021  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/

--- a/implant/sliver/evasion/evasion_darwin.go
+++ b/implant/sliver/evasion/evasion_darwin.go
@@ -1,1 +1,19 @@
 package evasion
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2021  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/

--- a/implant/sliver/evasion/evasion_linux.go
+++ b/implant/sliver/evasion/evasion_linux.go
@@ -1,1 +1,19 @@
 package evasion
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2021  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/

--- a/implant/sliver/evasion/evasion_windows.go
+++ b/implant/sliver/evasion/evasion_windows.go
@@ -1,5 +1,23 @@
 package evasion
 
+/*
+	Sliver Implant Framework
+	Copyright (C) 2021  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import (
 	"github.com/bishopfox/sliver/implant/sliver/syscalls"
 	"golang.org/x/sys/windows"

--- a/implant/sliver/hostuuid/uuid_windows.go
+++ b/implant/sliver/hostuuid/uuid_windows.go
@@ -25,8 +25,8 @@ import (
 )
 
 // Stored Format: {U-U-I-D}
-const uuid_keypath = "HKEY_LOCAL_MACHINE\\SYSTEM\\HardwareConfig"
-const uuid_key = "LastConfig"
+var uuid_keypath = "HKEY_LOCAL_MACHINE\\SYSTEM\\HardwareConfig"
+var uuid_key = "LastConfig"
 
 func GetUUID() string {
 	key, err := registry.OpenKey(registry.CURRENT_USER, uuid_keypath, registry.QUERY_VALUE)

--- a/implant/sliver/netstat/netstat_linux.go
+++ b/implant/sliver/netstat/netstat_linux.go
@@ -192,7 +192,7 @@ type procFd struct {
 	p     *Process
 }
 
-const sockPrefix = "socket:["
+var sockPrefix = "socket:["
 
 func getProcName(s []byte) string {
 	i := bytes.Index(s, []byte("("))
@@ -251,7 +251,7 @@ func (p *procFd) iterFdDir() {
 }
 
 func extractProcInfo(sktab []SockTabEntry) {
-	const basedir = "/proc"
+	var basedir = "/proc"
 	fi, err := ioutil.ReadDir(basedir)
 	if err != nil {
 		return

--- a/implant/sliver/proxy/provider_darwin_test.go
+++ b/implant/sliver/proxy/provider_darwin_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
+var (
 	ScutilDataHttpsHttp = "ScutilDataHttpsHttp"
 	ScutilDataHttps     = "ScutilDataHttps"
 	ScutilDataHttp      = "ScutilDataHttp"
 )
 
-const (
+var (
 	ScutilBypassTest1 = "localhost"
 	ScutilBypassTest2 = "myorg1.com"
 	ScutilBypassTest3 = "endpoint.myorg2.com"

--- a/server/assets/assets.go
+++ b/server/assets/assets.go
@@ -161,13 +161,17 @@ func setupGo(appDir string) error {
 		return err
 	}
 
-	garbleAssetPath := path.Join("fs", runtime.GOOS, runtime.GOARCH, "garble")
+	garbleFileName := "garble"
+	if runtime.GOOS == "windows" {
+		garbleFileName = "garble.exe"
+	}
+	garbleAssetPath := path.Join("fs", runtime.GOOS, runtime.GOARCH, garbleFileName)
 	garbleFile, err := assetsFs.ReadFile(garbleAssetPath)
 	if err != nil {
 		setupLog.Errorf("Static asset not found: %s", garbleFile)
 		return err
 	}
-	garbleLocalPath := path.Join(appDir, "go", "bin", "garble")
+	garbleLocalPath := path.Join(appDir, "go", "bin", garbleFileName)
 	err = ioutil.WriteFile(garbleLocalPath, garbleFile, 0755)
 	if err != nil {
 		setupLog.Errorf("Failed to write garble %s", err)

--- a/server/generate/canaries.go
+++ b/server/generate/canaries.go
@@ -97,5 +97,5 @@ func (g *CanaryGenerator) GenerateCanary() string {
 	dbSession := db.Session()
 	dbSession.Create(&canary)
 
-	return fmt.Sprintf("%s%s", canaryPrefix, canaryDomain)
+	return canaryDomain
 }


### PR DESCRIPTION
* Canaries are no longer obfuscated in Garble builds
* Fixed Windows Garble asset file names