### PR TITLE
Fix/namedpipe pivots

### DIFF
--- a/implant/sliver/pivots/pivots.go
+++ b/implant/sliver/pivots/pivots.go
@@ -467,8 +467,10 @@ func (p *NetConnPivot) write(message []byte) error {
 		}
 		total += n
 		if err != nil {
+			// {{if .Config.Debug}}
 			//
 			log.Printf("[pivot] Error writing message: %v", err)
+			// {{end}}
 			//
 			return err
 		}

--- a/implant/sliver/pivots/pivots.go
+++ b/implant/sliver/pivots/pivots.go
@@ -473,6 +473,7 @@ func (p *NetConnPivot) write(message []byte) error {
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/implant/sliver/pivots/pivots.go
+++ b/implant/sliver/pivots/pivots.go
@@ -468,10 +468,8 @@ func (p *NetConnPivot) write(message []byte) error {
 		total += n
 		if err != nil {
 			// {{if .Config.Debug}}
-			//
 			log.Printf("[pivot] Error writing message: %v", err)
 			// {{end}}
-			//
 			return err
 		}
 	}

--- a/implant/sliver/pivots/pivots.go
+++ b/implant/sliver/pivots/pivots.go
@@ -458,13 +458,18 @@ func (p *NetConnPivot) write(message []byte) error {
 	}
 
 	total := 0
+	chunk := 1024
 	for total < len(message) {
-		n, err = p.conn.Write(message[total:])
+		if total+chunk <= len(message) {
+			n, err = p.conn.Write(message[total : total+chunk])
+		} else {
+			n, err = p.conn.Write(message[total:])
+		}
 		total += n
 		if err != nil {
-			// {{if .Config.Debug}}
+			//
 			log.Printf("[pivot] Error writing message: %v", err)
-			// {{end}}
+			//
 			return err
 		}
 	}


### PR DESCRIPTION
#### Card
Quick fix for correcting the bug reported here https://github.com/BishopFox/sliver/issues/789
#### Details
When a pivot implant send the envelope to a pivoted implant now It sends it by chunks of size 1024 bytes. 
The for loop in function func (p *NetConnPivot) write(message []byte) , defined in github.com/bishopfox/sliver/implant/sliver/pivots/pivots.go, now send chunks of fixed size, 1024 bytes, instead of sending all the bytes with one write operation.
In the issue you can find additional details https://github.com/BishopFox/sliver/issues/789
 