### PR TITLE
WIP: HTTP Proxy Egress Strategies

### DIFF
--- a/implant/sliver/transports/httpclient/drivers_generic.go
+++ b/implant/sliver/transports/httpclient/drivers_generic.go
@@ -40,3 +40,7 @@ func GetHTTPDriver(origin string, secure bool, opts *HTTPOptions) (HTTPDriver, e
 		return GoHTTPDriver(origin, secure, opts)
 	}
 }
+
+func getHTTPClientDriverOptions(opts *HTTPOptions) []func(string, bool, *HTTPOptions) (HTTPDriver, error) {
+	return []func(string, bool, *HTTPOptions) (HTTPDriver, error){GoHTTPDriver}
+}

--- a/implant/sliver/transports/httpclient/drivers_generic.go
+++ b/implant/sliver/transports/httpclient/drivers_generic.go
@@ -22,14 +22,12 @@ import "net/url"
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-// {{if .Config.Debug}}
-
-// {{end}}
-
+// getHTTPClientDriverOptions returns a list of HTTP driver types to try for SliverHTTPClient generation on non-windows machines
 func getHTTPClientDriverOptions(opts *HTTPOptions) []HTTPDriverType {
 	return []HTTPDriverType{GoHTTPDriverType}
 }
 
+// GetImpl returns a function that builds the HTTPDriver of type d
 func (d HTTPDriverType) GetImpl() func(string, bool, *url.URL, *HTTPOptions) (HTTPDriver, error) {
 	return GoHTTPDriver
 }

--- a/implant/sliver/transports/httpclient/drivers_generic.go
+++ b/implant/sliver/transports/httpclient/drivers_generic.go
@@ -2,6 +2,8 @@
 
 package httpclient
 
+import "net/url"
+
 /*
 	Sliver Implant Framework
 	Copyright (C) 2019  Bishop Fox
@@ -20,27 +22,14 @@ package httpclient
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import (
-	// {{if .Config.Debug}}
-	"log"
-	// {{end}}
-)
+// {{if .Config.Debug}}
 
-// GetHTTPDriver - Get an instance of the specified HTTP driver
-func GetHTTPDriver(origin string, secure bool, opts *HTTPOptions) (HTTPDriver, error) {
-	switch opts.Driver {
+// {{end}}
 
-	case goHTTPDriver:
-		return GoHTTPDriver(origin, secure, opts)
-
-	default:
-		// {{if .Config.Debug}}
-		log.Printf("WARNING: unknown HTTP driver: %s", opts.Driver)
-		// {{end}}
-		return GoHTTPDriver(origin, secure, opts)
-	}
+func getHTTPClientDriverOptions(opts *HTTPOptions) []HTTPDriverType {
+	return []HTTPDriverType{GoHTTPDriverType}
 }
 
-func getHTTPClientDriverOptions(opts *HTTPOptions) []func(string, bool, *HTTPOptions) (HTTPDriver, error) {
-	return []func(string, bool, *HTTPOptions) (HTTPDriver, error){GoHTTPDriver}
+func (d HTTPDriverType) GetImpl() func(string, bool, *url.URL, *HTTPOptions) (HTTPDriver, error) {
+	return GoHTTPDriver
 }

--- a/implant/sliver/transports/httpclient/drivers_windows.go
+++ b/implant/sliver/transports/httpclient/drivers_windows.go
@@ -61,3 +61,22 @@ func WininetDriver(origin string, secure bool, opts *HTTPOptions) (HTTPDriver, e
 	wininetClient.AskProxyCreds = opts.AskProxyCreds
 	return wininetClient, nil
 }
+
+func getHTTPClientDriverOptions(opts *HTTPOptions) []func(string, bool, *HTTPOptions) (HTTPDriver, error) {
+	var drivers []func(string, bool, *HTTPOptions) (HTTPDriver, error)
+
+	switch opts.Driver {
+
+	case goHTTPDriver:
+		drivers = append(drivers, GoHTTPDriver)
+
+	case wininetDriver:
+		drivers = append(drivers, WininetDriver)
+
+	default:
+		drivers = append(drivers, WininetDriver)
+		drivers = append(drivers, GoHTTPDriver)
+	}
+
+	return drivers
+}

--- a/implant/sliver/transports/httpclient/drivers_windows.go
+++ b/implant/sliver/transports/httpclient/drivers_windows.go
@@ -41,6 +41,7 @@ func WininetDriver(origin string, secure bool, proxyURL *url.URL, opts *HTTPOpti
 	return wininetClient, nil
 }
 
+// getHTTPClientDriverOptions returns a list of HTTP driver types to try for SliverHTTPClient generation on Windows
 func getHTTPClientDriverOptions(opts *HTTPOptions) []HTTPDriverType {
 	var drivers []HTTPDriverType
 
@@ -60,6 +61,7 @@ func getHTTPClientDriverOptions(opts *HTTPOptions) []HTTPDriverType {
 	return drivers
 }
 
+// GetImpl returns a function that builds the HTTPDriver of type d
 func (d HTTPDriverType) GetImpl() func(string, bool, *url.URL, *HTTPOptions) (HTTPDriver, error) {
 	switch d {
 	case WininetHTTPDriverType:

--- a/implant/sliver/transports/httpclient/gohttp.go
+++ b/implant/sliver/transports/httpclient/gohttp.go
@@ -27,10 +27,6 @@ import (
 	"sync"
 	"time"
 
-	// {{if .Config.Debug}}
-
-	// {{end}}
-
 	"github.com/bishopfox/sliver/implant/sliver/proxy"
 )
 
@@ -61,7 +57,7 @@ func GoHTTPDriver(origin string, secure bool, proxyURL *url.URL, opts *HTTPOptio
 	}
 	if proxyURL != nil {
 		// {{if .Config.Debug}}
-		log.Printf("[GoHTTPDriver] using proxy: %s", proxyURL)
+		log.Printf("[http] GoHTTPDriver using proxy: %s", proxyURL)
 		// {{end}}
 
 		transport.Proxy = http.ProxyURL(proxyURL)

--- a/implant/sliver/transports/httpclient/gohttp.go
+++ b/implant/sliver/transports/httpclient/gohttp.go
@@ -20,12 +20,15 @@ package httpclient
 
 import (
 	"crypto/tls"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
+
+	// {{if .Config.Debug}}
+	"log"
+	// {{end}}
 
 	"github.com/bishopfox/sliver/implant/sliver/proxy"
 )

--- a/implant/sliver/transports/httpclient/httpclient.go
+++ b/implant/sliver/transports/httpclient/httpclient.go
@@ -37,6 +37,8 @@ import (
 
 	// {{if .Config.Debug}}
 	"log"
+	"reflect"
+	"runtime"
 
 	// {{end}}
 
@@ -189,6 +191,10 @@ func (g *SliverHTTPClientGenerator) Next() bool {
 			continue
 		}
 
+		// {{if .Config.Debug}}
+		log.Printf("XXX [SliverHTTPClientGenerator] next strategy: %v", currentStrategy.String())
+		// {{end}}
+
 		g.value = &SliverHTTPClient{
 			Origin:    origin,
 			driver:    driver,
@@ -227,6 +233,17 @@ type SliverHTTPClientGenerationStrategy struct {
 	Secure bool
 	Driver func(string, bool, *HTTPOptions) (HTTPDriver, error)
 }
+
+// {{if .Config.Debug}}
+func (s *SliverHTTPClientGenerationStrategy) String() string {
+	return fmt.Sprintf(
+		"SliverHTTPClientGenerationStrategy[Secure=%t Driver=%s]",
+		s.Secure,
+		runtime.FuncForPC(reflect.ValueOf(s.Driver).Pointer()).Name(),
+	)
+}
+
+// {{end}}
 
 // HTTPDriver - The interface to send/recv HTTP data
 type HTTPDriver interface {

--- a/implant/sliver/transports/httpclient/httpclient.go
+++ b/implant/sliver/transports/httpclient/httpclient.go
@@ -125,7 +125,7 @@ func HTTPStartSession(address string, pathPrefix string, opts *HTTPOptions) (*Sl
 
 		if err := client.SessionInit(); err != nil {
 			// {{if .Config.Debug}}
-			log.Printf("XXX [HTTPStartSession] failed to initiate session: %v", err)
+			log.Printf("[HTTPStartSession] failed to initiate session: %v", err)
 			// {{end}}
 			continue
 		}
@@ -193,13 +193,13 @@ func (g *SliverHTTPClientGenerator) Next() bool {
 		driver, err := currentStrategy.Driver.GetImpl()(origin, currentStrategy.Secure, currentStrategy.ProxyURL, g.Opts)
 		if err != nil {
 			// {{if .Config.Debug}}
-			log.Printf("XXX [SliverHTTPClientGenerator] (Strategy: %+v) failed to initialize driver: %v", currentStrategy, err)
+			log.Printf("[SliverHTTPClientGenerator] (Strategy: %+v) failed to initialize driver: %v", currentStrategy, err)
 			// {{end}}
 			continue
 		}
 
 		// {{if .Config.Debug}}
-		log.Printf("XXX [SliverHTTPClientGenerator] next strategy: %v", currentStrategy.String())
+		log.Printf("[SliverHTTPClientGenerator] next strategy: %v", currentStrategy.String())
 		// {{end}}
 
 		g.value = &SliverHTTPClient{

--- a/implant/sliver/transports/httpclient/proxy.go
+++ b/implant/sliver/transports/httpclient/proxy.go
@@ -1,0 +1,63 @@
+package httpclient
+
+import (
+	"log"
+	"net/url"
+
+	"github.com/bishopfox/sliver/implant/sliver/proxy"
+)
+
+func getHTTPClientProxyOptions(origin string, driver HTTPDriverType, opts *HTTPOptions) []*url.URL {
+	var proxies []*url.URL
+
+	if driver != GoHTTPDriverType {
+		return proxies
+	}
+
+	switch opts.ProxyConfig {
+	case "never":
+		break
+	case "", "auto":
+		p := proxy.NewProvider("").GetHTTPSProxy(origin)
+		if p != nil {
+			// {{if .Config.Debug}}
+			log.Printf("Found proxy %#v\n", p)
+			// {{end}}
+
+			proxyURL := p.URL()
+			proxies = addProxyURLs(proxies, proxyURL)
+		}
+	default:
+		// {{if .Config.Debug}}
+		log.Printf("Force proxy %#v\n", opts.ProxyConfig)
+		// {{end}}
+
+		proxyURL, err := url.Parse(opts.ProxyConfig)
+		if err != nil {
+			break
+		}
+
+		proxies = addProxyURLs(proxies, proxyURL)
+	}
+
+	// {{if .Config.Debug}}
+	log.Printf("Proxy list: %+v\n", proxies)
+	// {{end}}
+
+	return proxies
+}
+
+func addProxyURLs(proxies []*url.URL, proxyURL *url.URL) []*url.URL {
+	if proxyURL.Scheme != "" {
+		proxies = append(proxies, proxyURL)
+	} else {
+		proxyURL.Scheme = "https"
+		proxies = append(proxies, proxyURL)
+
+		proxyURLCopy := *proxyURL
+		proxyURL.Scheme = "http"
+		proxies = append(proxies, &proxyURLCopy)
+	}
+
+	return proxies
+}

--- a/implant/sliver/transports/httpclient/proxy.go
+++ b/implant/sliver/transports/httpclient/proxy.go
@@ -1,5 +1,23 @@
 package httpclient
 
+/*
+	Sliver Implant Framework
+	Copyright (C) 2019  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import (
 	"log"
 	"net/url"
@@ -7,6 +25,7 @@ import (
 	"github.com/bishopfox/sliver/implant/sliver/proxy"
 )
 
+// getHTTPClientProxyOptions returns a list of candidate proxy URLs for SliverHTTPClient generation
 func getHTTPClientProxyOptions(origin string, driver HTTPDriverType, opts *HTTPOptions) []*url.URL {
 	var proxies []*url.URL
 
@@ -21,7 +40,7 @@ func getHTTPClientProxyOptions(origin string, driver HTTPDriverType, opts *HTTPO
 		p := proxy.NewProvider("").GetHTTPSProxy(origin)
 		if p != nil {
 			// {{if .Config.Debug}}
-			log.Printf("Found proxy %#v\n", p)
+			log.Printf("[http] Found proxy %#v\n", p)
 			// {{end}}
 
 			proxyURL := p.URL()
@@ -29,7 +48,7 @@ func getHTTPClientProxyOptions(origin string, driver HTTPDriverType, opts *HTTPO
 		}
 	default:
 		// {{if .Config.Debug}}
-		log.Printf("Force proxy %#v\n", opts.ProxyConfig)
+		log.Printf("[http] Force proxy %#v\n", opts.ProxyConfig)
 		// {{end}}
 
 		proxyURL, err := url.Parse(opts.ProxyConfig)
@@ -41,12 +60,13 @@ func getHTTPClientProxyOptions(origin string, driver HTTPDriverType, opts *HTTPO
 	}
 
 	// {{if .Config.Debug}}
-	log.Printf("Proxy list: %+v\n", proxies)
+	log.Printf("[http] Proxy list: %+v\n", proxies)
 	// {{end}}
 
 	return proxies
 }
 
+// addProxyURLs appends a proxy URL to a list of proxy URLs, or adds an HTTP- as well as HTTPS-based URL if the proxy URL scheme is not specified
 func addProxyURLs(proxies []*url.URL, proxyURL *url.URL) []*url.URL {
 	if proxyURL.Scheme != "" {
 		proxies = append(proxies, proxyURL)

--- a/implant/sliver/transports/httpclient/proxy.go
+++ b/implant/sliver/transports/httpclient/proxy.go
@@ -19,8 +19,11 @@ package httpclient
 */
 
 import (
-	"log"
 	"net/url"
+
+	// {{if .Config.Debug}}
+	"log"
+	// {{end}}
 
 	"github.com/bishopfox/sliver/implant/sliver/proxy"
 )


### PR DESCRIPTION
#### Card

A small change I came up with to fix https://github.com/BishopFox/sliver/issues/790

The HTTP C2 protocol provides several options which have default values when left unspecified. Most importantly
- when a proxy is detected but the scheme (HTTP vs HTTPS) is unknown, it defaults to HTTPS.
- but also, if a proxy is detected but no connection can be established, it will not try to connect without (but who knows, maybe it would work?)
- and if you don't pick a driver it always uses the Go driver, never tries wininet even if the Go driver does not get out (why not give it try?)

I only really ran into the first of those cases during some experiments and initially only tried to fix that, but while coding the other two things came to my mind as well. Let me know if it makes sense.

#### Details

The change is basically that `func HTTPStartSession` now creates a `SliverHTTPClientGenerator` that can iteratively build and tests HTTP clients according to a list of possible `SliverHTTPClientGenerationStrategy`s until one is found that can connect to the C2 server. They looks as follows:

```
type SliverHTTPClientGenerationStrategy struct {
	Secure   bool
	Driver   HTTPDriverType
	ProxyURL *url.URL
}
```

`Secure` indicates if HTTP or HTTPS should be used to contact the Sliver server, Driver is either the Go or Wininet HTTP driver and ProxyURL is a proxy URL. The `SliverHTTPClientGenerator` will always consider all possible values in its strategy list unless some of them are explicitly specified. Check `func newSliverHTTPClientGenerator` for how it does that.

