### PR TITLE
Changing token owner to token user to display user name associated with processes in Windows

### DIFF
--- a/implant/sliver/ps/ps_windows.go
+++ b/implant/sliver/ps/ps_windows.go
@@ -104,7 +104,7 @@ func getInfo(t syscall.Token, class uint32, initSize int) (unsafe.Pointer, error
 
 // getTokenOwner retrieves access token t owner account information.
 func getTokenOwner(t syscall.Token) (*syscall.Tokenuser, error) {
-	i, e := getInfo(t, syscall.TokenOwner, 50)
+	i, e := getInfo(t, syscall.TokenUser, 50)
 	if e != nil {
 		return nil, e
 	}


### PR DESCRIPTION
I was digging into #666 a bit, and Sliver uses the [token owner](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_owner?redirectedfrom=MSDN) to correlate a SID / user to a process. We can see this using Process Explorer:
![image](https://user-images.githubusercontent.com/84349012/165584528-ef60ad7e-98e8-4949-b9ac-aeddb947f3b0.png)

![image](https://user-images.githubusercontent.com/84349012/165584941-bfe88f7b-60ff-47ab-ba5e-3b416418fcf8.png)

The token owner represents the SID that will own anything created by the process. We might want to use the [token user](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_user?redirectedfrom=MSDN) instead. The token user is the user whose credentials were used to generate the access token.  When I modified Sliver to grab the token user, the output addresses #666 :

![image](https://user-images.githubusercontent.com/84349012/165585988-ab06b372-69ac-4e75-8a1d-07b62a849962.png)

I am not sure if there was a specific reason Sliver shows the owner, so please let me know if you would like a different approach.