### PR TITLE
Log new pivot connection to audit log

### DIFF
--- a/implant/sliver/sliver.go
+++ b/implant/sliver/sliver.go
@@ -41,6 +41,7 @@ import (
 	// {{if eq .Config.GOOS "windows"}}
 	"github.com/bishopfox/sliver/implant/sliver/priv"
 	"github.com/bishopfox/sliver/implant/sliver/syscalls"
+
 	// {{end}}
 
 	consts "github.com/bishopfox/sliver/implant/sliver/constants"
@@ -158,11 +159,10 @@ func main() {
 }
 
 func mainLoop(connection *transports.Connection) {
-
-	connection.Send <- getRegisterSliver() // Send registration information
-
 	// Reconnect active pivots
 	pivots.ReconnectActivePivots(connection)
+
+	connection.Send <- getRegisterSliver() // Send registration information
 
 	pivotHandlers := handlers.GetPivotHandlers()
 	tunHandlers := handlers.GetTunnelHandlers()

--- a/server/c2/pivot.go
+++ b/server/c2/pivot.go
@@ -19,8 +19,10 @@ package c2
 */
 
 import (
+	"encoding/json"
 	"sync"
 
+	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
 	"github.com/bishopfox/sliver/server/core"
 	serverHandlers "github.com/bishopfox/sliver/server/handlers"
@@ -133,7 +135,25 @@ func HandlePivotOpen(session *core.Session, data []byte) {
 		}
 	}()
 	core.Sessions.Add(sliverPivoted)
+	go auditLogSession(sliverPivoted, register)
 	Pivots.AddSession(pivotOpen.GetPivotID(), sliverPivoted)
+}
+
+type auditLogNewSessionMsg struct {
+	Session  *clientpb.Session
+	Register *sliverpb.Register
+}
+
+func auditLogSession(session *core.Session, register *sliverpb.Register) {
+	msg, err := json.Marshal(auditLogNewSessionMsg{
+		Session:  session.ToProtobuf(),
+		Register: register,
+	})
+	if err != nil {
+		pivotLog.Errorf("Failed to log new session to audit log %s", err)
+	} else {
+		log.AuditLogger.Warn(string(msg))
+	}
 }
 
 // HandlePivotClose - Handles a PivotClose message


### PR DESCRIPTION
New sessions events for pivot connections did not generate a new session event in the audit log. This PR fixes that, so we can track sessions more accurately.
