### PR TITLE
Fix argument parsing in execute-assembly to remove trailing spaces

### DIFF
--- a/client/command/alias/load.go
+++ b/client/command/alias/load.go
@@ -269,6 +269,8 @@ func runAliasCommand(ctx *grumble.Context, con *console.SliverConsoleClient) {
 	} else {
 		extArgs = strings.Join(args, " ")
 	}
+
+	extArgs = strings.TrimSpace(extArgs)
 	entryPoint := aliasManifest.Entrypoint
 	processName := ctx.Flags.String("process")
 	if processName == "" {

--- a/client/command/exec/execute-assembly.go
+++ b/client/command/exec/execute-assembly.go
@@ -58,13 +58,16 @@ func ExecuteAssemblyCmd(ctx *grumble.Context, con *console.SliverConsoleClient) 
 	assemblyArgs := ctx.Args.StringList("arguments")
 	process := ctx.Flags.String("process")
 
+	assemblyArgsStr := strings.Join(assemblyArgs, " ")
+	assemblyArgsStr = strings.TrimSpace(assemblyArgsStr)
+
 	ctrl := make(chan bool)
 	con.SpinUntil("Executing assembly ...", ctrl)
 	execAssembly, err := con.Rpc.ExecuteAssembly(context.Background(), &sliverpb.ExecuteAssemblyReq{
 		Request:   con.ActiveTarget.Request(ctx),
 		IsDLL:     isDLL,
 		Process:   process,
-		Arguments: strings.Join(assemblyArgs, " "),
+		Arguments: assemblyArgsStr,
 		Assembly:  assemblyBytes,
 		Arch:      ctx.Flags.String("arch"),
 		Method:    ctx.Flags.String("method"),


### PR DESCRIPTION
Fix #720 