### PR TITLE
Add missing `--name` flag for beacon profiles

### DIFF
--- a/client/command/commands.go
+++ b/client/command/commands.go
@@ -1523,6 +1523,7 @@ func BindCommands(con *console.SliverConsoleClient) {
 
 			f.String("c", "canary", "", "canary domain(s)")
 
+			f.String("N", "name", "", "implant name")
 			f.String("m", "mtls", "", "mtls connection strings")
 			f.String("g", "wg", "", "wg connection strings")
 			f.String("b", "http", "", "http(s) connection strings")


### PR DESCRIPTION
Fix #785 
