### PR TITLE
Prevent shellcode generation for other platforms than Windows.

### DIFF
--- a/client/command/generate/generate.go
+++ b/client/command/generate/generate.go
@@ -281,6 +281,10 @@ func parseCompileFlags(ctx *grumble.Context, con *console.SliverConsoleClient) *
 	if targetOS == "" || targetArch == "" {
 		return nil
 	}
+	if configFormat == clientpb.OutputFormat_SHELLCODE && targetOS != "windows" {
+		con.PrintErrorf("Shellcode format is currently only supported on Windows\n")
+		return nil
+	}
 	if len(namedPipeC2) > 0 && targetOS != "windows" {
 		con.PrintErrorf("Named pipe pivoting can only be used in Windows.")
 		return nil

--- a/server/generate/binaries.go
+++ b/server/generate/binaries.go
@@ -255,6 +255,9 @@ func GetSliversDir() string {
 
 // SliverShellcode - Generates a sliver shellcode using Donut
 func SliverShellcode(name string, config *models.ImplantConfig) (string, error) {
+	if config.GOOS != "windows" {
+		return "", fmt.Errorf("Shellcode format is currently only supported on Windows")
+	}
 	appDir := assets.GetRootAppDir()
 	goConfig := &gogo.GoConfig{
 		CGO: "0",


### PR DESCRIPTION
We currently don't support the `shellcode` format for other platforms than Windows, but we never prevented users to tried, which can lead to confusion. This PR prevents both the client and server (in case of a custom client) to generate a Sliver payload in `shellcode` format for targeted platforms other than Windows.