### PR TITLE
Only log screenshot error if there is one

### DIFF
--- a/implant/sliver/screen/screenshot_darwin.go
+++ b/implant/sliver/screen/screenshot_darwin.go
@@ -58,9 +58,11 @@ func DarwinCapture() []byte {
 	}
 	img, err := screen.Capture(0, 0, width, height)
 
-	//{{if .Config.Debug}}
-	log.Printf("Error Capture: %s", err)
-	//{{end}}
+	if err != nil {
+		//{{if .Config.Debug}}
+		log.Printf("Error Capture: %s", err)
+		//{{end}}
+	}
 
 	var buf bytes.Buffer
 	if err != nil {

--- a/implant/sliver/screen/screenshot_linux.go
+++ b/implant/sliver/screen/screenshot_linux.go
@@ -47,9 +47,11 @@ func LinuxCapture() []byte {
 	}
 	img, err := screen.Capture(0, 0, width, height)
 
-	//{{if .Config.Debug}}
-	log.Printf("Error Capture: %s", err)
-	//{{end}}
+	if err != nil {
+		//{{if .Config.Debug}}
+		log.Printf("Error Capture: %s", err)
+		//{{end}}
+	}
 
 	var buf bytes.Buffer
 	if err != nil {

--- a/implant/sliver/screen/screenshot_windows.go
+++ b/implant/sliver/screen/screenshot_windows.go
@@ -47,9 +47,11 @@ func WindowsCapture() []byte {
 	}
 	img, err := screen.Capture(0, 0, width, height)
 
-	//{{if .Config.Debug}}
-	log.Printf("Error Capture: %s", err)
-	//{{end}}
+	if err != nil {
+		//{{if .Config.Debug}}
+		log.Printf("Error Capture: %s", err)
+		//{{end}}
+	}
 
 	var buf bytes.Buffer
 	if err != nil {


### PR DESCRIPTION
#### Details
Noticed the following error in my logs but the screenshot worked.  Easy fix

```
2022/09/01 14:46:18 screenshot_linux.go:51: Error Capture: %!s(<nil>)
```