### PR TITLE
Wireguard Session Health Status Fix

### DIFF
--- a/server/core/sessions.go
+++ b/server/core/sessions.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/bishopfox/sliver/implant/sliver/transports/mtls"
+	"github.com/bishopfox/sliver/implant/sliver/transports/wireguard"
 	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
 	"github.com/bishopfox/sliver/server/log"
@@ -91,8 +92,14 @@ func (s *Session) IsDead() bool {
 		return false
 	}
 	if s.Connection.Transport == consts.MtlsStr {
-		if time.Since(s.Connection.LastMessage) < mtls.PingInterval+padding {
+		if timePassed < mtls.PingInterval+padding {
 			sessionsLog.Debugf("Last message within ping interval with padding")
+			return false
+		}
+	}
+	if s.Connection.Transport == consts.WGStr {
+		if timePassed < wireguard.PingInterval+padding {
+			sessionsLog.Debugf("Last message with ping interval with padding")
 			return false
 		}
 	}


### PR DESCRIPTION
This PR addresses #667 .

The `IsDead()` function was looking at the reconnect and poll intervals for Wireguard connections instead of the ping interval. Changed `IsDead()` to look at the ping interval for Wireguard connections, like it does for mTLS.