### PR TITLE
Race conditions fixes and stability improvements

### DIFF
--- a/client/command/commands.go
+++ b/client/command/commands.go
@@ -2775,7 +2775,7 @@ func BindCommands(con *console.SliverConsoleClient) {
 		LongHelp: help.GetHelpFor([]string{consts.Socks5Str}),
 		Flags: func(f *grumble.Flags) {
 			f.Int("t", "timeout", defaultTimeout, "router timeout in seconds")
-			f.Int("i", "id", 0, "id of portfwd to remove")
+			f.Uint64("i", "id", 0, "id of portfwd to remove")
 		},
 		Run: func(ctx *grumble.Context) error {
 			con.Println()

--- a/client/command/exec/execute-shellcode.go
+++ b/client/command/exec/execute-shellcode.go
@@ -125,7 +125,7 @@ func executeInteractive(ctx *grumble.Context, hostProc string, shellcode []byte,
 		return
 	}
 
-	tunnel := core.Tunnels.Start(rpcTunnel.GetTunnelID(), rpcTunnel.GetSessionID())
+	tunnel := core.GetTunnels().Start(rpcTunnel.GetTunnelID(), rpcTunnel.GetSessionID())
 
 	shell, err := con.Rpc.Shell(context.Background(), &sliverpb.ShellReq{
 		Request:   con.ActiveTarget.Request(ctx),

--- a/client/command/shell/shell.go
+++ b/client/command/shell/shell.go
@@ -78,7 +78,7 @@ func runInteractive(ctx *grumble.Context, shellPath string, noPty bool, con *con
 	log.Printf("Created new tunnel with id: %d, binding to shell ...", rpcTunnel.TunnelID)
 
 	// Start() takes an RPC tunnel and creates a local Reader/Writer tunnel object
-	tunnel := core.Tunnels.Start(rpcTunnel.TunnelID, rpcTunnel.SessionID)
+	tunnel := core.GetTunnels().Start(rpcTunnel.TunnelID, rpcTunnel.SessionID)
 
 	shell, err := con.Rpc.Shell(context.Background(), &sliverpb.ShellReq{
 		Request:   con.ActiveTarget.Request(ctx),

--- a/client/command/socks/socks-stop.go
+++ b/client/command/socks/socks-stop.go
@@ -29,7 +29,7 @@ import (
 
 // SocksStopCmd - Remove an existing tunneled port forward
 func SocksStopCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
-	socksID := ctx.Flags.Int("id")
+	socksID := ctx.Flags.Uint64("id")
 	if socksID < 1 {
 		con.PrintErrorf("Must specify a valid socks5 id\n")
 		return

--- a/client/console/console.go
+++ b/client/console/console.go
@@ -215,6 +215,7 @@ func (con *SliverConsoleClient) EventLoop() {
 			con.PrintEventErrorf("Lost session %s %s - %s (%s) - %s/%s - %v",
 				shortID, session.Name, session.RemoteAddress, session.Hostname, session.OS, session.Arch, currentTime)
 			activeSession := con.ActiveTarget.GetSession()
+			core.GetTunnels().CloseForSession(session.ID)
 			if activeSession != nil && activeSession.ID == session.ID {
 				con.ActiveTarget.Set(nil, nil)
 				con.PrintEventErrorf("Active session disconnected")

--- a/client/core/portfwd.go
+++ b/client/core/portfwd.go
@@ -125,7 +125,7 @@ func (p *ChannelProxy) HandleConn(conn net.Conn) {
 	// Cleanup
 	defer func() {
 		go conn.Close()
-		Tunnels.Close(tunnel.ID)
+		GetTunnels().Close(tunnel.ID)
 	}()
 
 	errs := make(chan error, 1)
@@ -172,7 +172,7 @@ func (p *ChannelProxy) Host() string {
 	return host
 }
 
-func (p *ChannelProxy) dialImplant(ctx context.Context) (*Tunnel, error) {
+func (p *ChannelProxy) dialImplant(ctx context.Context) (*TunnelIO, error) {
 
 	log.Printf("[tcpproxy] Dialing implant to create tunnel ...")
 
@@ -185,7 +185,7 @@ func (p *ChannelProxy) dialImplant(ctx context.Context) (*Tunnel, error) {
 		return nil, err
 	}
 	log.Printf("[tcpproxy] Created new tunnel with id %d (session %s)", rpcTunnel.TunnelID, p.Session.ID)
-	tunnel := Tunnels.Start(rpcTunnel.TunnelID, rpcTunnel.SessionID)
+	tunnel := GetTunnels().Start(rpcTunnel.TunnelID, rpcTunnel.SessionID)
 
 	log.Printf("[tcpproxy] Binding tunnel to portfwd %d", p.Port())
 	portfwdResp, err := p.Rpc.Portfwd(ctx, &sliverpb.PortfwdReq{
@@ -219,7 +219,7 @@ func (p *ChannelProxy) dialTimeout() time.Duration {
 	return 30 * time.Second
 }
 
-func toImplantLoop(conn net.Conn, tunnel *Tunnel, errs chan<- error) {
+func toImplantLoop(conn net.Conn, tunnel *TunnelIO, errs chan<- error) {
 	if wc, ok := conn.(*tcpproxy.Conn); ok && len(wc.Peeked) > 0 {
 		if _, err := tunnel.Write(wc.Peeked); err != nil {
 			errs <- err
@@ -232,7 +232,7 @@ func toImplantLoop(conn net.Conn, tunnel *Tunnel, errs chan<- error) {
 	errs <- err
 }
 
-func fromImplantLoop(conn net.Conn, tunnel *Tunnel, errs chan<- error) {
+func fromImplantLoop(conn net.Conn, tunnel *TunnelIO, errs chan<- error) {
 	n, err := io.Copy(conn, tunnel)
 	log.Printf("[tcpproxy] Closing from-implant after %d byte(s)", n)
 	errs <- err

--- a/client/core/portfwd.go
+++ b/client/core/portfwd.go
@@ -116,7 +116,7 @@ func (p *ChannelProxy) HandleConn(conn net.Conn) {
 	}
 	tunnel, err := p.dialImplant(ctx)
 	if cancel != nil {
-		cancel()
+		defer cancel()
 	}
 	if err != nil {
 		return
@@ -124,7 +124,7 @@ func (p *ChannelProxy) HandleConn(conn net.Conn) {
 
 	// Cleanup
 	defer func() {
-		go conn.Close()
+		conn.Close()
 		GetTunnels().Close(tunnel.ID)
 	}()
 

--- a/client/core/tunnel.go
+++ b/client/core/tunnel.go
@@ -15,7 +15,10 @@ func TunnelLoop(rpc rpcpb.SliverRPCClient) error {
 	log.Println("Starting tunnel data loop ...")
 	defer log.Printf("Warning: TunnelLoop exited")
 
-	stream, err := rpc.TunnelData(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := rpc.TunnelData(ctx)
+	defer cancel()
+
 	if err != nil {
 		return err
 	}
@@ -26,6 +29,8 @@ func TunnelLoop(rpc rpcpb.SliverRPCClient) error {
 		// log.Printf("Waiting for TunnelData ...")
 		incoming, err := stream.Recv()
 		// log.Printf("Recv stream msg: %v", incoming)
+		// log.Printf("Recv stream err: %s", err)
+
 		if err == io.EOF {
 			log.Printf("EOF Error: Tunnel data stream closed")
 			return nil

--- a/client/core/tunnel.go
+++ b/client/core/tunnel.go
@@ -1,127 +1,28 @@
 package core
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"log"
-	"sync"
 
 	"github.com/bishopfox/sliver/protobuf/rpcpb"
-	"github.com/bishopfox/sliver/protobuf/sliverpb"
 )
-
-var (
-	// Tunnels - Holds refs to all tunnels
-	Tunnels tunnels
-)
-
-// Holds the tunnels locally so we can map incoming data
-// messages to the tunnel
-type tunnels struct {
-	tunnels *map[uint64]*Tunnel
-	mutex   *sync.RWMutex
-	stream  rpcpb.SliverRPC_TunnelDataClient
-}
-
-// Get - Get a tunnel
-func (t *tunnels) Get(tunnelID uint64) *Tunnel {
-	t.mutex.RLock()
-	defer t.mutex.RUnlock()
-	return (*t.tunnels)[tunnelID]
-}
-
-// Start - Add a tunnel to the core mapper
-func (t *tunnels) Start(tunnelID uint64, sessionID string) *Tunnel {
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
-	tunnel := &Tunnel{
-		ID:        tunnelID,
-		SessionID: sessionID,
-		Send:      make(chan []byte),
-		Recv:      make(chan []byte),
-	}
-	(*t.tunnels)[tunnelID] = tunnel
-	go func() {
-		tunnel.IsOpen = true
-		for data := range tunnel.Send {
-			log.Printf("Send %d bytes on tunnel %d", len(data), tunnel.ID)
-			t.stream.Send(&sliverpb.TunnelData{
-				TunnelID:  tunnel.ID,
-				SessionID: tunnel.SessionID,
-				Data:      data,
-			})
-		}
-	}()
-	tunnel.Send <- make([]byte, 0) // Send "zero" message to bind client to tunnel
-	return tunnel
-}
-
-// Close - Close the tunnel channels
-func (t *tunnels) Close(tunnelID uint64) {
-	log.Printf("Closing tunnel %d", tunnelID)
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
-	tunnel := (*t.tunnels)[tunnelID]
-	if tunnel != nil {
-		delete((*t.tunnels), tunnelID)
-		tunnel.IsOpen = false
-		close(tunnel.Recv)
-		close(tunnel.Send)
-	}
-}
-
-// Tunnel - Duplex data tunnel
-type Tunnel struct {
-	ID        uint64
-	IsOpen    bool
-	SessionID string
-
-	Send chan []byte
-	Recv chan []byte
-}
-
-// Write - Writer method for interface
-func (tun *Tunnel) Write(data []byte) (int, error) {
-	log.Printf("Write %d bytes", len(data))
-	if !tun.IsOpen {
-		return 0, io.EOF
-	}
-	tun.Send <- data
-	n := len(data)
-	return n, nil
-}
-
-// Read - Reader method for interface
-func (tun *Tunnel) Read(data []byte) (int, error) {
-	var buff bytes.Buffer
-	if !tun.IsOpen {
-		log.Printf("Warning: Read on closed tunnel %d", tun.ID)
-		return 0, io.EOF
-	}
-	recvData := <-tun.Recv
-	log.Printf("Read %d bytes", len(recvData))
-	buff.Write(recvData)
-	n := copy(data, buff.Bytes())
-	return n, nil
-}
 
 // TunnelLoop - Parses incoming tunnel messages and distributes them
 //              to session/tunnel objects
+// 				Expected to be called only once during initialization
 func TunnelLoop(rpc rpcpb.SliverRPCClient) error {
 	log.Println("Starting tunnel data loop ...")
 	defer log.Printf("Warning: TunnelLoop exited")
+
 	stream, err := rpc.TunnelData(context.Background())
 	if err != nil {
 		return err
 	}
-	Tunnels = tunnels{
-		tunnels: &map[uint64]*Tunnel{},
-		mutex:   &sync.RWMutex{},
-		stream:  stream,
-	}
-	for {
 
+	GetTunnels().SetStream(stream)
+
+	for {
 		// log.Printf("Waiting for TunnelData ...")
 		incoming, err := stream.Recv()
 		// log.Printf("Recv stream msg: %v", incoming)
@@ -134,15 +35,15 @@ func TunnelLoop(rpc rpcpb.SliverRPCClient) error {
 			return err
 		}
 		// log.Printf("Received TunnelData for tunnel %d", incoming.TunnelID)
-		tunnel := Tunnels.Get(incoming.TunnelID)
+		tunnel := GetTunnels().Get(incoming.TunnelID)
+
 		if tunnel != nil {
 			if !incoming.Closed {
 				log.Printf("Received data on tunnel %d", tunnel.ID)
 				tunnel.Recv <- incoming.GetData()
 			} else {
 				log.Printf("Closing tunnel %d", tunnel.ID)
-				tunnel.IsOpen = false
-				close(tunnel.Recv)
+				GetTunnels().Close(tunnel.ID)
 			}
 		} else {
 			log.Printf("Received tunnel data for non-existent tunnel id %d", incoming.TunnelID)

--- a/client/core/tunnel_io.go
+++ b/client/core/tunnel_io.go
@@ -1,0 +1,115 @@
+package core
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log"
+	"sync"
+)
+
+// TunnelIO - Duplex data tunnel, compatible with both io.ReadWriter
+type TunnelIO struct {
+	ID        uint64
+	SessionID string
+
+	Send chan []byte
+	Recv chan []byte
+
+	isOpen bool
+	mutex  *sync.RWMutex
+}
+
+// NewTunnelIO - Single entry point for creating instance of new TunnelIO
+func NewTunnelIO(tunnelID uint64, sessionID string) *TunnelIO {
+	log.Printf("New tunnel!: %d", tunnelID)
+
+	return &TunnelIO{
+		ID:        tunnelID,
+		SessionID: sessionID,
+		Send:      make(chan []byte),
+		Recv:      make(chan []byte),
+		isOpen:    false,
+		mutex:     &sync.RWMutex{},
+	}
+}
+
+// Write - Writer method for interface
+func (tun *TunnelIO) Write(data []byte) (int, error) {
+	if !tun.IsOpen() {
+		log.Printf("Warning: Write on closed tunnel %d", tun.ID)
+		return 0, io.EOF
+	}
+
+	// This is necessary to avoid any race conditions on thay byte array
+	dataCopy := make([]byte, len(data))
+	copy(dataCopy, data)
+
+	log.Printf("Write %d bytes", len(dataCopy))
+
+	tun.Send <- dataCopy
+	n := len(dataCopy)
+
+	return n, nil
+}
+
+// Read - Reader method for interface
+func (tun *TunnelIO) Read(data []byte) (int, error) {
+	if !tun.IsOpen() {
+		log.Printf("Warning: Read on closed tunnel %d", tun.ID)
+		return 0, io.EOF
+	}
+
+	var buff bytes.Buffer
+
+	recvData := <-tun.Recv
+	log.Printf("Read %d bytes", len(recvData))
+	buff.Write(recvData)
+
+	n := copy(data, buff.Bytes())
+	return n, nil
+}
+
+// Close - Close tunnel IO operations
+func (tun *TunnelIO) Close() error {
+	tun.mutex.Lock()
+	defer tun.mutex.Unlock()
+
+	if !tun.isOpen {
+		log.Printf("Warning: Close on closed tunnel %d", tun.ID)
+
+		// I guess we can ignore it and don't return any error
+		return nil
+	}
+
+	log.Printf("Close tunnel %d", tun.ID)
+
+	tun.isOpen = false
+
+	close(tun.Recv)
+	close(tun.Send)
+
+	return nil
+}
+
+func (tun *TunnelIO) IsOpen() bool {
+	tun.mutex.RLock()
+	defer tun.mutex.RUnlock()
+
+	return tun.isOpen
+}
+
+func (tun *TunnelIO) Open() error {
+	tun.mutex.Lock()
+	defer tun.mutex.Unlock()
+
+	if tun.isOpen {
+		return errors.New("tunnel relady in open state")
+	}
+
+	log.Printf("Open tunnel %d", tun.ID)
+
+	tun.isOpen = true
+
+	return nil
+}

--- a/client/core/tunnel_io.go
+++ b/client/core/tunnel_io.go
@@ -43,12 +43,11 @@ func (tun *TunnelIO) Write(data []byte) (int, error) {
 
 	// This is necessary to avoid any race conditions on thay byte array
 	dataCopy := make([]byte, len(data))
-	copy(dataCopy, data)
+	n := copy(dataCopy, data)
 
-	log.Printf("Write %d bytes", len(dataCopy))
+	log.Printf("Write %d bytes", n)
 
 	tun.Send <- dataCopy
-	n := len(dataCopy)
 
 	return n, nil
 }

--- a/client/core/tunnels.go
+++ b/client/core/tunnels.go
@@ -1,0 +1,124 @@
+package core
+
+import (
+	"errors"
+	"log"
+	"sync"
+
+	"github.com/bishopfox/sliver/protobuf/rpcpb"
+	"github.com/bishopfox/sliver/protobuf/sliverpb"
+)
+
+var (
+	// tunnelsStorage - Holds refs to all tunnels
+	tunnelsStorage *tunnels
+
+	tunnelsSingletonLock = &sync.Mutex{}
+)
+
+// GetTunnels - singleton function that returns or initializes all tunnels
+func GetTunnels() *tunnels {
+	tunnelsSingletonLock.Lock()
+	defer tunnelsSingletonLock.Unlock()
+
+	if tunnelsStorage == nil {
+		log.Println("Creating single instance of tunnels.")
+
+		tunnelsStorage = &tunnels{
+			tunnels:     &map[uint64]*TunnelIO{},
+			mutex:       &sync.RWMutex{},
+			streamMutex: &sync.Mutex{},
+		}
+	}
+
+	return tunnelsStorage
+}
+
+// Holds the tunnels locally so we can map incoming data
+// messages to the tunnel
+type tunnels struct {
+	tunnels     *map[uint64]*TunnelIO
+	mutex       *sync.RWMutex
+	streamMutex *sync.Mutex
+	stream      rpcpb.SliverRPC_TunnelDataClient
+}
+
+func (t *tunnels) SetStream(stream rpcpb.SliverRPC_TunnelDataClient) {
+	t.streamMutex.Lock()
+	defer t.streamMutex.Unlock()
+
+	log.Printf("Set stream")
+
+	t.stream = stream
+}
+
+// Get - Get a tunnel
+func (t *tunnels) Get(tunnelID uint64) *TunnelIO {
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
+
+	log.Printf("Get tunnel %d", tunnelID)
+
+	return (*t.tunnels)[tunnelID]
+}
+
+// send - safe way to send a message to the stream
+// protobuf stream allow only one writer at a time, so just in case there is a mutex for it
+func (t *tunnels) send(tunnelData *sliverpb.TunnelData) error {
+	t.streamMutex.Lock()
+	defer t.streamMutex.Unlock()
+
+	if t.stream == nil {
+		return errors.New("uninitizlied stream")
+	}
+
+	log.Printf("Private send to stream, tunnelId: %d", tunnelData.TunnelID)
+
+	return t.stream.Send(tunnelData)
+}
+
+// Start - Add a tunnel to the core mapper
+func (t *tunnels) Start(tunnelID uint64, sessionID string) *TunnelIO {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	tunnel := NewTunnelIO(tunnelID, sessionID)
+
+	(*t.tunnels)[tunnelID] = tunnel
+
+	go func(tunnel *TunnelIO) {
+		tunnel.Open()
+		log.Printf("Tunnel now is open, %d", tunnelID)
+
+		for data := range tunnel.Send {
+			log.Printf("Send %d bytes on tunnel %d", len(data), tunnel.ID)
+
+			t.send(&sliverpb.TunnelData{
+				TunnelID:  tunnel.ID,
+				SessionID: tunnel.SessionID,
+				Data:      data,
+			})
+		}
+
+		log.Printf("Tunnel Send channel looks closed now. %d", tunnelID)
+	}(tunnel)
+
+	tunnel.Send <- make([]byte, 0) // Send "zero" message to bind client to tunnel
+	return tunnel
+}
+
+// Close - Close the tunnel channels
+func (t *tunnels) Close(tunnelID uint64) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	log.Printf("Closing tunnel %d", tunnelID)
+
+	tunnel := (*t.tunnels)[tunnelID]
+
+	if tunnel != nil {
+		tunnel.Close()
+
+		delete((*t.tunnels), tunnelID)
+	}
+}

--- a/implant/sliver/handlers/tun-handlers.go
+++ b/implant/sliver/handlers/tun-handlers.go
@@ -405,7 +405,7 @@ func portfwdReqHandler(envelope *sliverpb.Envelope, connection *transports.Conne
 			conn: connection,
 		}
 		n, err := io.Copy(tWriter, tunnel.Reader)
-
+		_ = n // avoid not used compiler error if debug mode is disabled
 		// {{if .Config.Debug}}
 		log.Printf("[tunnel] Tunnel done, wrote %v bytes", n)
 		// {{end}}

--- a/implant/sliver/shell/shell.go
+++ b/implant/sliver/shell/shell.go
@@ -32,10 +32,12 @@ type Shell struct {
 	Stdin   io.WriteCloser
 }
 
-// StartAndWait starts a system shell then waits for it to complete
-func (s *Shell) StartAndWait() {
-	s.Command.Start()
-	s.Command.Wait()
+func (s *Shell) Start() error {
+	return s.Command.Start()
+}
+
+func (s *Shell) Wait() error {
+	return s.Command.Wait()
 }
 
 func exists(path string) bool {

--- a/implant/sliver/shell/shell_generic.go
+++ b/implant/sliver/shell/shell_generic.go
@@ -42,11 +42,11 @@ func Start(command string) error {
 }
 
 // StartInteractive - Start a shell
-func StartInteractive(tunnelID uint64, command []string, _ bool) *Shell {
+func StartInteractive(tunnelID uint64, command []string, _ bool) (*Shell, error) {
 	return pipedShell(tunnelID, command)
 }
 
-func pipedShell(tunnelID uint64, command []string) *Shell {
+func pipedShell(tunnelID uint64, command []string) (*Shell, error) {
 	// {{if .Config.Debug}}
 	log.Printf("[shell] %s", command)
 	// {{end}}
@@ -57,14 +57,14 @@ func pipedShell(tunnelID uint64, command []string) *Shell {
 		// {{if .Config.Debug}}
 		log.Printf("[shell] stdin pipe failed\n")
 		// {{end}}
-		return nil
+		return nil, err
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		// {{if .Config.Debug}}
 		log.Printf("[shell] stdout pipe failed\n")
 		// {{end}}
-		return nil
+		return nil, err
 	}
 
 	return &Shell{
@@ -72,7 +72,7 @@ func pipedShell(tunnelID uint64, command []string) *Shell {
 		Command: cmd,
 		Stdout:  stdout,
 		Stdin:   stdin,
-	}
+	}, nil
 }
 
 // GetSystemShellPath - Find bash or sh

--- a/implant/sliver/shell/shell_windows.go
+++ b/implant/sliver/shell/shell_windows.go
@@ -61,11 +61,11 @@ func Start(command string) error {
 }
 
 // StartInteractive - Start a shell
-func StartInteractive(tunnelID uint64, command []string, _ bool) *Shell {
+func StartInteractive(tunnelID uint64, command []string, _ bool) (*Shell, error) {
 	return pipedShell(tunnelID, command)
 }
 
-func pipedShell(tunnelID uint64, command []string) *Shell {
+func pipedShell(tunnelID uint64, command []string) (*Shell, error) {
 	// {{if .Config.Debug}}
 	log.Printf("[shell] %s", command)
 	// {{end}}
@@ -84,5 +84,5 @@ func pipedShell(tunnelID uint64, command []string) *Shell {
 		Command: cmd,
 		Stdout:  stdout,
 		Stdin:   stdin,
-	}
+	}, nil
 }

--- a/implant/sliver/transports/session.go
+++ b/implant/sliver/transports/session.go
@@ -124,10 +124,49 @@ type Tunnel struct {
 	ID uint64
 
 	Reader       io.ReadCloser
-	ReadSequence uint64
+	readSequence uint64
 
 	Writer        io.WriteCloser
-	WriteSequence uint64
+	writeSequence uint64
+
+	mutex *sync.RWMutex
+}
+
+func NewTunnel(id uint64, reader io.ReadCloser, writer io.WriteCloser) *Tunnel {
+	return &Tunnel{
+		ID:     id,
+		Reader: reader,
+		Writer: writer,
+		mutex:  &sync.RWMutex{},
+	}
+}
+
+func (c *Tunnel) ReadSequence() uint64 {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	return c.readSequence
+}
+
+func (c *Tunnel) WriteSequence() uint64 {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	return c.writeSequence
+}
+
+func (c *Tunnel) IncReadSequence() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.readSequence += 1
+}
+
+func (c *Tunnel) IncWriteSequence() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.writeSequence += 1
 }
 
 // Tunnel - Add tunnel to mapping

--- a/implant/sliver/transports/session.go
+++ b/implant/sliver/transports/session.go
@@ -19,7 +19,6 @@ package transports
 */
 
 import (
-
 	// {{if or .Config.WGc2Enabled .Config.HTTPc2Enabled}}
 	"net"
 
@@ -373,6 +372,9 @@ func mtlsConnect(uri *url.URL) (*Connection, error) {
 					if !ok {
 						return
 					}
+					// {{if .Config.Debug}}
+					log.Printf("TRANSPORT MESSAGE: type (%d) - %s", envelope.Type, envelope.Data)
+					// {{end}}
 					err := mtls.WriteEnvelope(conn, envelope)
 					if err != nil {
 						return

--- a/server/core/connnection.go
+++ b/server/core/connnection.go
@@ -28,31 +28,44 @@ import (
 
 // ImplantConnection - Abstract connection to an implant
 type ImplantConnection struct {
-	ID            string
-	Send          chan *sliverpb.Envelope
-	RespMutex     *sync.RWMutex
-	Resp          map[int64]chan *sliverpb.Envelope
-	Transport     string
-	RemoteAddress string
-	LastMessage   time.Time
-	Cleanup       func()
+	ID               string
+	Send             chan *sliverpb.Envelope
+	RespMutex        *sync.RWMutex
+	LastMessageMutex *sync.RWMutex
+	Resp             map[int64]chan *sliverpb.Envelope
+	Transport        string
+	RemoteAddress    string
+	LastMessage      time.Time
+	Cleanup          func()
+}
+
+// GetLastMessage - Retrieves the last message time
+func (c *ImplantConnection) GetLastMessage() time.Time {
+	c.LastMessageMutex.RLock()
+	defer c.LastMessageMutex.RUnlock()
+
+	return c.LastMessage
 }
 
 // UpdateLastMessage - Updates the last message time
 func (c *ImplantConnection) UpdateLastMessage() {
+	c.LastMessageMutex.Lock()
+	defer c.LastMessageMutex.Unlock()
+
 	c.LastMessage = time.Now()
 }
 
 // NewImplantConnection - Creates a new implant connection
 func NewImplantConnection(transport string, remoteAddress string) *ImplantConnection {
 	return &ImplantConnection{
-		ID:            generateImplantConnectionID(),
-		Send:          make(chan *sliverpb.Envelope),
-		RespMutex:     &sync.RWMutex{},
-		Resp:          map[int64]chan *sliverpb.Envelope{},
-		Transport:     transport,
-		RemoteAddress: remoteAddress,
-		Cleanup:       func() {},
+		ID:               generateImplantConnectionID(),
+		Send:             make(chan *sliverpb.Envelope),
+		RespMutex:        &sync.RWMutex{},
+		LastMessageMutex: &sync.RWMutex{},
+		Resp:             map[int64]chan *sliverpb.Envelope{},
+		Transport:        transport,
+		RemoteAddress:    remoteAddress,
+		Cleanup:          func() {},
 	}
 }
 

--- a/server/core/sessions.go
+++ b/server/core/sessions.go
@@ -76,13 +76,13 @@ type Session struct {
 
 // LastCheckin - Get the last time a session message was received
 func (s *Session) LastCheckin() time.Time {
-	return s.Connection.LastMessage
+	return s.Connection.GetLastMessage()
 }
 
 // IsDead - See if last check-in is within expected variance
 func (s *Session) IsDead() bool {
 	sessionsLog.Debugf("Checking health of %s", s.ID)
-	sessionsLog.Debugf("Last checkin was %v", s.Connection.LastMessage)
+	sessionsLog.Debugf("Last checkin was %v", s.LastCheckin())
 	padding := time.Duration(10 * time.Second) // Arbitrary margin of error
 	timePassed := time.Since(s.LastCheckin())
 	reconnect := time.Duration(s.ReconnectInterval)
@@ -104,7 +104,7 @@ func (s *Session) IsDead() bool {
 		}
 	}
 	if s.Connection.Transport == "pivot" {
-		if time.Since(s.Connection.LastMessage) < time.Duration(time.Minute)+padding {
+		if time.Since(s.Connection.GetLastMessage()) < time.Duration(time.Minute)+padding {
 			sessionsLog.Debugf("Last message within pivot/server ping interval with padding")
 			return false
 		}

--- a/server/core/tunnels.go
+++ b/server/core/tunnels.go
@@ -111,6 +111,7 @@ func (t *tunnels) Close(tunnelID uint64) error {
 func (t *tunnels) Get(tunnelID uint64) *Tunnel {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
+
 	return t.tunnels[tunnelID]
 }
 

--- a/server/core/tunnels.go
+++ b/server/core/tunnels.go
@@ -23,6 +23,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/bishopfox/sliver/protobuf/rpcpb"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
@@ -40,6 +41,12 @@ var (
 	ErrInvalidTunnelID = errors.New("invalid tunnel ID")
 )
 
+const (
+	// delayBeforeClose - delay before closing the tunnel.
+	// I assume 10 seconds may be an overkill for a good connection, but it looks good enough for less stable one.
+	delayBeforeClose = 10 * time.Second
+)
+
 // Tunnel  - Essentially just a mapping between a specific client and sliver
 // with an identifier, these tunnels are full duplex. The server doesn't really
 // care what data gets passed back and forth it just facilitates the connection
@@ -54,6 +61,43 @@ type Tunnel struct {
 	FromImplantSequence uint64
 
 	Client rpcpb.SliverRPC_TunnelDataServer
+
+	mutex               *sync.RWMutex
+	lastDataMessageTime time.Time
+}
+
+func NewTunnel(id uint64, sessionID string) *Tunnel {
+	return &Tunnel{
+		ID:          id,
+		SessionID:   sessionID,
+		ToImplant:   make(chan []byte),
+		FromImplant: make(chan *sliverpb.TunnelData),
+
+		mutex:               &sync.RWMutex{},
+		lastDataMessageTime: time.Now(), // need to be initialized
+	}
+}
+
+func (t *Tunnel) setLastMessageTime() {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	t.lastDataMessageTime = time.Now()
+}
+
+func (t *Tunnel) GetLastMessageTime() time.Time {
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
+
+	return t.lastDataMessageTime
+}
+
+func (t *Tunnel) SendDataFromImplant(tunnelData *sliverpb.TunnelData) {
+	// Setting the date right before and right after message, since channel can be blocked for some amount of time
+	t.setLastMessageTime()
+	defer t.setLastMessageTime()
+
+	t.FromImplant <- tunnelData
 }
 
 type tunnels struct {
@@ -64,12 +108,12 @@ type tunnels struct {
 func (t *tunnels) Create(sessionID string) *Tunnel {
 	tunnelID := NewTunnelID()
 	session := Sessions.Get(sessionID)
-	tunnel := &Tunnel{
-		ID:          tunnelID,
-		SessionID:   session.ID,
-		ToImplant:   make(chan []byte),
-		FromImplant: make(chan *sliverpb.TunnelData),
-	}
+
+	tunnel := NewTunnel(
+		tunnelID,
+		session.ID,
+	)
+
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 	t.tunnels[tunnel.ID] = tunnel
@@ -77,6 +121,37 @@ func (t *tunnels) Create(sessionID string) *Tunnel {
 	return tunnel
 }
 
+// ScheduleClose - schedules a close for tunnel, must be called as routine.
+// will close it once there is no data for at least delayBeforeClose delay since last message
+// This is _necessary_ since we processing messages asynchronously
+// and if tunnelCloseHandler routine will fire before tunnelDataHandler routine we will lose some data
+// (this is what happends for socks and portfwd)
+// There is no another way around it, if we want to stick to async processing as we do now.
+// All additional changes requires changes on implants(like sequencing for close messages),
+// and as there is a goal to keep compatability we don't do that at the moment.
+func (t *tunnels) ScheduleClose(tunnelID uint64) {
+	tunnel := t.Get(tunnelID)
+	if tunnel == nil {
+		return
+	}
+
+	timeDelta := time.Now().Sub(tunnel.GetLastMessageTime())
+
+	coreLog.Printf("Scheduled close for channel %d (delta: %v)", tunnelID, timeDelta)
+
+	if timeDelta >= delayBeforeClose {
+		coreLog.Printf("Closing channel %d", tunnelID)
+		t.Close(tunnelID)
+	} else {
+		// Reschedule
+		coreLog.Printf("Rescheduling closing channel %d", tunnelID)
+		time.Sleep(delayBeforeClose - timeDelta + time.Second)
+		go t.ScheduleClose(tunnelID)
+	}
+}
+
+// Close - closing tunnel
+// It's prefered to use ScheduleClose function if you don't 100% sure there is no more data to receive
 func (t *tunnels) Close(tunnelID uint64) error {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()

--- a/server/core/tunnels.go
+++ b/server/core/tunnels.go
@@ -129,6 +129,8 @@ func (t *tunnels) Create(sessionID string) *Tunnel {
 // There is no another way around it, if we want to stick to async processing as we do now.
 // All additional changes requires changes on implants(like sequencing for close messages),
 // and as there is a goal to keep compatability we don't do that at the moment.
+// So there is trade off - more stability or more speed. Or rewriting implant logic.
+// At the moment, i see it affects only `shell` command and locking it for 10 seconds on exit. Not a big deal.
 func (t *tunnels) ScheduleClose(tunnelID uint64) {
 	tunnel := t.Get(tunnelID)
 	if tunnel == nil {

--- a/server/gogo/go.go
+++ b/server/gogo/go.go
@@ -190,6 +190,7 @@ func GoBuild(config GoConfig, src string, dest string, buildmode string, tags []
 		return nil, fmt.Errorf(fmt.Sprintf("Invalid compiler target: %s", target))
 	}
 	var goCommand = []string{"build"}
+
 	if 0 < len(trimpath) {
 		goCommand = append(goCommand, trimpath)
 	}

--- a/server/handlers/beacons.go
+++ b/server/handlers/beacons.go
@@ -125,7 +125,7 @@ func beaconTasksHandler(implantConn *core.ImplantConnection, data []byte) *slive
 		return nil
 	}
 	go func() {
-		err = db.UpdateBeaconCheckinByID(beaconTasks.ID, beaconTasks.NextCheckin)
+		err := db.UpdateBeaconCheckinByID(beaconTasks.ID, beaconTasks.NextCheckin)
 		if err != nil {
 			beaconHandlerLog.Errorf("failed to update checkin: %s", err)
 		}

--- a/server/handlers/beacons.go
+++ b/server/handlers/beacons.go
@@ -74,7 +74,7 @@ func beaconRegisterHandler(implantConn *core.ImplantConnection, data []byte) *sl
 	beacon.RemoteAddress = implantConn.RemoteAddress
 	beacon.PID = beaconReg.Register.Pid
 	beacon.Filename = beaconReg.Register.Filename
-	beacon.LastCheckin = implantConn.LastMessage
+	beacon.LastCheckin = implantConn.GetLastMessage()
 	beacon.Version = beaconReg.Register.Version
 	beacon.ReconnectInterval = beaconReg.Register.ReconnectInterval
 	beacon.ActiveC2 = beaconReg.Register.ActiveC2

--- a/server/rpc/rpc-tunnel.go
+++ b/server/rpc/rpc-tunnel.go
@@ -21,6 +21,7 @@ package rpc
 import (
 	"context"
 	"io"
+	"sync"
 
 	"github.com/bishopfox/sliver/protobuf/commonpb"
 	"github.com/bishopfox/sliver/protobuf/rpcpb"
@@ -34,11 +35,58 @@ var (
 	tunnelLog = log.NamedLogger("rpc", "tunnel")
 
 	// SessionID->Tunnels[TunnelID]->Tunnel->Cache
-	toImplantCache = map[uint64]map[uint64]*sliverpb.TunnelData{}
+	toImplantCache = dataCache{mutex: &sync.RWMutex{}, cache: map[uint64]map[uint64]*sliverpb.TunnelData{}}
 
 	// SessionID->Tunnels[TunnelID]->Tunnel->Cache
-	fromImplantCache = map[uint64]map[uint64]*sliverpb.TunnelData{}
+	fromImplantCache = dataCache{mutex: &sync.RWMutex{}, cache: map[uint64]map[uint64]*sliverpb.TunnelData{}}
 )
+
+type dataCache struct {
+	mutex *sync.RWMutex
+	cache map[uint64]map[uint64]*sliverpb.TunnelData
+}
+
+func (c *dataCache) Add(tunnelID uint64, sequence uint64, tunnelData *sliverpb.TunnelData) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if _, ok := c.cache[tunnelID]; !ok {
+		c.cache[tunnelID] = map[uint64]*sliverpb.TunnelData{}
+	}
+
+	c.cache[tunnelID][sequence] = tunnelData
+}
+
+func (c *dataCache) Get(tunnelID uint64, sequence uint64) (*sliverpb.TunnelData, bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	if _, ok := c.cache[tunnelID]; !ok {
+		return nil, false
+	}
+
+	val, ok := c.cache[tunnelID][sequence]
+
+	return val, ok
+}
+
+func (c *dataCache) DeleteTun(tunnelID uint64) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	delete(c.cache, tunnelID)
+}
+
+func (c *dataCache) DeleteSeq(tunnelID uint64, sequence uint64) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if _, ok := c.cache[tunnelID]; !ok {
+		return
+	}
+
+	delete(c.cache[tunnelID], sequence)
+}
 
 // CreateTunnel - Create a new tunnel on the server, however based on only this request there's
 //                no way to associate the tunnel with the correct client, so the client must send
@@ -52,8 +100,6 @@ func (s *Server) CreateTunnel(ctx context.Context, req *sliverpb.Tunnel) (*slive
 	if tunnel == nil {
 		return nil, ErrTunnelInitFailure
 	}
-	toImplantCache[tunnel.ID] = map[uint64]*sliverpb.TunnelData{}
-	fromImplantCache[tunnel.ID] = map[uint64]*sliverpb.TunnelData{}
 	return &sliverpb.Tunnel{
 		SessionID: session.ID,
 		TunnelID:  tunnel.ID,
@@ -63,8 +109,8 @@ func (s *Server) CreateTunnel(ctx context.Context, req *sliverpb.Tunnel) (*slive
 // CloseTunnel - Client requests we close a tunnel
 func (s *Server) CloseTunnel(ctx context.Context, req *sliverpb.Tunnel) (*commonpb.Empty, error) {
 	err := core.Tunnels.Close(req.TunnelID)
-	delete(toImplantCache, req.TunnelID)
-	delete(fromImplantCache, req.TunnelID)
+	toImplantCache.DeleteTun(req.TunnelID)
+	fromImplantCache.DeleteTun(req.TunnelID)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +146,6 @@ func (s *Server) TunnelData(stream rpcpb.SliverRPC_TunnelDataServer) error {
 
 			go func() {
 
-				sendCache := toImplantCache[tunnel.ID]
 				for tunnelData := range tunnel.FromImplant {
 
 					tunnelLog.Debugf("Tunnel %d: From implant %d byte(s), seq: %d ack: %d",
@@ -110,30 +155,28 @@ func (s *Server) TunnelData(stream rpcpb.SliverRPC_TunnelDataServer) error {
 					if !tunnelData.Resend {
 
 						index := tunnelData.Ack - 1
-						for sendMsg, ok := sendCache[index]; ok; sendMsg, ok = sendCache[index] {
+						for sendMsg, ok := toImplantCache.Get(tunnel.ID, index); ok; sendMsg, ok = toImplantCache.Get(tunnel.ID, index) {
 							tunnelLog.Debugf("Tunnel %d: Removing ack: %d from send cache", tunnel.ID, sendMsg.Sequence)
-							delete(sendCache, index)
+							toImplantCache.DeleteSeq(tunnel.ID, index)
 							index = index - 1
 						}
 
-						recvCache, ok := fromImplantCache[tunnel.ID]
-						if ok {
-							recvCache[tunnelData.Sequence] = tunnelData
-						}
-						for recv, ok := recvCache[tunnel.FromImplantSequence]; ok; recv, ok = recvCache[tunnel.FromImplantSequence] {
+						fromImplantCache.Add(tunnel.ID, tunnelData.Sequence, tunnelData)
+
+						for recv, ok := fromImplantCache.Get(tunnel.ID, tunnel.FromImplantSequence); ok; recv, ok = fromImplantCache.Get(tunnel.ID, tunnel.FromImplantSequence) {
 							tunnel.Client.Send(&sliverpb.TunnelData{
 								TunnelID:  tunnel.ID,
 								SessionID: tunnel.SessionID,
 								Data:      recv.Data,
 								Closed:    false,
 							})
-							delete(recvCache, tunnel.FromImplantSequence)
+							fromImplantCache.DeleteSeq(tunnel.ID, tunnel.FromImplantSequence)
 							tunnel.FromImplantSequence++
 						}
 
 					} else {
 
-						origtunnelData, ok := sendCache[tunnelData.Ack]
+						origtunnelData, ok := toImplantCache.Get(tunnel.ID, tunnelData.Ack)
 						if ok {
 							tunnelLog.Debugf("Tunnel %d: Resending cached msg: %d", tunnel.ID, tunnelData.Ack)
 							session := core.Sessions.Get(tunnel.SessionID)
@@ -163,7 +206,6 @@ func (s *Server) TunnelData(stream rpcpb.SliverRPC_TunnelDataServer) error {
 
 			go func() {
 				session := core.Sessions.Get(tunnel.SessionID)
-				sendCache := toImplantCache[tunnel.ID]
 				for data := range tunnel.ToImplant {
 					tunnelLog.Debugf("Tunnel %d: To implant %d byte(s), seq: %d", tunnel.ID, len(data), tunnel.ToImplantSequence)
 					tunnelData := sliverpb.TunnelData{
@@ -174,7 +216,7 @@ func (s *Server) TunnelData(stream rpcpb.SliverRPC_TunnelDataServer) error {
 						Closed:    false,
 					}
 					// Add tunnel data to cache
-					sendCache[tunnelData.Sequence] = &tunnelData
+					toImplantCache.Add(tunnel.ID, tunnelData.Sequence, &tunnelData)
 
 					data, _ := proto.Marshal(&tunnelData)
 					tunnel.ToImplantSequence++

--- a/server/rpc/rpc-tunnel.go
+++ b/server/rpc/rpc-tunnel.go
@@ -108,12 +108,10 @@ func (s *Server) CreateTunnel(ctx context.Context, req *sliverpb.Tunnel) (*slive
 
 // CloseTunnel - Client requests we close a tunnel
 func (s *Server) CloseTunnel(ctx context.Context, req *sliverpb.Tunnel) (*commonpb.Empty, error) {
-	err := core.Tunnels.Close(req.TunnelID)
+	go core.Tunnels.ScheduleClose(req.TunnelID)
 	toImplantCache.DeleteTun(req.TunnelID)
 	fromImplantCache.DeleteTun(req.TunnelID)
-	if err != nil {
-		return nil, err
-	}
+
 	return &commonpb.Empty{}, nil
 }
 


### PR DESCRIPTION
Well, this is a big one. 
My first thought was to make few improvements here and there, but here we are. I did my best to split fixes in different commits, so it can be cherry-picked one by one without breaking anything(i guess) and added comments where it's necessary, so i guess it's may be better to review it commit by commit.

### First of all
Compatibility saved. Old server works with new implants, old implants works with new server.
My focus was on stability of `shell`, `socks5`, `portfwd` and `pivots` functions. I assume there are still may be things to do for other features, but mentioned above just needed for me the most.

### This PR likely solves this issues:
- https://github.com/BishopFox/sliver/issues/545
- https://github.com/BishopFox/sliver/issues/651
- https://github.com/BishopFox/sliver/issues/688 (highly unsure about that, since i don't find a right way to reproduce it, but test server now running my pivoted session for a few hours, so fingers crossed. I guess i can be related to https://github.com/BishopFox/sliver/commit/f7633bbb9ed7a6b5683fac99479019529d5fee9c)

### In general:
- resolved all race conditions i was able to found (using `-race` while building client-server and implants)
- improve tunnels handling:
- resolve caching race conditions
- resolve issue when tunnel may be closed before it received data https://github.com/BishopFox/sliver/commit/f7633bbb9ed7a6b5683fac99479019529d5fee9c (well, in some way. Looks about right for now, but it indeed needs to be rethinked)
- socks5 now works like a charm and doesn't crash anything
- same for portfwd
- more logs added

### Test setup:
- x64 linux machine
- mtls connection (i assume fixes will also works for different transports, i just not tested them)

