### PR TITLE
Trap failed build when running 'go generate' on the implant

### DIFF
--- a/implant/scripts/update-vendor.sh
+++ b/implant/scripts/update-vendor.sh
@@ -1,6 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
+
+cleanup() {
+  [ ! -z "$1" ] && echo "Error $1 occurred on $2"
+
+  mv "${tempDir}/vendor" "${pwd}/../vendor"
+  mv "${tempDir}/go.mod" "${pwd}/../go-mod"
+  mv "${tempDir}/go.sum" "${pwd}/../go-sum"
+  cd ..
+  rm -rf "$tempDir"
+}
 
 # we are expecting from run from sliver/implant via 'go generate'
 cd scripts
@@ -12,6 +22,10 @@ cp ../go-mod "${tempDir}/go.mod"
 cp ../go-sum "${tempDir}/go.sum"
 mv ../vendor "${tempDir}/vendor"
 
+
+# Trap when a build fails so we can reset the environment
+trap 'cleanup $? $LINENO' ERR
+
 # build Go file with all imported packages
 go run update-vendor.go "$tempDir"
 cd "$tempDir"
@@ -20,8 +34,4 @@ go mod tidy -compat=1.17
 go mod vendor
 
 # move updated files back
-mv "${tempDir}/vendor" "${pwd}/../vendor"
-mv "${tempDir}/go.mod" "${pwd}/../go-mod"
-mv "${tempDir}/go.sum" "${pwd}/../go-sum"
-cd ..
-rm -rf "$tempDir"
+cleanup


### PR DESCRIPTION
I had an error that caused the build to fail which left the environment without a vendor directory