### PR TITLE
Added support for path prefixes in HTTP C2

### DIFF
--- a/client/command/generate.go
+++ b/client/command/generate.go
@@ -499,12 +499,15 @@ func parseHTTPc2(args string) []*clientpb.ImplantC2 {
 		if strings.HasPrefix(arg, "http://") || strings.HasPrefix(arg, "https://") {
 			uri, err = url.Parse(arg)
 			if err != nil {
-				log.Printf("Failed to parse c2 URL %v", err)
+				log.Printf("Failed to parse C2 URL %s", err)
 				continue
 			}
 		} else {
-			uri = &url.URL{Scheme: "https"} // HTTPS is the default, will fallback to HTTP
-			uri.Host = arg
+			uri, err = url.Parse(fmt.Sprintf("https://%s", arg))
+			if err != nil {
+				log.Printf("Failed to parse C2 URL %s", err)
+				continue
+			}
 		}
 		c2s = append(c2s, &clientpb.ImplantC2{
 			Priority: uint32(index),

--- a/implant/sliver/transports/transports.go
+++ b/implant/sliver/transports/transports.go
@@ -494,7 +494,7 @@ func httpConnect(uri *url.URL) (*Connection, error) {
 	// {{if .Config.Debug}}
 	log.Printf("Connecting -> http(s)://%s", uri.Host)
 	// {{end}}
-	client, err := HTTPStartSession(uri.Host)
+	client, err := HTTPStartSession(uri.Host, uri.Path)
 	if err != nil {
 		// {{if .Config.Debug}}
 		log.Printf("http(s) connection error %v", err)


### PR DESCRIPTION
* Adds support for HTTP path prefixes in HTTP C2 which can be specified in the `generate` command e.g. `generate --http foobar.com/path/prefix`
