### PR TITLE
Re-enable codeql scanning on master PRs

### DIFF
--- a/.github/workflows/codeql-scanning.yml
+++ b/.github/workflows/codeql-scanning.yml
@@ -76,4 +76,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
         env:
-          VERSION: 1.4.11
+          VERSION: ${{github.sha}}

--- a/.github/workflows/codeql-scanning.yml
+++ b/.github/workflows/codeql-scanning.yml
@@ -75,3 +75,5 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
+        env:
+          VERSION: 1.4.11

--- a/.github/workflows/codeql-scanning.yml
+++ b/.github/workflows/codeql-scanning.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - test/*
-  # pull_request:
-  #   branches:
-  #     - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   CodeQL-Build:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TAGS = -tags osusergo,netgo,sqlite_omit_load_extension
 # Version Information
 #
 GO_VERSION = $(shell $(GO) version)
-VERSION = $(shell git describe --abbrev=0)
+VERSION? = $(shell git describe --abbrev=0)
 COMPILED_AT = $(shell date +%s)
 RELEASES_URL = https://api.github.com/repos/BishopFox/sliver/releases
 PKG = github.com/bishopfox/sliver/client/version


### PR DESCRIPTION
Re-enable codeql scanning on PR to `master`.


The issue was that the `VERSION=$(shell git describe --abbrev=0)` line in the Makefile  errored out, breaking the build process. I modified the Makefile so we can override `VERSION` with an environment variable during the build process. We don't care whether the binary can be executed, but it need to be successfully compiled for the codeql analysis  to work.