### PR TITLE
Fixed bug in ls command and added timestamp to SessionClosed

### DIFF
--- a/client/command/filesystem/ls.go
+++ b/client/command/filesystem/ls.go
@@ -81,6 +81,10 @@ func LsCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 				// Then we have a filter on the end of the path
 				remotePath = baseDir
 				filter = potentialFilter
+			} else {
+				if !strings.HasSuffix(remotePath, "/") {
+					remotePath = remotePath + "/"
+				}
 			}
 		}
 	}

--- a/client/console/console.go
+++ b/client/console/console.go
@@ -208,8 +208,9 @@ func (con *SliverConsoleClient) EventLoop() {
 
 		case consts.SessionClosedEvent:
 			session := event.Session
-			con.PrintEventErrorf("Lost session #%d %s - %s (%s) - %s/%s",
-				session.ID, session.Name, session.RemoteAddress, session.Hostname, session.OS, session.Arch)
+			currentTime := time.Now().Format(time.RFC1123)
+			con.PrintEventErrorf("Lost session #%d %s - %s (%s) - %s/%s - %v",
+				session.ID, session.Name, session.RemoteAddress, session.Hostname, session.OS, session.Arch, currentTime)
 			activeSession := con.ActiveTarget.GetSession()
 			if activeSession != nil && activeSession.ID == session.ID {
 				con.ActiveTarget.Set(nil, nil)


### PR DESCRIPTION
#### Card

1. Added timestamp to SessionClosed
2. Fixed ls command


#### Details
1. Commit de3f2c8: For consistency I added the timestamp to the SessionClosed even. I found it useful to know when an implant died
![Screen Shot 2022-01-05 at 5 19 31 PM](https://user-images.githubusercontent.com/45320229/148312772-9aafd8fb-c8ab-4db9-855c-69c3cd0a7c61.png)

2. Commit dfb6d2e:  Fixed the `ls` command not returning the content when the path doesn't have a trailing `\`. Tested on a Windows and Linux machine. 

![Screen Shot 2022-01-05 at 5 25 56 PM](https://user-images.githubusercontent.com/45320229/148313255-607b57fb-1ba8-47ed-a487-8b11bb6c09e6.png)




