### PR TITLE
Add WG config to implant profiles

### DIFF
--- a/client/command/psexec.go
+++ b/client/command/psexec.go
@@ -69,7 +69,7 @@ func psExec(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 		fmt.Printf(Warn+"no profile found for name %s\n", profile)
 		return
 	}
-	sliverBinary, err := getSliverBinary(*p, rpc)
+	sliverBinary, err := getSliverBinary(p, rpc)
 	filename := randomString(10)
 	filePath := fmt.Sprintf("%s\\%s.exe", uploadPath, filename)
 	uploadGzip := new(encoders.Gzip).Encode(sliverBinary)

--- a/implant/sliver/transports/transports.go
+++ b/implant/sliver/transports/transports.go
@@ -22,6 +22,7 @@ import (
 
 	// {{if or .Config.HTTPc2Enabled .Config.TCPPivotc2Enabled .Config.WGc2Enabled}}
 	"net"
+
 	// {{end}}
 
 	// {{if .Config.Debug}}
@@ -30,8 +31,7 @@ import (
 
 	"crypto/x509"
 	// {{if .Config.WGc2Enabled}}
-	"fmt"
-
+	"errors"
 	// {{end}}
 	"io"
 	"net/url"
@@ -415,7 +415,7 @@ func wgConnect(uri *url.URL) (*Connection, error) {
 		return nil, err
 	}
 	if len(addrs) == 0 {
-		return nil, fmt.Errorf("invalid address")
+		return nil, errors.New("{{if .Config.Debug}}Invalid address{{end}}")
 	}
 	hostname := addrs[0]
 	conn, dev, err := wgSocketConnect(hostname, uint16(lport))

--- a/server/db/models/implant.go
+++ b/server/db/models/implant.go
@@ -140,10 +140,15 @@ func (ic *ImplantConfig) ToProtobuf() *clientpb.ImplantConfig {
 		LimitUsername:     ic.LimitUsername,
 		LimitFileExists:   ic.LimitFileExists,
 
-		IsSharedLib: ic.IsSharedLib,
-		IsService:   ic.IsService,
-		IsShellcode: ic.IsShellcode,
-		Format:      ic.Format,
+		IsSharedLib:       ic.IsSharedLib,
+		IsService:         ic.IsService,
+		IsShellcode:       ic.IsShellcode,
+		Format:            ic.Format,
+		WGImplantPrivKey:  ic.WGImplantPrivKey,
+		WGServerPubKey:    ic.WGServerPubKey,
+		WGPeerTunIP:       ic.WGPeerTunIP,
+		WGKeyExchangePort: ic.WGKeyExchangePort,
+		WGTcpCommsPort:    ic.WGTcpCommsPort,
 
 		FileName: ic.FileName,
 	}


### PR DESCRIPTION
The `generate-profile` and `stage-listener` commands were failing to generate wireguard implants as the WG config was not saved in the implant profile.