### PR TITLE
Allow additional characters in implant, session, and beacon names

### DIFF
--- a/client/command/generate/generate.go
+++ b/client/command/generate/generate.go
@@ -29,7 +29,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 
@@ -39,6 +38,7 @@ import (
 	"github.com/bishopfox/sliver/client/console"
 	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/bishopfox/sliver/protobuf/commonpb"
+	"github.com/bishopfox/sliver/util"
 	"github.com/desertbit/grumble"
 )
 
@@ -167,12 +167,9 @@ func parseCompileFlags(ctx *grumble.Context, con *console.SliverConsoleClient) *
 	if ctx.Flags["name"] != nil {
 		name = strings.ToLower(ctx.Flags.String("name"))
 
-		if name != "" {
-			isAlphanumeric := regexp.MustCompile(`^[[:alnum:]]+$`).MatchString
-			if !isAlphanumeric(name) {
-				con.PrintErrorf("Implant's name must be in alphanumeric only\n")
-				return nil
-			}
+		if err := util.AllowedName(name); err != nil {
+			con.PrintErrorf("%s\n", err)
+			return nil
 		}
 	}
 

--- a/client/command/reconfig/rename.go
+++ b/client/command/reconfig/rename.go
@@ -20,10 +20,9 @@ package reconfig
 
 import (
 	"context"
-	"regexp"
-
 	"github.com/bishopfox/sliver/client/console"
 	"github.com/bishopfox/sliver/protobuf/clientpb"
+	"github.com/bishopfox/sliver/util"
 	"github.com/desertbit/grumble"
 )
 
@@ -36,12 +35,9 @@ func RenameCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 
 	// Option to change the agent name
 	name := ctx.Flags.String("name")
-	if name != "" {
-		isAlphanumeric := regexp.MustCompile(`^[[:alnum:]]+$`).MatchString
-		if !isAlphanumeric(name) {
-			con.PrintErrorf("Name must be in alphanumeric only\n")
-			return
-		}
+	if err := util.AllowedName(name); err != nil {
+		con.PrintErrorf("%s\n", err)
+		return
 	}
 
 	var beaconID string

--- a/server/generate/binaries.go
+++ b/server/generate/binaries.go
@@ -29,7 +29,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"text/template"
@@ -194,18 +193,10 @@ func ImplantConfigFromProtobuf(pbConfig *clientpb.ImplantConfig) (string, *model
 	}
 
 	name := ""
-	if pbConfig.Name != "" {
-		// allow for alphanumeric, periods, dashes, and underscores in name
-		isAllowed := regexp.MustCompile(`^[[:alnum:]\.\-_]+$`).MatchString
-		// do not allow for files ".", "..", or anything starting with ".."
-		additionalDeny := regexp.MustCompile(`^\.\.|^\.$`).MatchString
-		if !isAllowed(pbConfig.Name) {
-			buildLog.Warnf("Name must be alphanumeric or .-_ only\n")
-		} else if additionalDeny(pbConfig.Name) {
-			buildLog.Warnf("Name cannot be \".\", \"..\", or start with \"..\"")
-		} else {
-			name = pbConfig.Name
-		}
+	if err := util.AllowedName(pbConfig.Name); err != nil {
+		buildLog.Warnf("%s\n", err)
+	} else {
+		name = pbConfig.Name
 	}
 	return name, cfg
 }

--- a/server/generate/binaries.go
+++ b/server/generate/binaries.go
@@ -195,8 +195,15 @@ func ImplantConfigFromProtobuf(pbConfig *clientpb.ImplantConfig) (string, *model
 
 	name := ""
 	if pbConfig.Name != "" {
-		// Only allow user-provided alpha/numeric names
-		if regexp.MustCompile(`^[[:alnum:]]+$`).MatchString(pbConfig.Name) {
+		// allow for alphanumeric, periods, dashes, and underscores in name
+		isAllowed := regexp.MustCompile(`^[[:alnum:]\.\-_]+$`).MatchString
+		// do not allow for files ".", "..", or anything starting with ".."
+		additionalDeny := regexp.MustCompile(`^\.\.|^\.$`).MatchString
+		if !isAllowed(pbConfig.Name) {
+			buildLog.Warnf("Name must be alphanumeric or .-_ only\n")
+		} else if additionalDeny(pbConfig.Name) {
+			buildLog.Warnf("Name cannot be \".\", \"..\", or start with \"..\"")
+		} else {
 			name = pbConfig.Name
 		}
 	}

--- a/server/rpc/errors.go
+++ b/server/rpc/errors.go
@@ -40,5 +40,5 @@ var (
 	ErrDatabaseFailure = status.Error(codes.Internal, "Database operation failed")
 
 	// ErrInvalidName - Invalid name
-	ErrInvalidName = status.Error(codes.InvalidArgument, "Invalid session name, alphanumerics only")
+	ErrInvalidName = status.Error(codes.InvalidArgument, "Invalid session name, alphanumerics and _-. only")
 )

--- a/server/rpc/rpc-reconfig.go
+++ b/server/rpc/rpc-reconfig.go
@@ -20,13 +20,12 @@ package rpc
 
 import (
 	"context"
-	"regexp"
-
 	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/bishopfox/sliver/protobuf/commonpb"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
 	"github.com/bishopfox/sliver/server/core"
 	"github.com/bishopfox/sliver/server/db"
+	"github.com/bishopfox/sliver/util"
 )
 
 const maxNameLength = 32
@@ -56,7 +55,7 @@ func (rpc *Server) Rename(ctx context.Context, req *clientpb.RenameReq) (*common
 	if len(req.Name) < 1 || maxNameLength < len(req.Name) {
 		return resp, ErrInvalidName
 	}
-	if !regexp.MustCompile(`^[[:alnum:]]+$`).MatchString(req.Name) {
+	if err := util.AllowedName(req.Name); err != nil {
 		return resp, ErrInvalidName
 	}
 

--- a/util/implant.go
+++ b/util/implant.go
@@ -1,0 +1,42 @@
+package util
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2019  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"errors"
+	"regexp"
+)
+
+func AllowedName(name string) error {
+	if name != "" {
+		// allow for alphanumeric, periods, dashes, and underscores in name
+		isAllowed := regexp.MustCompile(`^[[:alnum:]\.\-_]+$`).MatchString
+		// do not allow for files ".", "..", or anything starting with ".."
+		additionalDeny := regexp.MustCompile(`^\.\.|^\.$`).MatchString
+		if !isAllowed(name) {
+			return errors.New("Name must be alphanumeric or .-_ only\n")
+		} else if additionalDeny(name) {
+			return errors.New("Name cannot be \".\", \"..\", or start with \"..\"")
+		} else {
+			return nil
+		}
+	} else {
+		return errors.New("Name cannot be blank!")
+	}
+}

--- a/util/implant_test.go
+++ b/util/implant_test.go
@@ -1,0 +1,40 @@
+package util
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2019  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"testing"
+)
+
+func TestAllowedName(t *testing.T) {
+	notAllowed := [3]string{".", "..", "..test"}
+	isAllowed := [6]string{"test", "testing_string", "testing.string", "testing-string", "testing..string", "test.."}
+
+	for i := 0; i < len(notAllowed); i++ {
+		if err := AllowedName(notAllowed[i]); err == nil {
+			t.Fatalf("failed to deny non allowed implant name")
+		}
+	}
+	for i := 0; i < len(isAllowed); i++ {
+		if err := AllowedName(isAllowed[i]); err != nil {
+			t.Fatalf("failed to allow allowed implant name")
+		}
+	}
+
+}


### PR DESCRIPTION
#### Card
#735 & #738

#### Details
Allows additional characters (underscores, dashes, and periods) in implant/session/beacon names, as well as restricts ./../..etc since the implant name is used in folder creation.
Also moved the client side check to a single place in the util code, and included tests.

![image](https://user-images.githubusercontent.com/1518719/178127208-c8dc731b-1259-43fb-a3fa-690b1dc445e8.png)
(lab IPs)
![image](https://user-images.githubusercontent.com/1518719/178127805-4a039de5-96c7-4595-b0be-a298b0f821b1.png)