### PR TITLE
Extensions

### DIFF
--- a/client/assets/assets.go
+++ b/client/assets/assets.go
@@ -109,7 +109,7 @@ func setupCoffLoaderExt(appDir string) error {
 	win64ExtDir := path.Join("windows", "amd64")
 	coffLoader32 := path.Join("fs", SliverExtensionsDirName, win32ExtDir, "COFFLoader.x86.dll")
 	coffLoader64 := path.Join("fs", SliverExtensionsDirName, win64ExtDir, "COFFLoader.x64.dll")
-	manfiestPath := path.Join("fs", SliverExtensionsDirName, "manifest.json")
+	manifestPath := path.Join("fs", SliverExtensionsDirName, "manifest.json")
 	loader64, err := assetsFs.ReadFile(coffLoader64)
 	if err != nil {
 		return err
@@ -118,7 +118,7 @@ func setupCoffLoaderExt(appDir string) error {
 	if err != nil {
 		return err
 	}
-	manifest, err := assetsFs.ReadFile(manfiestPath)
+	manifest, err := assetsFs.ReadFile(manifestPath)
 	if err != nil {
 		return err
 	}

--- a/client/cli/cli.go
+++ b/client/cli/cli.go
@@ -80,10 +80,9 @@ var rootCmd = &cobra.Command{
 
 // StartClientConsole - Start the client console
 func StartClientConsole() error {
-	assets.Setup(false, true)
 	configs := assets.GetConfigs()
 	if len(configs) == 0 {
-		fmt.Printf("No config files found at %s or -import\n", assets.GetConfigDir())
+		fmt.Printf("No config files found at %s (see --help)\n", assets.GetConfigDir())
 		return nil
 	}
 	config := selectConfig()
@@ -94,7 +93,7 @@ func StartClientConsole() error {
 	fmt.Printf("Connecting to %s:%d ...\n", config.LHost, config.LPort)
 	rpc, ln, err := transport.MTLSConnect(config)
 	if err != nil {
-		fmt.Printf("Connection to server failed %v", err)
+		fmt.Printf("Connection to server failed %s", err)
 		return nil
 	}
 	defer ln.Close()

--- a/client/console/console.go
+++ b/client/console/console.go
@@ -95,6 +95,8 @@ type BindCmds func(console *SliverConsoleClient)
 // Start - Console entrypoint
 func Start(rpc rpcpb.SliverRPCClient, bindCmds BindCmds, extraCmds BindCmds, isServer bool) error {
 
+	assets.Setup(false, false)
+
 	con := &SliverConsoleClient{
 		App: grumble.New(&grumble.Config{
 			Name:                  "Sliver",

--- a/implant/sliver/extension/extension_windows.go
+++ b/implant/sliver/extension/extension_windows.go
@@ -19,12 +19,13 @@ const (
 )
 
 type WindowsExtension struct {
-	id       string
-	data     []byte
-	module   *memmod.Module
-	arch     string
-	init     string
-	onFinish func([]byte)
+	id          string
+	data        []byte
+	module      *memmod.Module
+	arch        string
+	init        string
+	onFinish    func([]byte)
+	serverStore bool
 }
 
 func NewWindowsExtension(data []byte, id string, arch string, init string) *WindowsExtension {
@@ -105,7 +106,7 @@ func (w *WindowsExtension) extensionCallback(data uintptr, dataLen uintptr) uint
 		b := (*byte)(unsafe.Pointer(uintptr(i) + data))
 		outBuff.WriteByte(*b)
 	}
-	//TODO: do somethig with outBuff
+	//TODO: do something with outBuff
 	if outBuff.Len() > 0 {
 		w.onFinish(outBuff.Bytes())
 	}

--- a/protobuf/sliverpb/sliver.proto
+++ b/protobuf/sliverpb/sliver.proto
@@ -850,6 +850,7 @@ message CallExtensionReq {
   string Name = 1;
   string Export = 2;
   bytes Args = 3;
+  bool ServerStore = 2;
 
   commonpb.Request Request = 9;
 }


### PR DESCRIPTION
Moved asset setup to client/console so that extension setup occurs with both the `sliver-server` client and `sliver-client` client