### PR TITLE
Add option to log TLS info so packets can be decoded with wireshark

### DIFF
--- a/implant/sliver/cryptography/tlskeys.go
+++ b/implant/sliver/cryptography/tlskeys.go
@@ -1,0 +1,42 @@
+package cryptography
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2019  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"os"
+)
+
+var (
+	// TLSKeyLogger - File descriptor for logging TLS keys
+	TLSKeyLogger = newKeyLogger()
+)
+
+func newKeyLogger() *os.File {
+	// {{if .Config.Debug}}
+	keyFilePath, present := os.LookupEnv("SSLKEYLOGFILE")
+	if present {
+		keyFile, err := os.OpenFile(keyFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		if err != nil {
+			return nil
+		}
+		return keyFile
+	}
+	// {{end}}
+	return nil
+}

--- a/implant/sliver/transports/mtls/mtls.go
+++ b/implant/sliver/transports/mtls/mtls.go
@@ -167,6 +167,11 @@ func getTLSConfig() *tls.Config {
 			return cryptography.RootOnlyVerifyCertificate(caCertPEM, rawCerts, verifiedChains)
 		},
 	}
+	// {{if .Config.Debug}}
+	if cryptography.TLSKeyLogger != nil {
+		tlsConfig.KeyLogWriter = cryptography.TLSKeyLogger
+	}
+	// {{end}}
 
 	return tlsConfig
 }

--- a/server/c2/http.go
+++ b/server/c2/http.go
@@ -245,9 +245,13 @@ func getHTTPTLSConfig(conf *HTTPServerConfig) *tls.Config {
 		httpLog.Errorf("Failed to parse tls cert/key pair %s", err)
 		return nil
 	}
-	return &tls.Config{
+	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 	}
+	if certs.TLSKeyLogger != nil {
+		tlsConfig.KeyLogWriter = certs.TLSKeyLogger
+	}
+	return tlsConfig
 }
 
 func (s *SliverHTTPC2) router() *mux.Router {

--- a/server/c2/jobs.go
+++ b/server/c2/jobs.go
@@ -429,6 +429,9 @@ func listenAndServeTLS(srv *http.Server, certPEMBlock, keyPEMBlock []byte) error
 	if srv.TLSConfig != nil {
 		*config = *srv.TLSConfig
 	}
+	if certs.TLSKeyLogger != nil {
+		config.KeyLogWriter = certs.TLSKeyLogger
+	}
 	if config.NextProtos == nil {
 		config.NextProtos = []string{"http/1.1"}
 	}

--- a/server/c2/mtls.go
+++ b/server/c2/mtls.go
@@ -220,5 +220,8 @@ func getServerTLSConfig(host string) *tls.Config {
 		Certificates: []tls.Certificate{cert},
 		MinVersion:   tls.VersionTLS13, // Force TLS v1.3
 	}
+	if certs.TLSKeyLogger != nil {
+		tlsConfig.KeyLogWriter = certs.TLSKeyLogger
+	}
 	return tlsConfig
 }

--- a/server/certs/tlskeys.go
+++ b/server/certs/tlskeys.go
@@ -36,6 +36,7 @@ func newKeyLogger() *os.File {
 			certsLog.Errorf(fmt.Sprintf("Failed to open TLS key file %v", err))
 			return nil
 		}
+		fmt.Printf("NOTICE: TLS Keys logged to '%s'\n", keyFilePath)
 		return keyFile
 	}
 	return nil

--- a/server/certs/tlskeys.go
+++ b/server/certs/tlskeys.go
@@ -1,0 +1,50 @@
+package certs
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2019  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"github.com/bishopfox/sliver/server/configs"
+	"github.com/bishopfox/sliver/server/log"
+)
+
+const (
+	keyFileName = "tls.keys"
+)
+
+var (
+	// TLSKeyLogger - File descriptor for logging TLS keys
+	TLSKeyLogger = newKeyLogger()
+)
+
+func newKeyLogger() *os.File {
+	serverConfig := configs.GetServerConfig()
+	if serverConfig.Logs.TLSKeyLogger {
+		keyFilePath := filepath.Join(log.GetLogDir(), keyFileName)
+		keyFile, err := os.OpenFile(keyFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		if err != nil {
+			certsLog.Errorf(fmt.Sprintf("Failed to open TLS key file %v", err))
+			return nil
+		}
+		return keyFile
+	}
+	return nil
+}

--- a/server/certs/tlskeys.go
+++ b/server/certs/tlskeys.go
@@ -21,13 +21,6 @@ package certs
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"github.com/bishopfox/sliver/server/configs"
-	"github.com/bishopfox/sliver/server/log"
-)
-
-const (
-	keyFileName = "tls.keys"
 )
 
 var (
@@ -36,9 +29,8 @@ var (
 )
 
 func newKeyLogger() *os.File {
-	serverConfig := configs.GetServerConfig()
-	if serverConfig.Logs.TLSKeyLogger {
-		keyFilePath := filepath.Join(log.GetLogDir(), keyFileName)
+	keyFilePath, present := os.LookupEnv("SSLKEYLOGFILE")
+	if present {
 		keyFile, err := os.OpenFile(keyFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 		if err != nil {
 			certsLog.Errorf(fmt.Sprintf("Failed to open TLS key file %v", err))

--- a/server/configs/server.go
+++ b/server/configs/server.go
@@ -53,6 +53,7 @@ type LogConfig struct {
 	Level              int  `json:"level"`
 	GRPCUnaryPayloads  bool `json:"grpc_unary_payloads"`
 	GRPCStreamPayloads bool `json:"grpc_stream_payloads"`
+	TLSKeyLogger       bool `json:"tls_key_logger"`
 }
 
 // DaemonConfig - Configure daemon mode

--- a/server/transport/mtls.go
+++ b/server/transport/mtls.go
@@ -116,6 +116,10 @@ func getOperatorServerTLSConfig(host string) *tls.Config {
 		PreferServerCipherSuites: true,
 		MinVersion:               tls.VersionTLS13,
 	}
+	if certs.TLSKeyLogger != nil {
+		tlsConfig.KeyLogWriter = certs.TLSKeyLogger
+	}
+
 	tlsConfig.BuildNameToCertificate()
 	return tlsConfig
 }


### PR DESCRIPTION
#### Details

I wanted to dig into what was happening on the wire, this gets most of the way there.  MTLS looks like it needs a custom decoder but multiplayer clients and HTTPS decode fine.

You have to manually enable it in the server.json, didn't think this needed a cli command to enable.  Probably only useful for debugging.