### PR TITLE
Multiple Fixes

### DIFF
--- a/implant/sliver/handlers/handlers.go
+++ b/implant/sliver/handlers/handlers.go
@@ -28,7 +28,6 @@ import (
 	"io/ioutil"
 	"os/exec"
 	"strings"
-	"time"
 
 	// {{if .Config.Debug}}
 	"log"
@@ -465,7 +464,7 @@ func reconnectIntervalHandler(data []byte, resp RPCResponse) {
 	// {{end}}
 
 	// Set the reconnect interval value
-	transports.SetReconnectInterval(time.Duration(reconnectInterval) * time.Second)
+	transports.SetReconnectInterval(int(reconnectInterval))
 
 	recIntervalResp := &sliverpb.ReconnectInterval{}
 	recIntervalResp.Response = &commonpb.Response{}
@@ -493,7 +492,7 @@ func pollIntervalHandler(data []byte, resp RPCResponse) {
 	// {{end}}
 
 	// Set the reconnect interval value
-	transports.SetPollInterval(time.Duration(pollInterval) * time.Second)
+	transports.SetPollInterval(int(pollInterval))
 
 	pollIntervalResp := &sliverpb.PollInterval{}
 	pollIntervalResp.Response = &commonpb.Response{}

--- a/implant/sliver/transports/transports.go
+++ b/implant/sliver/transports/transports.go
@@ -66,8 +66,8 @@ var (
 
 	readBufSize       = 16 * 1024 // 16kb
 	maxErrors         = getMaxConnectionErrors()
-	reconnectInterval = GetReconnectInterval()
-	pollInterval      = GetPollInterval()
+	reconnectInterval = -1
+	pollInterval      = -1
 
 	ccCounter = new(int)
 
@@ -251,10 +251,11 @@ func StartConnectionLoop() *Connection {
 			// {{end}}
 		}
 
+		reconnect := GetReconnectInterval()
 		// {{if .Config.Debug}}
-		log.Printf("Sleep %d second(s) ...", reconnectInterval/time.Second)
+		log.Printf("Sleep %d second(s) ...", reconnect/time.Second)
 		// {{end}}
-		time.Sleep(reconnectInterval)
+		time.Sleep(reconnect)
 	}
 	// {{if .Config.Debug}}
 	log.Printf("[!] Max connection errors reached\n")
@@ -298,27 +299,35 @@ func nextCCServer() *url.URL {
 
 // GetReconnectInterval - Parse the reconnect interval inserted at compile-time
 func GetReconnectInterval() time.Duration {
-	reconnect, err := strconv.Atoi(`{{.Config.ReconnectInterval}}`)
-	if err != nil {
-		return 60 * time.Second
+	if reconnectInterval == -1 {
+		reconnect, err := strconv.Atoi(`{{.Config.ReconnectInterval}}`)
+		if err != nil {
+			return 60 * time.Second
+		}
+		return time.Duration(reconnect) * time.Second
+	} else {
+		return time.Duration(reconnectInterval) * time.Second
 	}
-	return time.Duration(reconnect) * time.Second
 }
 
-func SetReconnectInterval(interval time.Duration) {
+func SetReconnectInterval(interval int) {
 	reconnectInterval = interval
 }
 
 // GetPollInterval - Parse the poll interval inserted at compile-time
 func GetPollInterval() time.Duration {
-	pollInterval, err := strconv.Atoi(`{{.Config.PollInterval}}`)
-	if err != nil {
-		return 1 * time.Second
+	if pollInterval == -1 {
+		pollInterval, err := strconv.Atoi(`{{.Config.PollInterval}}`)
+		if err != nil {
+			return 1 * time.Second
+		}
+		return time.Duration(pollInterval) * time.Second
+	} else {
+		return time.Duration(pollInterval) * time.Second
 	}
-	return time.Duration(pollInterval) * time.Second
 }
 
-func SetPollInterval(interval time.Duration) {
+func SetPollInterval(interval int) {
 	pollInterval = interval
 }
 

--- a/server/core/sessions.go
+++ b/server/core/sessions.go
@@ -87,7 +87,7 @@ func (s *Session) ToProtobuf() *clientpb.Session {
 		// If it hasn't checked in, flag it as DEAD.
 		var timePassed = uint32(math.Abs(s.LastCheckin.Sub(time.Now()).Seconds()))
 
-		if timePassed > (s.ReconnectInterval + 10) {
+		if timePassed > (s.ReconnectInterval+10) && timePassed > (s.PollInterval+10) {
 			isDead = true
 		} else {
 			isDead = false


### PR DESCRIPTION
1. Recently introduced configurable implant intervals where not persistent in the current run. If a reconnect happens, the original values were sent to the server during initial handshake rather than the updated values.
2. Fixed race condition in DNS UDP server code that was not unlocking the DNS session map and thus breaking everything.
3. Removed code that was removing the DNS UDP session key stored during the initial handshake in the event that a failure happens in the middle of the handshake. This bug was uncovered due to the race condition in 2.
4. Added 1 second sleep between DNS lookup retries.
5. Removed "-" from dnsCharSet on server like was done to fix DNS related issue in the implant in previous pull request.
6. Add line to update the checkin time for the UDP DNS implant on each poll rather that just when a initial handshake is completed.
7. Updated ALIVE/DEAD code to check the maximum of the reconnect interval and poll interval.
