### PR TITLE
Add a new RPC to generate a wireguard client configuration

### DIFF
--- a/client/command/bind-commands.go
+++ b/client/command/bind-commands.go
@@ -1541,4 +1541,16 @@ func BindCommands(app *grumble.App, rpc rpcpb.SliverRPCClient) {
 		HelpGroup: consts.SliverHelpGroup,
 	})
 
+	app.AddCommand(&grumble.Command{
+		Name:     consts.WgConfigStr,
+		Help:     "Generate a new wireguard client config",
+		LongHelp: help.GetHelpFor(consts.WgConfigStr),
+		Run: func(ctx *grumble.Context) error {
+			fmt.Println()
+			getWGClientConfig(ctx, rpc)
+			fmt.Println()
+			return nil
+		},
+	})
+
 }

--- a/client/command/wg-config.go
+++ b/client/command/wg-config.go
@@ -1,0 +1,71 @@
+package command
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"text/template"
+
+	"github.com/bishopfox/sliver/protobuf/commonpb"
+	"github.com/bishopfox/sliver/protobuf/rpcpb"
+	"github.com/desertbit/grumble"
+)
+
+var wgQuickTemplate = `[Interface]
+Address = {{.ClientIP}}/16
+ListenPort = 51902
+PrivateKey = {{.PrivateKey}}
+MTU = 1420
+
+[Peer]
+PublicKey = {{.ServerPublicKey}}
+AllowedIPs = {{.AllowedSubnet}}
+Endpoint = <configure yourself>`
+
+type wgQuickConfig struct {
+	ClientIP        string
+	PrivateKey      string
+	ServerPublicKey string
+	AllowedSubnet   string
+}
+
+func getWGClientConfig(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
+	wgConfig, err := rpc.GenerateWGClientConfig(context.Background(), &commonpb.Empty{})
+
+	if err != nil {
+		fmt.Printf(Warn+"Error: %v", err)
+		return
+	}
+	clientPrivKeyBytes, err := hex.DecodeString(wgConfig.ClientPrivateKey)
+	if err != nil {
+		fmt.Printf(Warn+"Error: %v", err)
+		return
+	}
+	serverPubKeyBytes, err := hex.DecodeString(wgConfig.ServerPubKey)
+	if err != nil {
+		fmt.Printf(Warn+"Error: %v", err)
+		return
+	}
+	tmpl, err := template.New("wgQuick").Parse(wgQuickTemplate)
+	if err != nil {
+		fmt.Printf(Warn+"Error: %v", err)
+		return
+	}
+	clientIP, network, err := net.ParseCIDR(wgConfig.ClientIP + "/16")
+	if err != nil {
+		fmt.Printf(Warn+"Error: %v", err)
+		return
+	}
+	output := bytes.Buffer{}
+	tmpl.Execute(&output, wgQuickConfig{
+		ClientIP:        clientIP.String(),
+		PrivateKey:      base64.StdEncoding.EncodeToString(clientPrivKeyBytes),
+		ServerPublicKey: base64.StdEncoding.EncodeToString(serverPubKeyBytes),
+		AllowedSubnet:   network.String(),
+	})
+	fmt.Println(Info + "New client config:")
+	fmt.Println(output.String())
+}

--- a/client/constants/constants.go
+++ b/client/constants/constants.go
@@ -156,6 +156,7 @@ const (
 	RegistryListValuesStr = "list-values"
 	RegistryCreateKeyStr  = "create"
 	PivotsListStr         = "pivots-list"
+	WgConfigStr           = "wg-config"
 
 	LicensesStr = "licenses"
 )

--- a/implant/sliver/transports/transports.go
+++ b/implant/sliver/transports/transports.go
@@ -30,7 +30,9 @@ import (
 	// {{end}}
 
 	"crypto/x509"
+	// {{if .Config.WGc2Enabled}}
 	"fmt"
+	// {{end}}
 	"io"
 	"net/url"
 	"os"

--- a/implant/sliver/transports/transports.go
+++ b/implant/sliver/transports/transports.go
@@ -22,6 +22,7 @@ import (
 
 	// {{if or .Config.HTTPc2Enabled .Config.TCPPivotc2Enabled}}
 	"net"
+
 	// {{end}}
 
 	// {{if .Config.Debug}}
@@ -29,6 +30,7 @@ import (
 	// {{end}}
 
 	"crypto/x509"
+	"fmt"
 	"io"
 	"net/url"
 	"os"
@@ -403,7 +405,15 @@ func wgConnect(uri *url.URL) (*Connection, error) {
 	if err != nil {
 		lport = 53
 	}
-	conn, dev, err := wgSocketConnect(uri.Hostname(), uint16(lport))
+	addrs, err := net.LookupHost(uri.Hostname())
+	if err != nil {
+		return nil, err
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("invalid address")
+	}
+	hostname := addrs[0]
+	conn, dev, err := wgSocketConnect(hostname, uint16(lport))
 	if err != nil {
 		return nil, err
 	}

--- a/protobuf/clientpb/client.proto
+++ b/protobuf/clientpb/client.proto
@@ -412,3 +412,13 @@ message Website {
 message Websites {
   repeated Website Websites = 1;
 }
+
+
+// [Wireguard]
+
+message WGClientConfig {
+  string ServerPubKey = 1;
+  string ClientPrivateKey = 2;
+  string ClientPubKey = 3;
+  string ClientIP = 4;
+}

--- a/protobuf/rpcpb/services.proto
+++ b/protobuf/rpcpb/services.proto
@@ -41,6 +41,7 @@ service SliverRPC {
     rpc ImplantBuilds(commonpb.Empty) returns (clientpb.ImplantBuilds);
     rpc DeleteImplantBuild(clientpb.DeleteReq) returns (commonpb.Empty);
     rpc Canaries(commonpb.Empty) returns (clientpb.Canaries);
+    rpc GenerateWGClientConfig(commonpb.Empty) returns (clientpb.WGClientConfig);
     rpc GenerateUniqueIP(commonpb.Empty) returns (clientpb.UniqueWGIP);
     rpc ImplantProfiles(commonpb.Empty) returns (clientpb.ImplantProfiles);
     rpc DeleteImplantProfile(clientpb.DeleteReq) returns (commonpb.Empty);

--- a/server/netstack/tun.go
+++ b/server/netstack/tun.go
@@ -125,9 +125,17 @@ func CreateNetTUN(localAddresses, dnsServers []net.IP, mtu int) (tun.Device, *Ne
 	}
 	if dev.hasV4 {
 		dev.stack.AddRoute(tcpip.Route{Destination: header.IPv4EmptySubnet, NIC: 1})
+		tcpipErr = dev.stack.SetForwarding(header.IPv4ProtocolNumber, true)
+		if tcpipErr != nil {
+			return nil, nil, fmt.Errorf("SetForwarding(): %v", tcpipErr)
+		}
 	}
 	if dev.hasV6 {
 		dev.stack.AddRoute(tcpip.Route{Destination: header.IPv6EmptySubnet, NIC: 1})
+		tcpipErr = dev.stack.SetForwarding(header.IPv6ProtocolNumber, true)
+		if tcpipErr != nil {
+			return nil, nil, fmt.Errorf("SetForwarding(): %v", tcpipErr)
+		}
 	}
 
 	dev.events <- tun.EventUp

--- a/server/rpc/rpc-wg.go
+++ b/server/rpc/rpc-wg.go
@@ -1,0 +1,36 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/bishopfox/sliver/protobuf/clientpb"
+	"github.com/bishopfox/sliver/protobuf/commonpb"
+	"github.com/bishopfox/sliver/server/certs"
+	"github.com/bishopfox/sliver/server/generate"
+)
+
+func (rpc *Server) GenerateWGClientConfig(ctx context.Context, _ *commonpb.Empty) (*clientpb.WGClientConfig, error) {
+	clientIP, err := generate.GenerateUniqueIP()
+	if err != nil {
+		rpcLog.Errorf("Could not generate WG unique IP: %v", err)
+		return nil, err
+	}
+	privkey, pubkey, err := certs.GenerateWGKeys(true, clientIP.String())
+	if err != nil {
+		rpcLog.Errorf("Could not generate WG keys: %v", err)
+		return nil, err
+	}
+	_, serverPubKey, err := certs.GetWGServerKeys()
+	if err != nil {
+		rpcLog.Errorf("Could not get WG server keys: %v", err)
+		return nil, err
+	}
+	resp := &clientpb.WGClientConfig{
+		ClientPrivateKey: privkey,
+		ClientIP:         clientIP.String(),
+		ClientPubKey:     pubkey,
+		ServerPubKey:     serverPubKey,
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
This PR adds a new client command, `wg-config` and its associated RPC (`GenerateWGClientConfig`).
The RPC generates a new virtual IP address, a new pair of client keys and add the info to the authorized peers in the database.

The command displays a `wg-quick` compatible configuration file that the user can use to configure a wireguard interface on another system, and that way join the same network as the implants.