### PR TITLE
Implement fix for issue #584

### DIFF
--- a/server/c2/http.go
+++ b/server/c2/http.go
@@ -404,7 +404,13 @@ func (s *SliverHTTPC2) DefaultRespHeaders(next http.Handler) http.Handler {
 		if s.c2Config.ServerConfig.RandomVersionHeaders {
 			resp.Header().Set("Server", s.getServerHeader())
 		}
-		for _, header := range s.c2Config.ServerConfig.ExtraHeaders {
+		for _, header := range s.c2Config.ServerConfig.Headers {
+			if 0 < header.Probability && header.Probability < 100 {
+				roll := insecureRand.Intn(99) + 1
+				if header.Probability < roll {
+					continue
+				}
+			}
 			resp.Header().Set(header.Name, header.Value)
 		}
 		next.ServeHTTP(resp, req)

--- a/server/configs/database.go
+++ b/server/configs/database.go
@@ -44,7 +44,7 @@ const (
 
 var (
 	// ErrInvalidDialect - An invalid dialect was specified
-	ErrInvalidDialect = errors.New("Invalid SQL Dialect")
+	ErrInvalidDialect = errors.New("invalid SQL Dialect")
 
 	databaseConfigLog = log.NamedLogger("config", "database")
 )

--- a/server/configs/http-c2_test.go
+++ b/server/configs/http-c2_test.go
@@ -51,7 +51,7 @@ func TestDefaultConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = CheckHTTPC2Config(config)
+	err = checkHTTPC2Config(config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func TestPollConfig(t *testing.T) {
 	origPollFileExt := config.ImplantConfig.PollFileExt
 	for _, ext := range []string{"", ".", "..."} {
 		config.ImplantConfig.PollFileExt = ext
-		err := CheckHTTPC2Config(&config)
+		err := checkHTTPC2Config(&config)
 		if err != ErrMissingPollFileExt {
 			t.Fatalf("Parsed '%s' as not missing (%s)", ext, config.ImplantConfig.PollFileExt)
 		}
@@ -82,7 +82,7 @@ func TestPollConfig(t *testing.T) {
 	origPollFiles := config.ImplantConfig.PollFiles
 	for _, empty := range emptyPollFiles {
 		config.ImplantConfig.PollFiles = empty
-		err := CheckHTTPC2Config(&config)
+		err := checkHTTPC2Config(&config)
 		if err != ErrTooFewPollFiles {
 			t.Fatalf("Expected too few poll files from %v got %v", empty, err)
 		}

--- a/server/console/console.go
+++ b/server/console/console.go
@@ -31,6 +31,7 @@ import (
 	consts "github.com/bishopfox/sliver/client/constants"
 	clienttransport "github.com/bishopfox/sliver/client/transport"
 	"github.com/bishopfox/sliver/protobuf/rpcpb"
+	"github.com/bishopfox/sliver/server/configs"
 	"github.com/bishopfox/sliver/server/transport"
 	"google.golang.org/grpc"
 )
@@ -49,11 +50,14 @@ func Start() {
 	}
 	conn, err := grpc.DialContext(context.Background(), "bufnet", options...)
 	if err != nil {
-		fmt.Printf(Warn+"Failed to dial bufnet: %s", err)
+		fmt.Printf(Warn+"Failed to dial bufnet: %s\n", err)
 		return
 	}
 	defer conn.Close()
 	localRPC := rpcpb.NewSliverRPCClient(conn)
+	if err := configs.CheckHTTPC2ConfigErrors(); err != nil {
+		fmt.Printf(Warn+"Error in HTTP C2 config: %s\n", err)
+	}
 	clientconsole.Start(localRPC, command.BindCommands, serverOnlyCmds, true)
 }
 


### PR DESCRIPTION
Implement extra headers and url parameters in http c2. I also added a `Probability` to these options, which can be used to specify the probability the value should be included in any given http request. The server will also report errors in the config at startup. 
