### PR TITLE
Fix regression: add back IP forwarding for wireguard tunnels.

### DIFF
--- a/server/netstack/tun.go
+++ b/server/netstack/tun.go
@@ -141,9 +141,17 @@ func CreateNetTUN(localAddresses, dnsServers []netip.Addr, mtu int) (tun.Device,
 	}
 	if dev.hasV4 {
 		dev.stack.AddRoute(tcpip.Route{Destination: header.IPv4EmptySubnet, NIC: 1})
+		tcpipErr = dev.stack.SetForwardingDefaultAndAllNICs(header.IPv4ProtocolNumber, true)
+		if tcpipErr != nil {
+			return nil, nil, fmt.Errorf("SetForwarding(): %v", tcpipErr)
+		}
 	}
 	if dev.hasV6 {
 		dev.stack.AddRoute(tcpip.Route{Destination: header.IPv6EmptySubnet, NIC: 1})
+		tcpipErr = dev.stack.SetForwardingDefaultAndAllNICs(header.IPv6ProtocolNumber, true)
+		if tcpipErr != nil {
+			return nil, nil, fmt.Errorf("SetForwarding(): %v", tcpipErr)
+		}
 	}
 
 	dev.events <- tun.EventUp


### PR DESCRIPTION
Fix regression introduced by 53afb01366dcb65cfe31eca9d86d0775b7cf7431 that broke `wg-socks` and `wg-portfwd` commands.