### PR TITLE
Prepend stack alignment check to shellcode

### DIFF
--- a/server/generate/donut.go
+++ b/server/generate/donut.go
@@ -78,6 +78,12 @@ func getDonut(data []byte, config *donut.DonutConfig) (shellcode []byte, err err
 		return
 	}
 	shellcode = res.Bytes()
+	stackCheckPrologue := []byte{
+		// Check stack is 8 byte but not 16 byte aligned or else errors in LoadLibrary
+		0x48, 0x83, 0xE4, 0xF0, // and rsp,0xfffffffffffffff0
+		0x48, 0x83, 0xC4, 0x08, // add rsp,0x8
+	}
+	shellcode = append(stackCheckPrologue, shellcode...)
 	return
 }
 


### PR DESCRIPTION
#### Card

Check the stack is aligned correctly at the start of the shellcode, required for metasploit reverse_https staging.

#### Details

Donut's shellcode requires the stack be 8 byte aligned but *not* 16 byte aligned or else calls to `LoadLibrary` fail as the stack at that point is *not* 16 byte aligned when it *should* be for some floating point calculations (the result is an EXCEPTION_ACCESS_VIOLATION).

![image](https://user-images.githubusercontent.com/20513519/161241760-8a1790e5-ebcc-45a9-ac67-0f690499a03c.png)

Normally this is fine as the stack is set up in this way in normal use (e.g. if we just alloc and run generated shellcode), however if the way the shellcode is injected results in it not being aligned in this way then the shellcode errors.

One example of this is metasploit's reverse_http(s) stagers which adjusts the stack itself (e.g. [here](https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/payload/windows/x64/reverse_http_x64.rb#L91)) and causes the above error. This change fixes that by adjusting the stack at the start of the shellcode to ensure it matches the requirements.

Here is an example of metasploit reverse_https staging working, though note this requires an additional change to metasploit to allow shellcode sizes to be set as it currently as a limit of 0x40000 bytes. A PR for that is open on metasploit [here](https://github.com/rapid7/metasploit-framework/pull/16397).

![WindowsTerminal_HYMluNd27r](https://user-images.githubusercontent.com/20513519/161241182-ea6f4125-7587-4afc-84a1-39104343f469.gif)

Regardless of how injected, this change will ensure that stack alignment is correct so it can be merged before the metasploit PR, it's just that metasploit staging will not work until that PR is merged (and we then pass the `ShellcodeSize` option to msfvenom)