### PR TITLE
Fix improper use of debug/pe

### DIFF
--- a/client/command/extensions.go
+++ b/client/command/extensions.go
@@ -274,6 +274,7 @@ func runExtensionCommand(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 			Data:        binData,
 			ProcessName: processName,
 			EntryPoint:  c.Entrypoint,
+			Kill:        true,
 		})
 		ctrl <- true
 		<-ctrl
@@ -298,6 +299,7 @@ func runExtensionCommand(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 			Data:        binData,
 			EntryPoint:  entryPoint,
 			ProcessName: processName,
+			Kill:        true,
 		})
 		ctrl <- true
 		<-ctrl

--- a/server/rpc/rpc-tasks.go
+++ b/server/rpc/rpc-tasks.go
@@ -345,7 +345,7 @@ func getExportOffsetFromFile(filepath string, exportName string) (funcOffset uin
 
 func getExportOffsetFromMemory(rawData []byte, exportName string) (funcOffset uint32, err error) {
 	peReader := bytes.NewReader(rawData)
-	fpe, err := pe.NewFileFromMemory(peReader)
+	fpe, err := pe.NewFile(peReader)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
I was mistakenly using `Binject/debug/pe.NewFileFromMemory()` instead of `Binject/debug/pe.NewFile()` to load a DLL from a `[]byte`, which caused a few issues. This had the side effect of breaking the `Spawndll`  RPC.

We also now force `Kill` on sideload/spawndll for extensions.
