### PR TITLE
Fix `prelude-operator connect`

### DIFF
--- a/client/command/prelude-operator/connect.go
+++ b/client/command/prelude-operator/connect.go
@@ -53,9 +53,11 @@ func ConnectCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		if len(sessions.Sessions) > 0 {
 			con.PrintInfof("Adding existing sessions ...\n")
 			for _, session := range sessions.Sessions {
-				err = implantMapper.AddImplant(session, nil)
-				if err != nil {
-					con.PrintErrorf("Could not add session %s to implant mapper: %s", session.Name, err)
+				if !session.IsDead {
+					err = implantMapper.AddImplant(session, nil)
+					if err != nil {
+						con.PrintErrorf("Could not add session %s to implant mapper: %s", session.Name, err)
+					}
 				}
 			}
 			con.PrintInfof("Done !\n")


### PR DESCRIPTION
Avoid adding dead sessions to Operator. When a session is added, the `Pwd` RPC is called on the session, which will timeout for dead sessions, leaving the UI hanging for 60 seconds for every dead session.
The same thing does not apply to beacons since the `Pwd` RPC is asynchronous, and there's no notion of dead beacon so far.