### PR TITLE
Refactoring of client side crypto code

### DIFF
--- a/client/command/jobs/stage.go
+++ b/client/command/jobs/stage.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/bishopfox/sliver/client/command/generate"
 	"github.com/bishopfox/sliver/client/console"
-	"github.com/bishopfox/sliver/client/prelude/util"
 	"github.com/bishopfox/sliver/protobuf/clientpb"
+	"github.com/bishopfox/sliver/util"
 	"github.com/desertbit/grumble"
 )
 
@@ -89,7 +89,7 @@ func StageListenerCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 	}
 
 	if aesEncrypt {
-		stage2 = util.EncryptStage(stage2, aesEncryptKey, aesEncryptIv)
+		stage2 = util.Encrypt(stage2, []byte(aesEncryptKey), []byte(aesEncryptIv))
 	}
 
 	switch stagingURL.Scheme {

--- a/client/prelude/prelude.go
+++ b/client/prelude/prelude.go
@@ -124,7 +124,6 @@ func (p *OperatorImplantMapper) AddImplant(a ActiveImplant, callback func(string
 		Executing: make(map[string]Instruction),
 		Sleep:     int(sleepTime),
 	}
-	util.EncryptionKey = &agentConfig.AESKey
 	bridge := NewImplantBridge(&conn, a, p.conf.RPC, beacon, agentConfig, callback)
 	p.Lock()
 	p.implantBridges = append(p.implantBridges, bridge)

--- a/util/cryptography.go
+++ b/util/cryptography.go
@@ -34,6 +34,7 @@ func Encrypt(data []byte, key []byte, iv []byte) []byte {
 	}
 	block, _ := aes.NewCipher(key)
 	cipherText := make([]byte, aes.BlockSize+len(plainText))
+	// Create a random IV if none was provided
 	// len(nil) returns 0
 	if len(iv) == 0 {
 		iv = cipherText[:aes.BlockSize]

--- a/util/cryptography.go
+++ b/util/cryptography.go
@@ -22,61 +22,42 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"encoding/hex"
 	"errors"
-	"fmt"
 	"io"
 )
 
-var EncryptionKey *string
-
 //Encrypt the results
-func Encrypt(bites []byte) []byte {
-	plainText, err := pad(bites, aes.BlockSize)
+func Encrypt(data []byte, key []byte, iv []byte) []byte {
+	plainText, err := pad(data, aes.BlockSize)
 	if err != nil {
 		return make([]byte, 0)
 	}
-	block, _ := aes.NewCipher([]byte(*EncryptionKey))
+	block, _ := aes.NewCipher(key)
 	cipherText := make([]byte, aes.BlockSize+len(plainText))
-	iv := cipherText[:aes.BlockSize]
-	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
-		return make([]byte, 0)
+	// len(nil) returns 0
+	if len(iv) == 0 {
+		iv = cipherText[:aes.BlockSize]
+		if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+			return make([]byte, 0)
+		}
 	}
 	mode := cipher.NewCBCEncrypter(block, iv)
 	mode.CryptBlocks(cipherText[aes.BlockSize:], plainText)
-	return []byte(fmt.Sprintf("%x", cipherText))
-}
-
-func EncryptStage(bites []byte, AESKey string, AESIV string) []byte {
-	bites, err := pad(bites, aes.BlockSize)
-	if err != nil {
-		return make([]byte, 0)
-	}
-
-	aesKeyBytes := []byte(AESKey)
-	aesIVBytes := []byte(AESIV)
-
-	block, _ := aes.NewCipher(aesKeyBytes)
-	cipherText := make([]byte, aes.BlockSize+len(bites))
-	mode := cipher.NewCBCEncrypter(block, aesIVBytes)
-	mode.CryptBlocks(cipherText, bites)
-
 	return cipherText
 }
 
 //Decrypt a command
-func Decrypt(text string) string {
-	cipherText, _ := hex.DecodeString(text)
-	block, err := aes.NewCipher([]byte(*EncryptionKey))
+func Decrypt(data []byte, key []byte) []byte {
+	block, err := aes.NewCipher(key)
 	if err != nil {
-		return ""
+		return nil
 	}
-	iv := cipherText[:aes.BlockSize]
-	cipherText = cipherText[aes.BlockSize:]
+	iv := data[:aes.BlockSize]
+	data = data[aes.BlockSize:]
 	mode := cipher.NewCBCDecrypter(block, iv)
-	mode.CryptBlocks(cipherText, cipherText)
-	cipherText, _ = unpad(cipherText, aes.BlockSize)
-	return string(cipherText)
+	mode.CryptBlocks(data, data)
+	data, _ = unpad(data, aes.BlockSize)
+	return data
 }
 
 func pad(buf []byte, size int) ([]byte, error) {


### PR DESCRIPTION
This PR removes the `client/prelude/util/crypto.go` code and moves it to a more generic and usable version in the `util` package. Also removes the stage generation client code from the prelude code.