### PR TITLE
Beacon Interval Display Changes

### DIFF
--- a/client/command/beacons/beacons.go
+++ b/client/command/beacons/beacons.go
@@ -142,17 +142,40 @@ func renderBeacons(beacons []*clientpb.Beacon, filter string, filterRegex *regex
 		}
 
 		nextCheckin := time.Unix(beacon.NextCheckin, 0)
+		nextCheckinDateTime := nextCheckin.Format(time.UnixDate)
+
 		var next string
+		var interval string
+
 		if time.Unix(beacon.NextCheckin, 0).Before(time.Now()) {
-			past := time.Since(nextCheckin)
-			next = fmt.Sprintf("%s-%s%s", console.Bold+console.Red, past, console.Normal)
+			if con.Settings.SmallTermWidth < width {
+				interval = fmt.Sprintf("%s (%s ago)", nextCheckinDateTime, time.Since(nextCheckin).Round(time.Second))
+
+			} else {
+				interval = time.Since(nextCheckin).Round(time.Second).String()
+			}
+			next = fmt.Sprintf("%s%s%s", console.Bold+console.Red, interval, console.Normal)
 		} else {
-			eta := time.Until(nextCheckin)
-			next = fmt.Sprintf("%s%s%s", console.Bold+console.Green, eta, console.Normal)
+			if con.Settings.SmallTermWidth < width {
+				interval = fmt.Sprintf("%s (in %s)", nextCheckinDateTime, time.Until(nextCheckin).Round(time.Second))
+			} else {
+				interval = time.Until(nextCheckin).Round(time.Second).String()
+			}
+
+			next = fmt.Sprintf("%s%s%s", console.Bold+console.Green, interval, console.Normal)
 		}
 
 		// We need a slice of strings so we can apply filters
 		var rowEntries []string
+
+		/*
+			Round the duration to the nearest second to be more output friendly.
+			We deal in seconds for everything, so it makes sense to show outputs
+			in seconds to remain consistent.
+		*/
+		timeSinceLastCheckin := time.Since(time.Unix(beacon.LastCheckin, 0)).Round(time.Second)
+		lastCheckinDateTime := time.Unix(beacon.LastCheckin, 0).Format(time.UnixDate)
+
 		if con.Settings.SmallTermWidth < width {
 			rowEntries = []string{
 				fmt.Sprintf(color+"%s"+console.Normal, strings.Split(beacon.ID, "-")[0]),
@@ -163,7 +186,7 @@ func renderBeacons(beacons []*clientpb.Beacon, filter string, filterRegex *regex
 				fmt.Sprintf(color+"%s"+console.Normal, beacon.Hostname),
 				fmt.Sprintf(color+"%s"+console.Normal, strings.TrimPrefix(beacon.Username, beacon.Hostname+"\\")),
 				fmt.Sprintf(color+"%s/%s"+console.Normal, beacon.OS, beacon.Arch),
-				fmt.Sprintf(color+"%s ago"+console.Normal, time.Since(time.Unix(beacon.LastCheckin, 0))),
+				fmt.Sprintf(color+"%s (%s ago)"+console.Normal, lastCheckinDateTime, timeSinceLastCheckin),
 				next,
 			}
 		} else {
@@ -173,7 +196,7 @@ func renderBeacons(beacons []*clientpb.Beacon, filter string, filterRegex *regex
 				fmt.Sprintf(color+"%s"+console.Normal, beacon.Transport),
 				fmt.Sprintf(color+"%s"+console.Normal, strings.TrimPrefix(beacon.Username, beacon.Hostname+"\\")),
 				fmt.Sprintf(color+"%s/%s"+console.Normal, beacon.OS, beacon.Arch),
-				fmt.Sprintf(color+"%s ago"+console.Normal, time.Since(time.Unix(beacon.LastCheckin, 0))),
+				fmt.Sprintf(color+"%s ago"+console.Normal, timeSinceLastCheckin),
 				next,
 			}
 		}

--- a/client/command/generate/generate-beacon.go
+++ b/client/command/generate/generate-beacon.go
@@ -38,7 +38,17 @@ func parseBeaconFlags(ctx *grumble.Context, con *console.SliverConsoleClient, co
 	interval := time.Duration(ctx.Flags.Int64("days")) * time.Hour * 24
 	interval += time.Duration(ctx.Flags.Int64("hours")) * time.Hour
 	interval += time.Duration(ctx.Flags.Int64("minutes")) * time.Minute
-	interval += time.Duration(ctx.Flags.Int64("seconds")) * time.Second
+
+	/*
+		If seconds has not been specified but any of the other time units have, then do not add
+		the default 60 seconds to the interval.
+
+		If seconds have been specified, then add them regardless.
+	*/
+	if (ctx.Flags["seconds"].IsDefault && interval.Seconds() == 0) || (!ctx.Flags["seconds"].IsDefault) {
+		interval += time.Duration(ctx.Flags.Int64("seconds")) * time.Second
+	}
+
 	if interval < minBeaconInterval {
 		return ErrBeaconIntervalTooShort
 	}

--- a/implant/sliver/sliver.go
+++ b/implant/sliver/sliver.go
@@ -298,7 +298,7 @@ func beaconMainLoop(beacon *transports.Beacon) error {
 		Interval:    beacon.Interval(),
 		Jitter:      beacon.Jitter(),
 		Register:    register,
-		NextCheckin: nextCheckin.UTC().Unix(),
+		NextCheckin: int64(beacon.Duration().Seconds()),
 	}))
 	beacon.Close()
 	time.Sleep(time.Second)
@@ -360,7 +360,7 @@ func beaconMain(beacon *transports.Beacon, nextCheckin time.Time) error {
 	// {{end}}
 	err = beacon.Send(wrapEnvelope(sliverpb.MsgBeaconTasks, &sliverpb.BeaconTasks{
 		ID:          InstanceID,
-		NextCheckin: nextCheckin.UTC().Unix(),
+		NextCheckin: int64(beacon.Duration().Seconds()),
 	}))
 	if err != nil {
 		// {{if .Config.Debug}}

--- a/server/db/helpers.go
+++ b/server/db/helpers.go
@@ -322,7 +322,7 @@ func UpdateBeaconCheckinByID(beaconID string, next int64) error {
 		ID: uuid.FromStringOrNil(beaconID),
 	}).Updates(models.Beacon{
 		LastCheckin: time.Now(),
-		NextCheckin: next,
+		NextCheckin: time.Now().Unix() + next,
 	}).Error
 	return err
 }

--- a/server/handlers/beacons.go
+++ b/server/handlers/beacons.go
@@ -83,7 +83,7 @@ func beaconRegisterHandler(implantConn *core.ImplantConnection, data []byte) *sl
 
 	beacon.Interval = beaconReg.Interval
 	beacon.Jitter = beaconReg.Jitter
-	beacon.NextCheckin = beaconReg.NextCheckin
+	beacon.NextCheckin = time.Now().Unix() + beaconReg.NextCheckin
 
 	err = db.Session().Save(beacon).Error
 	if err != nil {


### PR DESCRIPTION
This PR addresses #684 and makes a few other changes.

Changes:
- Beacon check in times are sent from the implant as a duration until the next check in instead of an absolute time. The server calculates the check in time relative to its local time.
- While testing the change above, I noticed that if you do not specify an amount seconds to `generate beacon` but you specify another unit of time (like hours or minutes), 60 seconds was automatically added to whatever interval you specified. For example, if you specified `-M 5`, the interval would be 6 minutes. This PR checks to see if seconds were not specified and any of the other time units were. If so, the seconds are ignored. If the seconds are specified, they are always added.
- This PR also changes how the check in times are displayed. It makes the display a bit more human friendly by rounding to the nearest second. We do everything in seconds, so it makes sense to display seconds.

On a small width terminal:
```
[server] sliver > beacons

 ID         Name          Transport   Username   Operating System   Last Check-In   Next Check-In 
========== ============= =========== ========== ================== =============== ===============
 40a3e070   SHY_TUGBOAT   mtls        user       linux/amd64        3s ago          5m19s         
```

On a larger width terminal:
```
[server] sliver > beacons

 ID         Name          Tasks   Transport   Remote Address    Hostname   Username   Operating System   Last Check-In                            Next Check-In                          
========== ============= ======= =========== ================= ========== ========== ================== ======================================== ========================================
 40a3e070   SHY_TUGBOAT   0/0     mtls        127.0.0.1:52658   box       user       linux/amd64        Mon May 23 16:14:54 UTC 2022 (16s ago)   Mon May 23 16:20:16 UTC 2022 (in 5m6s) 
```