### PR TITLE
Ensure persistent multiplayer consoles startup

### DIFF
--- a/server/cli/cli.go
+++ b/server/cli/cli.go
@@ -131,6 +131,7 @@ var rootCmd = &cobra.Command{
 
 		serverConfig := configs.GetServerConfig()
 		c2.StartPersistentJobs(serverConfig)
+		console.StartPersistentJobs(serverConfig)
 		if serverConfig.DaemonMode {
 			daemon.Start(daemon.BlankHost, daemon.BlankPort)
 		} else {

--- a/server/console/console-admin.go
+++ b/server/console/console-admin.go
@@ -177,6 +177,16 @@ func kickOperatorCmd(ctx *grumble.Context) {
 	fmt.Printf(Info+"Operator %s has been kicked out.\n", operator)
 }
 
+func StartPersistentJobs(cfg *configs.ServerConfig) error {
+	if cfg.Jobs == nil {
+		return nil
+	}
+	for _, j := range cfg.Jobs.Multiplayer {
+		jobStartClientListener(j.Host, j.Port)
+	}
+	return nil
+}
+
 func startMultiplayerModeCmd(ctx *grumble.Context) {
 	lhost := ctx.Flags.String("lhost")
 	lport := uint16(ctx.Flags.Int("lport"))


### PR DESCRIPTION
#### Details
Couldn't quite figure out how to easily shoehorn a GRPC listener into the c2 jobs that were already checking to see if they should startup.

This does allow multiple listeners on different ports to run and persist (not sure why anyone would do that).  

Fixes #689
