### PR TITLE
Sleep before shutting down beacon instead of after

### DIFF
--- a/implant/sliver/sliver.go
+++ b/implant/sliver/sliver.go
@@ -353,6 +353,7 @@ func beaconMain(beacon *transports.Beacon, nextCheckin time.Time) error {
 		// {{if .Config.Debug}}
 		log.Printf("[beacon] closing ...")
 		// {{end}}
+		time.Sleep(time.Second)
 		beacon.Close()
 	}()
 	// {{if .Config.Debug}}

--- a/implant/sliver/sliver.go
+++ b/implant/sliver/sliver.go
@@ -300,8 +300,8 @@ func beaconMainLoop(beacon *transports.Beacon) error {
 		Register:    register,
 		NextCheckin: int64(beacon.Duration().Seconds()),
 	}))
-	beacon.Close()
 	time.Sleep(time.Second)
+	beacon.Close()
 
 	// BeaconMain - Is executed in it's own goroutine as the function will block
 	// until all tasks complete (in success or failure), if a task handler blocks


### PR DESCRIPTION
#### Details

When using a windows implant + wireguard it looks like the beacon registration message is never recieved by the server because the session is closed too quickly.

Fixes #670

