### PR TITLE
fix: upload raise error if file isn't accessible

### DIFF
--- a/client/command/filesystem/upload.go
+++ b/client/command/filesystem/upload.go
@@ -64,6 +64,10 @@ func UploadCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 	dst := remotePath
 
 	fileBuf, err := ioutil.ReadFile(src)
+	if err != nil {
+		con.PrintErrorf("%s\n", err)
+		return
+	}
 	uploadGzip := new(encoders.Gzip).Encode(fileBuf)
 
 	ctrl := make(chan bool)


### PR DESCRIPTION
#### Card
fix: upload raises an error if the file that is going to be transferred into the remote host  is not accessible

#### Details
When the user tries to upload a file using the `upload` command,  if the file is not accessible (e.g. sliver is running with a low privileged account and the file was created by root), a file of 0 bytes is created in the remote server without raising any error.