### PR TITLE
Fix for #359

### DIFF
--- a/implant/sliver/ps/ps_linux.go
+++ b/implant/sliver/ps/ps_linux.go
@@ -68,7 +68,8 @@ func getProcessOwner(pid int) (string, error) {
 	}
 	usr, err := user.LookupId(fmt.Sprintf("%d", uid))
 	if err != nil {
-		return "", err
+		// return the UID in case LookupId fails
+		return fmt.Sprintf("%d", uid), nil
 	}
 	return usr.Username, err
 }
@@ -151,12 +152,7 @@ func processes() ([]Process, error) {
 			}
 			p.owner, err = getProcessOwner(int(pid))
 			if err != nil {
-				uid, err := getProcessOwnerUid(int(pid))
-				if err != nil {
-					p.owner = ""
-				} else {
-					p.owner = fmt.Sprintf("%d", uid)
-				}
+				continue
 			}
 			results = append(results, p)
 		}


### PR DESCRIPTION
Fixes #359: in cases where we can't find the owner user name via `user.LookupId()`, we use the `uid` instead.