### PR TITLE
Fix go stager file saving

### DIFF
--- a/client/command/generate/generate-stager.go
+++ b/client/command/generate/generate-stager.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -95,15 +93,11 @@ func GenerateStagerCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 	}
 
 	if save != "" || format == "raw" {
-		saveTo, _ := filepath.Abs(save)
-		fi, err := os.Stat(saveTo)
+		saveTo, err := saveLocation(save, stageFile.GetFile().GetName())
 		if err != nil {
-			con.PrintErrorf("Failed to generate sliver stager %v\n", err)
 			return
 		}
-		if fi.IsDir() {
-			saveTo = filepath.Join(saveTo, stageFile.GetFile().GetName())
-		}
+
 		err = ioutil.WriteFile(saveTo, stageFile.GetFile().GetData(), 0700)
 		if err != nil {
 			con.PrintErrorf("Failed to write to: %s\n", saveTo)


### PR DESCRIPTION
#### Card

Fix stager manual file saving

#### Details

When saving a stager to a custom location the file errored as it calls `Stat` on the file before it is created.

![image](https://user-images.githubusercontent.com/20513519/161243551-7781a1aa-a673-4ff4-b5e6-b1d99a119964.png)


This has changed the file saving/path resolution to call the existing `saveLocation` function instead:

![WindowsTerminal_GdQU3wcsTJ](https://user-images.githubusercontent.com/20513519/161242938-0657442c-e444-4a0d-b77f-a5885cc5199f.png)
