### PR TITLE
Fix pivots not synced

### DIFF
--- a/implant/sliver/handlers/pivot-handlers.go
+++ b/implant/sliver/handlers/pivot-handlers.go
@@ -111,6 +111,7 @@ func pivotStopListenerHandler(envelope *pb.Envelope, connection *transports.Conn
 		return
 	}
 	pivots.StopListener(req.ID)
+	pivots.RemoveListener(req.ID)
 	connection.Send <- &pb.Envelope{
 		ID:   envelope.ID,
 		Data: []byte{},

--- a/implant/sliver/pivots/pivots.go
+++ b/implant/sliver/pivots/pivots.go
@@ -114,6 +114,7 @@ func RestartAllListeners(send chan<- *pb.Envelope) {
 				// {{if .Config.Debug}}
 				log.Printf("[pivot] failed to restart listener: %s", err)
 				// {{end}}
+				return false
 			}
 			go listener.Start()
 			AddListener(listener)


### PR DESCRIPTION
I noticed when you are playing with `pivots` it's not syncing up the state, eg:

1. `pivots tcp`
2. `pivots`
3. [server] sliver (testp2) > pivots

```
 ID   Protocol   Bind Address   Number Of Pivots
==== ========== ============== ==================
  1   TCP        :9898                         0
```
4. `pivots stop -i 1`
5. `pivots`
6. [server] sliver (testp2) > pivots

```
 ID   Protocol   Bind Address   Number Of Pivots
==== ========== ============== ==================
  1   TCP        :9898                         0
```
7. It should not show any pivots running. 


Unfortunately this bug in the implant code, so it required to regenerate it to make it work as expected. Anyway, still don't breaking any compatibility. 

Also fixed issue when implant may panic once it reconnects to server with previously enabled pivots (eg. server was down for some time).