### PR TITLE
Fix panic on x86 beacon startup, fix for #682

### DIFF
--- a/implant/sliver/transports/beacon.go
+++ b/implant/sliver/transports/beacon.go
@@ -103,7 +103,7 @@ func (b *Beacon) Duration() time.Duration {
 	// {{end}}
 	jitterDuration := time.Duration(0)
 	if 0 < b.Jitter() {
-		jitterDuration = time.Duration(int64(insecureRand.Intn(int(b.Jitter()))))
+		jitterDuration = time.Duration(insecureRand.Int63n(b.Jitter()))
 	}
 	duration := time.Duration(b.Interval()) + jitterDuration
 	// {{if .Config.Debug}}


### PR DESCRIPTION
One line fix for beacon panics on x86 builds. Tested on actual linux machine, looks like it works as expected now.

Issue: https://github.com/BishopFox/sliver/pull/686