### PR TITLE
Fix cannot find 'nm'

### DIFF
--- a/server/gogo/go.go
+++ b/server/gogo/go.go
@@ -186,7 +186,7 @@ func GoCmd(config GoConfig, cwd string, command []string) ([]byte, error) {
 		fmt.Sprintf("GOPATH=%s", config.ProjectDir),
 		fmt.Sprintf("GOCACHE=%s", config.GOCACHE),
 		fmt.Sprintf("GOMODCACHE=%s", config.GOMODCACHE),
-		fmt.Sprintf("PATH=%s", path.Join(config.GOROOT, "bin")),
+		fmt.Sprintf("PATH=%s:%s", path.Join(config.GOROOT, "bin"), os.Getenv("PATH")),
 	}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer


### PR DESCRIPTION
https://github.com/BishopFox/sliver/wiki/Stagers

I encountered this error when generating stagers. I located this location through the log and the environment variable was not added, which resulted in the nm not being found.

^[[36mINFO^[[0m[2021-03-11T02:50:45+01:00] [sliver/server/gogo/go.go:203] --- stdout ---

^[[36mINFO^[[0m[2021-03-11T02:50:45+01:00] [sliver/server/gogo/go.go:204] --- stderr ---
# runtime/cgo
collect2: fatal error: cannot find 'nm'
compilation terminated.

#### Card

#### Details
