### PR TITLE
Add hex dump to the cat command

### DIFF
--- a/client/command/commands.go
+++ b/client/command/commands.go
@@ -1134,6 +1134,7 @@ func BindCommands(con *console.SliverConsoleClient) {
 		Flags: func(f *grumble.Flags) {
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
 			f.Bool("c", "colorize-output", false, "colorize output")
+			f.Bool("x", "hex", false, "display as a hex dump")
 			f.Bool("X", "loot", false, "save output as loot")
 		},
 		Args: func(a *grumble.Args) {

--- a/client/command/filesystem/cat.go
+++ b/client/command/filesystem/cat.go
@@ -20,6 +20,7 @@ package filesystem
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"os"
 
@@ -66,7 +67,11 @@ func CatCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 			con.Println(string(download.Data))
 		}
 	} else {
-		con.Println(string(download.Data))
+		if ctx.Flags.Bool("hex") {
+			con.Println(hex.Dump(download.Data))
+		} else {
+			con.Println(string(download.Data))
+		}
 	}
 	// if ctx.Flags.Bool("loot") && 0 < len(download.Data) {
 	// 	err = AddLootFile(rpc, fmt.Sprintf("[cat] %s", filepath.Base(filePath)), filePath, download.Data, false)


### PR DESCRIPTION
Add the `-x` / `--hex` flag to `cat` to display the hex dump of the downloaded file.
