### PR TITLE
Prelude Operator: Small fixes and a new feature

### DIFF
--- a/client/prelude/bof.go
+++ b/client/prelude/bof.go
@@ -113,7 +113,7 @@ func registerLoader(session *clientpb.Session, rpc rpcpb.SliverRPCClient) error 
 	case "386":
 		coffLoaderPath = "COFFLoader.x86.dll"
 	}
-	loaderPath := path.Join(assets.GetExtensionsDir(), "windows", session.Arch, coffLoaderPath)
+	loaderPath := path.Join(assets.GetExtensionsDir(), coffLoaderName, coffLoaderPath)
 	loaderData, err := ioutil.ReadFile(loaderPath)
 	if err != nil {
 		return err

--- a/client/prelude/commands.go
+++ b/client/prelude/commands.go
@@ -85,6 +85,10 @@ func execute(cmd string, executor string, agentSession *AgentSession) (string, i
 	args := append(getCmdArg(executor), cmd)
 	if executor == "psh" {
 		executor = "powershell.exe"
+	} else if executor == "exec" {
+		commandSections := strings.Fields(cmd)
+		executor = commandSections[0]
+		args = commandSections[1:]
 	}
 	execResp, err := agentSession.RPC.Execute(context.Background(), &sliverpb.ExecuteReq{
 		Path:    executor,
@@ -110,6 +114,8 @@ func getCmdArg(executor string) []string {
 		args = []string{"/S", "/C"}
 	case "powershell", "psh":
 		args = []string{"-execu", "-C"}
+	case "exec":
+		args = []string{}
 	case "sh", "bash", "zsh":
 		args = []string{"-c"}
 	}

--- a/client/prelude/commands.go
+++ b/client/prelude/commands.go
@@ -67,6 +67,10 @@ func execute(cmd string, executor string, agentSession *AgentSession) (string, i
 	args := append(getCmdArg(executor), cmd)
 	if executor == "psh" {
 		executor = "powershell.exe"
+	} else if executor == "exec" {
+		commandSections := strings.Fields(cmd)
+		executor = commandSections[0]
+		args = commandSections[1:]
 	}
 	execResp, err := agentSession.RPC.Execute(context.Background(), &sliverpb.ExecuteReq{
 		Path:    executor,
@@ -89,9 +93,11 @@ func getCmdArg(executor string) []string {
 	var args []string
 	switch executor {
 	case "cmd":
-		args = []string{"/C", "/S"}
+		args = []string{"/S", "/C"}
 	case "powershell", "psh":
-		args = []string{"-execu", "ByPasS", "-C"}
+		args = []string{"-execu", "-C"}
+	case "exec":
+		args = []string{}
 	case "sh", "bash", "zsh":
 		args = []string{"-c"}
 	}

--- a/client/prelude/commands.go
+++ b/client/prelude/commands.go
@@ -65,12 +65,8 @@ func RunCommand(message string, executor string, payload []byte, agentSession *A
 
 func execute(cmd string, executor string, agentSession *AgentSession) (string, int, int) {
 	args := append(getCmdArg(executor), cmd)
-	if executor == "psh" || executor == "pwsh" {
+	if executor == "psh" {
 		executor = "powershell.exe"
-	} else if executor == "exec" {
-		commandSections := strings.Fields(cmd)
-		executor = commandSections[0]
-		args = commandSections[1:]
 	}
 	execResp, err := agentSession.RPC.Execute(context.Background(), &sliverpb.ExecuteReq{
 		Path:    executor,
@@ -96,8 +92,6 @@ func getCmdArg(executor string) []string {
 		args = []string{"/S", "/C"}
 	case "powershell", "psh":
 		args = []string{"-execu", "-C"}
-	case "exec":
-		args = []string{}
 	case "sh", "bash", "zsh":
 		args = []string{"-c"}
 	}

--- a/client/prelude/commands.go
+++ b/client/prelude/commands.go
@@ -65,7 +65,7 @@ func RunCommand(message string, executor string, payload []byte, agentSession *A
 
 func execute(cmd string, executor string, agentSession *AgentSession) (string, int, int) {
 	args := append(getCmdArg(executor), cmd)
-	if executor == "psh" {
+	if executor == "psh" || executor == "pwsh" {
 		executor = "powershell.exe"
 	} else if executor == "exec" {
 		commandSections := strings.Fields(cmd)

--- a/client/prelude/commands.go
+++ b/client/prelude/commands.go
@@ -51,6 +51,24 @@ func RunCommand(message string, executor string, payload []byte, agentSession *A
 				return err.Error(), ErrorExitStatus, ErrorExitStatus
 			}
 			return out, 0, 0
+		case "execute-assembly":
+			if len(task) < 2 {
+				break
+			}
+			var eaargs execasmArgs
+			argStr := strings.ReplaceAll(task[1], `\`, `\\`)
+			err := json.Unmarshal([]byte(argStr), &eaargs)
+			if err != nil {
+				return err.Error(), ErrorExitStatus, ErrorExitStatus
+			}
+			if payload == nil {
+				return "missing .NET assembly", ErrorExitStatus, ErrorExitStatus
+			}
+			out, err := execAsm(agentSession.Session, agentSession.RPC, payload, eaargs)
+			if err != nil {
+				return err.Error(), ErrorExitStatus, ErrorExitStatus
+			}
+			return out, 0, 0
 		case "exit":
 			return shutdown(agentSession)
 		default:

--- a/client/prelude/execute-assembly.go
+++ b/client/prelude/execute-assembly.go
@@ -9,10 +9,6 @@ import (
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
 )
 
-const (
-	execAsmName = "execute-assembly"
-)
-
 type execasmArgs struct {
 	IsDLL        bool   `json:"isDLL"`
 	Process      string `json:"process"`

--- a/client/prelude/execute-assembly.go
+++ b/client/prelude/execute-assembly.go
@@ -1,0 +1,56 @@
+package prelude
+
+import (
+	"context"
+	"errors"
+
+	"github.com/bishopfox/sliver/protobuf/clientpb"
+	"github.com/bishopfox/sliver/protobuf/rpcpb"
+	"github.com/bishopfox/sliver/protobuf/sliverpb"
+)
+
+const (
+	execAsmName = "execute-assembly"
+)
+
+type execasmArgs struct {
+	IsDLL        bool   `json:"isDLL"`
+	Process      string `json:"process"`
+	Arguments    string `json:"arguments"`
+	Architecture string `json:"architecture"`
+	Method       string `json:"method"`
+	Class        string `json:"class"`
+	AppDomain    string `json:"appDomain"`
+}
+
+func execAsm(session *clientpb.Session, rpc rpcpb.SliverRPCClient, asm []byte, args execasmArgs) (output string, err error) {
+	if !isLoaderLoaded(session, rpc) {
+		err = registerLoader(session, rpc)
+		if err != nil {
+			return
+		}
+	}
+
+	extResp, err := rpc.ExecuteAssembly(context.Background(), &sliverpb.ExecuteAssemblyReq{
+		Request:   MakeRequest(session),
+		IsDLL:     args.IsDLL,
+		Process:   args.Process,
+		Arguments: args.Arguments,
+		Assembly:  asm,
+		Arch:      args.Architecture,
+		Method:    args.Method,
+		ClassName: args.Class,
+		AppDomain: args.AppDomain,
+	})
+
+	if err != nil {
+		return
+	}
+
+	if extResp.Response != nil && extResp.Response.Err != "" {
+		err = errors.New(extResp.Response.Err)
+	}
+	output = string(extResp.Output)
+
+	return
+}

--- a/client/prelude/util/executors.go
+++ b/client/prelude/util/executors.go
@@ -21,8 +21,8 @@ package util
 func DetermineExecutors(platform string, arch string) []string {
 	platformExecutors := map[string]map[string][]string{
 		"windows": {
-			"file":     {"pwsh.exe", "powershell.exe", "cmd.exe"},
-			"executor": {"pwsh", "psh", "cmd", "bof"},
+			"file":     {"pwsh.exe", "powershell.exe", "cmd.exe", "", ""},
+			"executor": {"pwsh", "psh", "cmd", "bof", "exec"},
 		},
 		"linux": {
 			"file":     {"python3", "pwsh", "sh", "bash"},


### PR DESCRIPTION
### Bug Fixes
The current main branch has functional PowerShell execution, but cmd and BOF did not work out of the box. I've incorporated changes from the "v1.5.0_prelude_bugfix" which fixed the cmd execution. The coff-loader DLL path needed to be modified for the BOF keyword to function.

### New Feature
In addition to these fixes, I've added a new keyword: `execute-assembly` which is very similar to the existing BOF keyword. This should not affect any existing functionality. The usage can be seen in this screenshot:
![image](https://user-images.githubusercontent.com/9327972/153183042-f107544b-f699-48ad-ac70-ecb5d0344e8d.png)
