### PR TITLE
Fix panic on beacon session interactive mode

### DIFF
--- a/implant/sliver/pivots/pivots.go
+++ b/implant/sliver/pivots/pivots.go
@@ -121,7 +121,7 @@ func RestartAllListeners(send chan<- *pb.Envelope) {
 		}
 		return true
 	})
-	stoppedPivotListeners = nil
+	stoppedPivotListeners = &sync.Map{}
 }
 
 // StopAllListeners - Stop all pivot listeners


### PR DESCRIPTION
If you called for `interactive` mode twice, there is a chance it will panic. Now it's not.
