### PR TITLE
Add sysmon + sysmon64

### DIFF
--- a/client/command/processes/ps.go
+++ b/client/command/processes/ps.go
@@ -66,6 +66,8 @@ var (
 		"SentinelHelperService.exe":       {console.Red, "SentinelOne"},                  // Sentinel One
 		"SentinelBrowserNativeHost.exe":   {console.Red, "SentinelOne"},                  // Sentinel One
 		"SentinelUI.exe":                  {console.Red, "SentinelOne"},                  // Sentinel One
+		"Sysmon.exe":                  	   {console.Red, "Sysmon"},                  	  // Sysmon
+		"Sysmon64.exe":                    {console.Red, "Sysmon64"},                     // Sysmon64		
 		"CylanceSvc.exe":                  {console.Red, "Cylance"},                      // Cylance
 		"CylanceUI.exe":                   {console.Red, "Cylance"},                      // Cylance
 		"TaniumClient.exe":                {console.Red, "Tanium"},                       // Tanium


### PR DESCRIPTION
As Sysmon is more commonly used for logging I assume we should flag it also as known security tool.

Signed-off-by: cmprmsd <73472903+cmprmsd@users.noreply.github.com>
