### PR TITLE
Panic if someone specifies an invalid DB Dialect

### DIFF
--- a/server/db/sql.go
+++ b/server/db/sql.go
@@ -19,6 +19,7 @@ package db
 */
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/bishopfox/sliver/server/configs"
@@ -45,6 +46,8 @@ func newDBClient() *gorm.DB {
 		dbClient = postgresClient(dbConfig)
 	case configs.MySQL:
 		dbClient = mySQLClient(dbConfig)
+	default:
+		panic(fmt.Sprintf("Unknown DB Dialect: '%s'", dbConfig.Dialect))
 	}
 
 	err := dbClient.AutoMigrate(


### PR DESCRIPTION
#### Details

Had a typo in my configs/database.json and it generated the following segfault.  Not a recoverable error so panic is probably the way to go. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x7e6d98]

goroutine 1 [running]:
gorm.io/gorm.(*DB).getInstance(0xc0000df6c8?)
	gorm.io/gorm@v1.21.14/gorm.go:355 +0x18
gorm.io/gorm.(*DB).Migrator(0x414fa7?)
	gorm.io/gorm@v1.21.14/migrator.go:10 +0x1d
gorm.io/gorm.(*DB).AutoMigrate(0x0?, {0xc0002c6640, 0x13, 0x13})
	gorm.io/gorm@v1.21.14/migrator.go:26 +0x28
github.com/bishopfox/sliver/server/db.newDBClient()
	github.com/bishopfox/sliver/server/db/sql.go:50 +0x65a
github.com/bishopfox/sliver/server/db.init()
	github.com/bishopfox/sliver/server/db/db.go:26 +0x2dc

```