### PR TITLE
UX Changes for Looting and Refactoring in the client/exec package

### DIFF
--- a/client/command/commands.go
+++ b/client/command/commands.go
@@ -994,10 +994,12 @@ func BindCommands(con *console.SliverConsoleClient) {
 		Flags: func(f *grumble.Flags) {
 			f.Bool("T", "token", false, "execute command with current token (windows only)")
 			f.Bool("o", "output", false, "capture command output")
+			f.Bool("s", "save", false, "save output to a file")
 			f.Bool("X", "loot", false, "save output as loot")
 			f.Bool("S", "ignore-stderr", false, "don't print STDERR output")
 			f.String("O", "stdout", "", "remote path to redirect STDOUT to")
 			f.String("E", "stderr", "", "remote path to redirect STDERR to")
+			f.String("n", "name", "", "name to assign loot (optional)")
 
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
 		},
@@ -1030,6 +1032,7 @@ func BindCommands(con *console.SliverConsoleClient) {
 			f.String("a", "arch", "x84", "Assembly target architecture: x86, x64, x84 (x86+x64)")
 			f.Bool("s", "save", false, "save output to file")
 			f.Bool("X", "loot", false, "save output as loot")
+			f.String("n", "name", "", "name to assign loot (optional)")
 
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
 		},
@@ -1074,6 +1077,8 @@ func BindCommands(con *console.SliverConsoleClient) {
 			f.String("e", "entry-point", "", "Entrypoint for the DLL (Windows only)")
 			f.String("p", "process", `c:\windows\system32\notepad.exe`, "Path to process to host the shellcode")
 			f.Bool("s", "save", false, "save output to file")
+			f.Bool("X", "loot", false, "save output as loot")
+			f.String("n", "name", "", "name to assign loot (optional)")
 			f.Bool("k", "keep-alive", false, "don't terminate host process once the execution completes")
 
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
@@ -1099,6 +1104,8 @@ func BindCommands(con *console.SliverConsoleClient) {
 			f.String("p", "process", `c:\windows\system32\notepad.exe`, "Path to process to host the shellcode")
 			f.String("e", "export", "ReflectiveLoader", "Entrypoint of the Reflective DLL")
 			f.Bool("s", "save", false, "save output to file")
+			f.Bool("X", "loot", false, "save output as loot")
+			f.String("n", "name", "", "name to assign loot (optional)")
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
 			f.Bool("k", "keep-alive", false, "don't terminate host process once the execution completes")
 		},
@@ -1765,6 +1772,9 @@ func BindCommands(con *console.SliverConsoleClient) {
 			f.Bool("c", "colorize-output", false, "colorize output")
 			f.Bool("x", "hex", false, "display as a hex dump")
 			f.Bool("X", "loot", false, "save output as loot")
+			f.String("n", "name", "", "name to assign loot (optional)")
+			f.String("T", "type", "", "force a specific loot type (file/cred) if looting (optional)")
+			f.String("F", "file-type", "", "force a specific file type (binary/text) if looting (optional)")
 		},
 		Args: func(a *grumble.Args) {
 			a.String("path", "path to the file to print")
@@ -1899,6 +1909,8 @@ func BindCommands(con *console.SliverConsoleClient) {
 			f.Int("p", "pid", -1, "target pid")
 			f.String("n", "name", "", "target process name")
 			f.String("s", "save", "", "save to file (will overwrite if exists)")
+			f.Bool("X", "loot", false, "save output as loot")
+			f.String("N", "loot-name", "", "name to assign when adding the memory dump to the loot store (optional)")
 
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
 		},
@@ -2132,6 +2144,7 @@ func BindCommands(con *console.SliverConsoleClient) {
 		Flags: func(f *grumble.Flags) {
 			f.String("s", "save", "", "save to file (will overwrite if exists)")
 			f.Bool("X", "loot", false, "save output as loot")
+			f.String("n", "name", "", "name to assign loot (optional)")
 
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
 		},

--- a/client/command/filesystem/download.go
+++ b/client/command/filesystem/download.go
@@ -59,10 +59,13 @@ func PerformDownload(remotePath string, fileName string, destination string, ctx
 		con.PrintAsyncResponse(download.Response)
 	}
 
+	if download.Response != nil && download.Response.Err != "" {
+		return download, fmt.Errorf("%s\n", download.Response.Err)
+	}
+
 	if download.Encoder == "gzip" {
 		download.Data, err = new(encoders.Gzip).Decode(download.Data)
 		if err != nil {
-			con.PrintErrorf("Decoding failed %s", err)
 			return nil, fmt.Errorf("Decoding failed %s", err)
 		}
 	}
@@ -92,11 +95,12 @@ func DownloadCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		// The destination is the loot store.
 		dst = "loot"
 		lootName = ctx.Flags.String("name")
-		if lootName == "" {
-			lootName = fileName
-		}
 
 		lootType, err = loot.ValidateLootType(ctx.Flags.String("type"))
+		if err != nil {
+			con.PrintErrorf("%s\n", err)
+			return
+		}
 		// Determine file type after the download is complete
 	} else {
 		// If this download is not being looted, make sure the local path exists

--- a/client/command/tasks/fetch.go
+++ b/client/command/tasks/fetch.go
@@ -233,7 +233,7 @@ func renderTaskResponse(task *clientpb.BeaconTask, con *console.SliverConsoleCli
 				"loot": &grumble.FlagMapItem{Value: false, IsDefault: true},
 			},
 		}
-		exec.PrintExecuteAssembly(execAssembly, hostname, assemblyPath, ctx, con)
+		exec.HandleExecuteAssemblyResponse(execAssembly, assemblyPath, hostname, ctx, con)
 
 	// execute-shellcode
 	case sliverpb.MsgTaskReq:
@@ -289,9 +289,10 @@ func renderTaskResponse(task *clientpb.BeaconTask, con *console.SliverConsoleCli
 			Command: &grumble.Command{Name: "sideload"},
 			Flags: grumble.FlagMap{
 				"save": &grumble.FlagMapItem{Value: false},
+				"loot": &grumble.FlagMapItem{Value: false},
 			},
 		}
-		exec.PrintSideload(sideload, hostname, ctx, con)
+		exec.HandleSideloadResponse(sideload, "", hostname, ctx, con)
 
 	case sliverpb.MsgSpawnDllReq:
 		spawnDll := &sliverpb.SpawnDll{}
@@ -309,9 +310,10 @@ func renderTaskResponse(task *clientpb.BeaconTask, con *console.SliverConsoleCli
 			Command: &grumble.Command{Name: "spawndll"},
 			Flags: grumble.FlagMap{
 				"save": &grumble.FlagMapItem{Value: false},
+				"loot": &grumble.FlagMapItem{Value: false},
 			},
 		}
-		exec.PrintSpawnDll(spawnDll, hostname, ctx, con)
+		exec.HandleSpawnDLLResponse(spawnDll, "", hostname, ctx, con)
 
 	case sliverpb.MsgSSHCommandReq:
 		sshCommand := &sliverpb.SSHCommand{}


### PR DESCRIPTION
This PR addresses #641:

- `loot` is added to commands that support it, but I kept the `save` command. There might be instances where someone wants a local copy and a looted copy. That means you can loot, save, or loot and save. This PR modifies the following commands:
  * `cat`
  * `execute`
  * `execute-assembly`
  * `procdump`
  * `screenshot`
  * `sideload`
  * `spawndll`
- Added `save` to the `execute` command so that UX is consistent across all of the commands that support looting.
- Refactored the injection `exec` commands (`spawndll`, `sideload`, `execute-assembly`) and put common code in `execute.go`
- This PR does not implement looting for several commands that have the `save` flag because it was not clear if looting would make sense for those commands. Those commands are:
  * `generate` and its subcommands
  * `loot fetch` (obviously)
  * `profiles generate`
  * `reaction save`
  * `regenerate`
  * `settings`
  * `update`
  * `wg-config`