### PR TITLE
Replace map with sync.Map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.vscode/*
 /.devcontainer
+/.idea
 
 /Dockerfile.*
 /*.sdk.tar.xz

--- a/server/c2/tcp-http.go
+++ b/server/c2/tcp-http.go
@@ -68,7 +68,7 @@ type HTTPSession struct {
 	Session *core.Session
 	Key     cryptography.AESKey
 	Started time.Time
-	replay  map[string]bool // Sessions are mutex'd
+	replay  sync.Map // Sessions are mutex'd
 }
 
 // Keeps a hash of each msg in a session to detect replay'd messages
@@ -79,10 +79,10 @@ func (s *HTTPSession) isReplayAttack(ciphertext []byte) bool {
 	sha := sha256.New()
 	sha.Write(ciphertext)
 	digest := base64.RawStdEncoding.EncodeToString(sha.Sum(nil))
-	if _, ok := s.replay[digest]; ok {
+	if _,ok:=s.replay.Load(digest);ok {
 		return true
 	}
-	s.replay[digest] = true
+	s.replay.Store(digest,true)
 	return false
 }
 
@@ -572,7 +572,7 @@ func newHTTPSession() *HTTPSession {
 	return &HTTPSession{
 		ID:      newHTTPSessionID(),
 		Started: time.Now(),
-		replay:  map[string]bool{},
+		replay:  sync.Map{},
 	}
 }
 

--- a/server/c2/udp-dns.go
+++ b/server/c2/udp-dns.go
@@ -102,7 +102,7 @@ type DNSSession struct {
 	ID      string
 	Session *core.Session
 	Key     cryptography.AESKey
-	replay  map[string]bool // Sessions are mutex 'd
+	replay  sync.Map // Sessions are mutex 'd
 }
 
 func (s *DNSSession) isReplayAttack(ciphertext []byte) bool {
@@ -112,10 +112,10 @@ func (s *DNSSession) isReplayAttack(ciphertext []byte) bool {
 	sha := sha256.New()
 	sha.Write(ciphertext)
 	digest := base64.RawStdEncoding.EncodeToString(sha.Sum(nil))
-	if _, ok := s.replay[digest]; ok {
+	if _,ok:=s.replay.Load(digest);ok {
 		return true
 	}
-	s.replay[digest] = true
+	s.replay.Store(digest,true)
 	return false
 }
 
@@ -456,7 +456,7 @@ func startDNSSession(domain string, fields []string) ([]string, error) {
 		ID:      sessionID,
 		Session: session,
 		Key:     aesKey,
-		replay:  map[string]bool{},
+		replay:  sync.Map{},
 	}
 	dnsSessionsMutex.Unlock()
 


### PR DESCRIPTION
#### Details
I completed the reverse Socks5 code. In use, I found that too fast when C2 receives data may lead to map read-write load.

After I have no problem using it, I will upload the relevant code of Socks5 in a month. PS: at present, 4K is very stable.