### PR TITLE
Go 1.16.5 & Darwin musl CC 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.4
+FROM golang:1.16.5
 
 #
 # IMPORTANT: This Dockerfile is used for testing, I do not recommend deploying
@@ -6,8 +6,7 @@ FROM golang:1.16.4
 #            a Docker deployment this is probably a good place to start.
 #
 
-ENV PROTOC_VER 3.15.8
-
+ENV PROTOC_VER 3.17.1
 ENV PROTOC_GEN_GO_VER v1.26.0
 ENV GRPC_GO v1.1.0
 

--- a/go-assets.sh
+++ b/go-assets.sh
@@ -19,7 +19,7 @@
 
 # Creates the static go asset archives
 
-GO_VER="1.16.4"
+GO_VER="1.16.5"
 GARBLE_VER="1.16.5"
 
 GO_ARCH_1="amd64"

--- a/server/generate/binaries.go
+++ b/server/generate/binaries.go
@@ -52,7 +52,8 @@ var (
 				"amd64": "/usr/bin/x86_64-w64-mingw32-gcc",
 			},
 			"darwin": {
-				"amd64": "/opt/osxcross/target/bin/o64-clang", // OSX Cross
+				// OSX Cross - https://github.com/tpoechtrager/osxcross
+				"amd64": "/opt/osxcross/target/bin/o64-clang",
 				"arm64": "/opt/osxcross/target/bin/aarch64-apple-darwin20.2-clang",
 			},
 		},
@@ -60,6 +61,10 @@ var (
 			"windows": {
 				"386":   "/usr/bin/i686-w64-mingw32-gcc",
 				"amd64": "/usr/bin/x86_64-w64-mingw32-gcc",
+			},
+			"linux": {
+				// brew install FiloSottile/musl-cross/musl-cross
+				"amd64": "/usr/local/bin/x86_64-linux-musl-gcc",
 			},
 		},
 	}


### PR DESCRIPTION
* Added default path for musl cc on Darwin to cross-compile to Linux
* Go 1.16.5