### PR TITLE
Check that the stager profile has a shellcode format

### DIFF
--- a/client/command/jobs/stage.go
+++ b/client/command/jobs/stage.go
@@ -60,11 +60,16 @@ func StageListenerCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		return
 	}
 
+	if profile.Config.Format != clientpb.OutputFormat_SHELLCODE {
+		con.PrintErrorf("A stager profile must be in the SHELLCODE format\n")
+		return
+	}
+
 	aesEncrypt := false
 	if aesEncryptKey != "" {
 		// check if aes encryption key is correct length
 		if len(aesEncryptKey)%16 != 0 {
-			con.PrintErrorf("Incorect length of AES Key\n")
+			con.PrintErrorf("Incorrect length of AES Key\n")
 			return
 		}
 
@@ -75,7 +80,7 @@ func StageListenerCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 
 		// check if aes iv is correct length
 		if len(aesEncryptIv)%16 != 0 {
-			con.PrintErrorf("Incorect length of AES IV\n")
+			con.PrintErrorf("Incorrect length of AES IV\n")
 			return
 		}
 


### PR DESCRIPTION
#### Card

Simple check to ensure that when create a stage-listener that the profile is for shellcode

#### Details

![WindowsTerminal_Bs8POnW9nD](https://user-images.githubusercontent.com/20513519/161242367-8bda74c0-e8d1-4d5d-958f-eb586feaee1f.png)

