### PR TITLE
Fix/kill

### DIFF
--- a/client/command/processes/terminate.go
+++ b/client/command/processes/terminate.go
@@ -41,6 +41,10 @@ func TerminateCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		Pid:     int32(pid),
 		Force:   ctx.Flags.Bool("force"),
 	})
+	if err != nil {
+		con.PrintErrorf("Terminate failed: %s", err)
+		return
+	}
 
 	if terminated.Response != nil && terminated.Response.Async {
 		con.AddBeaconCallback(terminated.Response.TaskID, func(task *clientpb.BeaconTask) {

--- a/implant/sliver/handlers/special-handlers.go
+++ b/implant/sliver/handlers/special-handlers.go
@@ -22,6 +22,7 @@ package handlers
 
 import (
 	"os"
+	"time"
 
 	"github.com/bishopfox/sliver/implant/sliver/transports"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
@@ -54,6 +55,9 @@ func killHandler(data []byte, _ *transports.Connection) error {
 	// {{if .Config.Debug}}
 	log.Println("Let's exit!")
 	// {{end}}
-	os.Exit(0)
+	go func() {
+		time.Sleep(time.Second)
+		os.Exit(0)
+	}()
 	return nil
 }

--- a/implant/sliver/sliver.c
+++ b/implant/sliver/sliver.c
@@ -1,6 +1,7 @@
 #include "sliver.h"
 
 #ifdef __WIN32
+#include <windows.h>
 
 DWORD WINAPI Start()
 {
@@ -19,10 +20,8 @@ BOOL WINAPI DllMain(
         // Initialize once for each new process.
         // Return FALSE to fail DLL load.
     {
-        // {{if .Config.IsSharedLib}}
         HANDLE hThread = CreateThread(NULL, 0, Start, NULL, 0, NULL);
         // CreateThread() because otherwise DllMain() is highly likely to deadlock.
-        // {{end}}
     }
     break;
     case DLL_PROCESS_DETACH:

--- a/server/core/sessions.go
+++ b/server/core/sessions.go
@@ -209,7 +209,7 @@ func (s *sessions) Remove(sessionID string) {
 	for _, child := range children {
 		childSession, ok := s.sessions.LoadAndDelete(child.SessionID)
 		if ok {
-			PivotSessions.Delete(childSession.(*Session).Connection.ID)
+			// PivotSessions.Delete(childSession.(*Session).Connection.ID)
 			EventBroker.Publish(Event{
 				EventType: consts.SessionClosedEvent,
 				Session:   childSession.(*Session),

--- a/server/core/sessions.go
+++ b/server/core/sessions.go
@@ -209,7 +209,7 @@ func (s *sessions) Remove(sessionID string) {
 	for _, child := range children {
 		childSession, ok := s.sessions.LoadAndDelete(child.SessionID)
 		if ok {
-			// PivotSessions.Delete(childSession.(*Session).Connection.ID)
+			PivotSessions.Delete(childSession.(*Session).Connection.ID)
 			EventBroker.Publish(Event{
 				EventType: consts.SessionClosedEvent,
 				Session:   childSession.(*Session),

--- a/server/generate/binaries.go
+++ b/server/generate/binaries.go
@@ -64,12 +64,12 @@ var (
 		},
 		"darwin": {
 			"windows": {
-				"386":   "/usr/local/bin/i686-w64-mingw32-gcc",
-				"amd64": "/usr/local/bin/x86_64-w64-mingw32-gcc",
+				"386":   "/opt/homebrew/bin/i686-w64-mingw32-gcc",
+				"amd64": "/opt/homebrew/bin/x86_64-w64-mingw32-gcc",
 			},
 			"linux": {
 				// brew install FiloSottile/musl-cross/musl-cross
-				"amd64": "/usr/local/bin/x86_64-linux-musl-gcc",
+				"amd64": "/opt/homebrew/bin/x86_64-linux-musl-gcc",
 			},
 		},
 	}

--- a/server/generate/canaries.go
+++ b/server/generate/canaries.go
@@ -75,9 +75,7 @@ func (g *CanaryGenerator) GenerateCanary() string {
 	index := insecureRand.Intn(len(g.ParentDomains))
 
 	parentDomain := g.ParentDomains[index]
-	if strings.HasPrefix(parentDomain, ".") {
-		parentDomain = parentDomain[1:]
-	}
+	parentDomain = strings.TrimPrefix(parentDomain, ".")
 	if !strings.HasSuffix(parentDomain, ".") {
 		parentDomain += "." // Ensure we have the FQDN
 	}

--- a/server/handlers/sessions.go
+++ b/server/handlers/sessions.go
@@ -102,6 +102,10 @@ func auditLogSession(session *core.Session, register *sliverpb.Register) {
 // two handlers calls may race when a tunnel is quickly created and closed.
 func tunnelDataHandler(implantConn *core.ImplantConnection, data []byte) *sliverpb.Envelope {
 	session := core.Sessions.FromImplantConnection(implantConn)
+	if session == nil {
+		sessionHandlerLog.Warnf("Received tunnel data from unknown session: %v", implantConn)
+		return nil
+	}
 	tunnelHandlerMutex.Lock()
 	defer tunnelHandlerMutex.Unlock()
 	tunnelData := &sliverpb.TunnelData{}
@@ -121,6 +125,10 @@ func tunnelDataHandler(implantConn *core.ImplantConnection, data []byte) *sliver
 
 func tunnelCloseHandler(implantConn *core.ImplantConnection, data []byte) *sliverpb.Envelope {
 	session := core.Sessions.FromImplantConnection(implantConn)
+	if session == nil {
+		sessionHandlerLog.Warnf("Received tunnel close from unknown session: %v", implantConn)
+		return nil
+	}
 	tunnelHandlerMutex.Lock()
 	defer tunnelHandlerMutex.Unlock()
 
@@ -145,12 +153,20 @@ func tunnelCloseHandler(implantConn *core.ImplantConnection, data []byte) *slive
 
 func pingHandler(implantConn *core.ImplantConnection, data []byte) *sliverpb.Envelope {
 	session := core.Sessions.FromImplantConnection(implantConn)
+	if session == nil {
+		sessionHandlerLog.Warnf("Received ping from unknown session: %v", implantConn)
+		return nil
+	}
 	sessionHandlerLog.Debugf("ping from session %s", session.ID)
 	return nil
 }
 
 func socksDataHandler(implantConn *core.ImplantConnection, data []byte) *sliverpb.Envelope {
 	session := core.Sessions.FromImplantConnection(implantConn)
+	if session == nil {
+		sessionHandlerLog.Warnf("Received socks data from unknown session: %v", implantConn)
+		return nil
+	}
 	tunnelHandlerMutex.Lock()
 	defer tunnelHandlerMutex.Unlock()
 	socksData := &sliverpb.SocksData{}

--- a/server/rpc/rpc-kill.go
+++ b/server/rpc/rpc-kill.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// Kill - Kill the implant proccess
 func (rpc *Server) Kill(ctx context.Context, kill *sliverpb.KillReq) (*commonpb.Empty, error) {
 	var (
 		beacon *models.Beacon
@@ -49,7 +50,6 @@ func (rpc *Server) Kill(ctx context.Context, kill *sliverpb.KillReq) (*commonpb.
 }
 
 func (rpc *Server) killSession(kill *sliverpb.KillReq, session *core.Session) (*commonpb.Empty, error) {
-	core.Sessions.Remove(session.ID)
 	data, err := proto.Marshal(kill)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* Fix crash when `terminate` is used against the current pid
* Fix session state mgmt when using `kill`
* Updated default mingw-w64 paths on Darwin