### PR TITLE
Catch error on 'loot remote' if file doesn't exist

### DIFF
--- a/implant/sliver/handlers/handlers.go
+++ b/implant/sliver/handlers/handlers.go
@@ -372,6 +372,9 @@ func prepareDownload(path string, filter string, recurse bool) ([]byte, bool, in
 		to download a single file
 	*/
 	fileInfo, err := os.Stat(path + filter)
+	if err != nil {
+		return nil, false, 0, 1, err
+	}
 	if err == nil && !fileInfo.IsDir() {
 		// Then this is a single file
 		rawData, err := os.ReadFile(path + filter)


### PR DESCRIPTION
#### Card

#### Details
Calling `loot remote file_that_doesnt_exist` would return without any error or success message.  

Before patch:
```
[server] sliver (VULNERABLE_PICKLE) > loot remote file_that_doesnt_exist


[server] sliver (VULNERABLE_PICKLE) > 

```

After patch:
```
[server] sliver (POWERFUL_BONE) > loot remote file_that_doesnt_exist

[!] rpc error: code = Unknown desc = stat /home/james/projects/sliver/file_that_doesnt_exist: no such file or directory

[server] sliver (POWERFUL_BONE) >

```