### PR TITLE
Fix `execute-assembly`, add PPID and arg spoofing to `sideload`

### DIFF
--- a/client/command/exec/execute-assembly.go
+++ b/client/command/exec/execute-assembly.go
@@ -90,7 +90,7 @@ func ExecuteAssemblyCmd(ctx *grumble.Context, con *console.SliverConsoleClient) 
 		ClassName:   ctx.Flags.String("class"),
 		AppDomain:   ctx.Flags.String("app-domain"),
 		ProcessArgs: processArgs,
-		PPid:        uint32(ctx.Flags.Int("ppid")),
+		PPid:        uint32(ctx.Flags.Uint("ppid")),
 		Runtime:     runtime,
 		EtwBypass:   etwBypass,
 		AmsiBypass:  amsiBypass,

--- a/client/command/exec/sideload.go
+++ b/client/command/exec/sideload.go
@@ -50,6 +50,8 @@ func SideloadCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		con.PrintErrorf("%s", err.Error())
 		return
 	}
+	processArgsStr := ctx.Flags.String("process-arguments")
+	processArgs := strings.Split(processArgsStr, " ")
 	isDLL := (filepath.Ext(binPath) == ".dll")
 	ctrl := make(chan bool)
 	con.SpinUntil(fmt.Sprintf("Sideloading %s ...", binPath), ctrl)
@@ -62,6 +64,8 @@ func SideloadCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		Kill:        !ctx.Flags.Bool("keep-alive"),
 		IsDLL:       isDLL,
 		IsUnicode:   ctx.Flags.Bool("unicode"),
+		PPid:        uint32(ctx.Flags.Uint("ppid")),
+		ProcessArgs: processArgs,
 	})
 	ctrl <- true
 	<-ctrl


### PR DESCRIPTION
Fix a bug in `execute-assembly` and add PPID spoofing and argument spoofing to `sideload`.