### PR TITLE
Make sure timeout gets set when cleaning up dead sessions.

### DIFF
--- a/client/command/beacons/beacons.go
+++ b/client/command/beacons/beacons.go
@@ -46,7 +46,7 @@ func BeaconsCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 			con.PrintErrorf("%s\n", err)
 			return
 		}
-		err = kill.KillBeacon(beacon, false, con)
+		err = kill.KillBeacon(beacon, ctx, con)
 		if err != nil {
 			con.PrintErrorf("%s\n", err)
 			return
@@ -62,7 +62,7 @@ func BeaconsCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 			return
 		}
 		for _, beacon := range beacons.Beacons {
-			err = kill.KillBeacon(beacon, true, con)
+			err = kill.KillBeacon(beacon, ctx, con)
 			if err != nil {
 				con.PrintErrorf("%s\n", err)
 				return

--- a/client/command/commands.go
+++ b/client/command/commands.go
@@ -558,6 +558,7 @@ func BindCommands(con *console.SliverConsoleClient) {
 			f.String("k", "kill", "", "kill the designated session")
 			f.Bool("K", "kill-all", false, "kill all the sessions")
 			f.Bool("C", "clean", false, "clean out any sessions marked as [DEAD]")
+			f.Bool("f", "force", false, "force session action without waiting for results")
 
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
 		},
@@ -574,7 +575,7 @@ func BindCommands(con *console.SliverConsoleClient) {
 		Help:     "Kill all stale/dead sessions",
 		LongHelp: help.GetHelpFor([]string{consts.SessionsStr, consts.PruneStr}),
 		Flags: func(f *grumble.Flags) {
-
+			f.Bool("f", "force", false, "Force the killing of stale/dead sessions")
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
 		},
 		Run: func(ctx *grumble.Context) error {
@@ -2163,6 +2164,7 @@ func BindCommands(con *console.SliverConsoleClient) {
 			f.String("k", "kill", "", "kill a beacon")
 			f.Bool("K", "kill-all", false, "kill all beacons")
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
+			f.Bool("f", "force", false, "force killing of the beacon")
 		},
 		HelpGroup: consts.GenericHelpGroup,
 		Run: func(ctx *grumble.Context) error {

--- a/client/command/kill/kill.go
+++ b/client/command/kill/kill.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/bishopfox/sliver/protobuf/commonpb"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
+	"github.com/bishopfox/sliver/server/core"
 	"github.com/desertbit/grumble"
 )
 
@@ -41,7 +42,7 @@ func KillCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		if !confirm {
 			return
 		}
-		err := KillSession(session, ctx.Flags.Bool("force"), con)
+		err := KillSession(session, ctx, con)
 		if err != nil {
 			con.PrintErrorf("%s\n", err)
 			return
@@ -54,7 +55,7 @@ func KillCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		if !confirm {
 			return
 		}
-		err := KillBeacon(beacon, ctx.Flags.Bool("force"), con)
+		err := KillBeacon(beacon, ctx, con)
 		if err != nil {
 			con.PrintErrorf("%s\n", err)
 			return
@@ -67,28 +68,31 @@ func KillCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 	return
 }
 
-func KillSession(session *clientpb.Session, force bool, con *console.SliverConsoleClient) error {
+func KillSession(session *clientpb.Session, ctx *grumble.Context, con *console.SliverConsoleClient) error {
 	if session == nil {
 		return errors.New("session does not exist")
 	}
 	_, err := con.Rpc.Kill(context.Background(), &sliverpb.KillReq{
 		Request: &commonpb.Request{
 			SessionID: session.ID,
+			Timeout:   int64(ctx.Flags.Int("timeout")),
 		},
-		Force: force,
+		Force: ctx.Flags.Bool("force"),
 	})
+	core.Sessions.Remove(session.ID)
 	return err
 }
 
-func KillBeacon(beacon *clientpb.Beacon, force bool, con *console.SliverConsoleClient) error {
+func KillBeacon(beacon *clientpb.Beacon, ctx *grumble.Context, con *console.SliverConsoleClient) error {
 	if beacon == nil {
 		return errors.New("session does not exist")
 	}
 	_, err := con.Rpc.Kill(context.Background(), &sliverpb.KillReq{
 		Request: &commonpb.Request{
 			BeaconID: beacon.ID,
+			Timeout:  int64(ctx.Flags.Int("timeout")),
 		},
-		Force: force,
+		Force: ctx.Flags.Bool("force"),
 	})
 	return err
 

--- a/client/command/sessions/prune.go
+++ b/client/command/sessions/prune.go
@@ -41,7 +41,7 @@ func SessionsPruneCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 	for _, session := range sessions.GetSessions() {
 		if session.IsDead {
 			con.Printf("Pruning session %s ... ", session.ID)
-			err = kill.KillSession(session, true, con)
+			err = kill.KillSession(session, ctx, con)
 			if err != nil {
 				con.Printf("failed!\n")
 				con.PrintErrorf("%s\n", err)

--- a/client/command/sessions/sessions.go
+++ b/client/command/sessions/sessions.go
@@ -51,7 +51,7 @@ func SessionsCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 	if killAll {
 		con.ActiveTarget.Background()
 		for _, session := range sessions.Sessions {
-			err := kill.KillSession(session, true, con)
+			err := kill.KillSession(session, ctx, con)
 			if err != nil {
 				con.PrintErrorf("%s\n", err)
 			}
@@ -65,7 +65,7 @@ func SessionsCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		con.ActiveTarget.Background()
 		for _, session := range sessions.Sessions {
 			if session.IsDead {
-				err := kill.KillSession(session, true, con)
+				err := kill.KillSession(session, ctx, con)
 				if err != nil {
 					con.PrintErrorf("%s\n", err)
 				}
@@ -81,7 +81,7 @@ func SessionsCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		if activeSession != nil && session.ID == activeSession.ID {
 			con.ActiveTarget.Background()
 		}
-		err := kill.KillSession(session, true, con)
+		err := kill.KillSession(session, ctx, con)
 		if err != nil {
 			con.PrintErrorf("%s\n", err)
 		}


### PR DESCRIPTION
#### Card

Fix UI hang when clearing dead sessions.

#### Details

* Make client add timeout values when sending to the gRPC handlers.
* Apply timeouts when sending to an implant.
* Remove dead sessions from core.Sessions when complete

Should resolve this issue: https://github.com/BishopFox/sliver/issues/608