### PR TITLE
A small fix for ls

### DIFF
--- a/client/command/filesystem/ls.go
+++ b/client/command/filesystem/ls.go
@@ -70,7 +70,7 @@ func LsCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 			// Then we need to test for a filter on the end of the string
 
 			// The indicies should be the same because we did not change the length of the string
-			baseDir := remotePath[:lastSeparatorOccurence]
+			baseDir := remotePath[:lastSeparatorOccurence+1]
 			potentialFilter := remotePath[lastSeparatorOccurence+1:]
 
 			_, err := filepath.Match(potentialFilter, "")


### PR DESCRIPTION
This is a small fix for `ls`. Previously, if you tried to ls the root of the drive (/ or C:\ for example), it would list the current working directory.  This is because the `ls` function on the client did not calculate the boundary between the path and the filter correctly.  On *nix, it calculated the path as blank and the filter as blank.  On Windows, it calculated the path as "C:" and the filter as blank.

This PR fixes that.

*nix:
```
[server] sliver (GIGANTIC_ALMANAC) > ls /

/
=
-rw-r--r--   .autorelabel  0 B    Wed Jul 21 14:41:49 +0000 2021
Lrwxrwxrwx   bin           7 B    Tue Jan 26 02:05:10 +0000 2021
dr-xr-xr-x   boot          <dir>  Fri Aug 06 08:17:15 +0000 2021
drwxr-xr-x   dev           <dir>  Fri Sep 03 08:15:51 +0000 2021
drwxr-xr-x   etc           <dir>  Thu Sep 02 12:36:51 +0000 2021
...
```
Windows:
```
[server] sliver (PROGRESSIVE_DILL) > ls "C:\\"

C:\
===
drwxrwxrwx  $Recycle.Bin               <dir>      Thu Aug 12 12:49:52 +0000 2021
drwxrwxrwx  $WinREAgent                <dir>      Wed Aug 11 12:37:06 +0000 2021
Lrw-rw-rw-  Documents and Settings     0 B        Sat Aug 07 01:53:40 +0000 2021
-rw-rw-rw-  DumpStack.log.tmp          8.0 KiB    Fri Aug 27 15:52:58 +0000 2021
-rw-rw-rw-  pagefile.sys               704.0 MiB  Fri Aug 27 15:52:58 +0000 2021
...
```