### PR TITLE
Stop excessive build logging if there are no canaries

### DIFF
--- a/server/generate/binaries.go
+++ b/server/generate/binaries.go
@@ -619,7 +619,9 @@ func renderSliverGoCode(name string, config *models.ImplantConfig, goConfig *gog
 		}
 
 		// Render canaries
-		buildLog.Debugf("Canary domain(s): %v", config.CanaryDomains)
+		if len(config.CanaryDomains) > 0 {
+			buildLog.Debugf("Canary domain(s): %v", config.CanaryDomains)
+		}
 		canaryTmpl := template.New("canary").Delims("[[", "]]")
 		canaryGenerator := &CanaryGenerator{
 			ImplantName:   name,


### PR DESCRIPTION
#### Card

#### Details
One log entry for every file, I assume it must happen in the loop to catch weird edge cases per file when building.