### PR TITLE
Add reverse port forwardings management 

### DIFF
--- a/client/command/commands.go
+++ b/client/command/commands.go
@@ -2548,8 +2548,8 @@ func BindCommands(con *console.SliverConsoleClient) {
 		HelpGroup: consts.SliverHelpGroup,
 	}
 	rportfwdCmd.AddCommand(&grumble.Command{
-		Name:     consts.StartStr,
-		Help:     "Start reverse port forwarding",
+		Name:     consts.AddStr,
+		Help:     "Add and start reverse port forwarding",
 		LongHelp: help.GetHelpFor([]string{consts.RportfwdStr}),
 		Run: func(ctx *grumble.Context) error {
 			con.Println()
@@ -2565,7 +2565,7 @@ func BindCommands(con *console.SliverConsoleClient) {
 		HelpGroup: consts.SliverWinHelpGroup,
 	})
 	rportfwdCmd.AddCommand(&grumble.Command{
-		Name:     consts.StopStr,
+		Name:     consts.RmStr,
 		Help:     "Stop and remove reverse port forwarding",
 		LongHelp: help.GetHelpFor([]string{consts.RportfwdStr}),
 		Run: func(ctx *grumble.Context) error {

--- a/client/command/commands.go
+++ b/client/command/commands.go
@@ -2548,8 +2548,8 @@ func BindCommands(con *console.SliverConsoleClient) {
 		HelpGroup: consts.SliverHelpGroup,
 	}
 	rportfwdCmd.AddCommand(&grumble.Command{
-		Name:     consts.AddStr,
-		Help:     "Add reverse port forwarding",
+		Name:     consts.StartStr,
+		Help:     "Start reverse port forwarding",
 		LongHelp: help.GetHelpFor([]string{consts.RportfwdStr}),
 		Run: func(ctx *grumble.Context) error {
 			con.Println()
@@ -2565,7 +2565,7 @@ func BindCommands(con *console.SliverConsoleClient) {
 		HelpGroup: consts.SliverWinHelpGroup,
 	})
 	rportfwdCmd.AddCommand(&grumble.Command{
-		Name:     consts.RmStr,
+		Name:     consts.StopStr,
 		Help:     "Stop and remove reverse port forwarding",
 		LongHelp: help.GetHelpFor([]string{consts.RportfwdStr}),
 		Run: func(ctx *grumble.Context) error {

--- a/client/command/rportfwd/portfwd-add.go
+++ b/client/command/rportfwd/portfwd-add.go
@@ -65,5 +65,13 @@ func StartRportFwdListenerCmd(ctx *grumble.Context, con *console.SliverConsoleCl
 		con.PrintWarnf("%s\n", err)
 		return
 	}
+	printStartedRportFwdListener(rportfwdListener, con)
+}
+
+func printStartedRportFwdListener(rportfwdListener *sliverpb.RportFwdListener, con *console.SliverConsoleClient) {
+	if rportfwdListener.Response != nil && rportfwdListener.Response.Err != "" {
+		con.PrintErrorf("%s", rportfwdListener.Response.Err)
+		return
+	}
 	con.PrintInfof("Reverse port forwarding %s <- %s\n", rportfwdListener.ForwardAddress, rportfwdListener.BindAddress)
 }

--- a/client/command/rportfwd/portfwd-rm.go
+++ b/client/command/rportfwd/portfwd-rm.go
@@ -43,6 +43,13 @@ func StopRportFwdListenerCmd(ctx *grumble.Context, con *console.SliverConsoleCli
 		con.PrintWarnf("%s\n", err)
 		return
 	}
-	con.PrintInfof("Stopped reverse port forwarding %s <- %s\n", rportfwdListener.BindAddress, rportfwdListener.ForwardAddress)
+	printStoppedRportFwdListener(rportfwdListener, con)
+}
 
+func printStoppedRportFwdListener(rportfwdListener *sliverpb.RportFwdListener, con *console.SliverConsoleClient) {
+	if rportfwdListener.Response != nil && rportfwdListener.Response.Err != "" {
+		con.PrintErrorf("%s", rportfwdListener.Response.Err)
+		return
+	}
+	con.PrintInfof("Stopped reverse port forwarding %s <- %s\n", rportfwdListener.ForwardAddress, rportfwdListener.BindAddress)
 }

--- a/client/command/rportfwd/portfwd.go
+++ b/client/command/rportfwd/portfwd.go
@@ -19,15 +19,13 @@ package rportfwd
 */
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"text/tabwriter"
 
+	"github.com/bishopfox/sliver/client/command/settings"
 	"github.com/bishopfox/sliver/client/console"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
-
 	"github.com/desertbit/grumble"
+	"github.com/jedib0t/go-pretty/v6/table"
 )
 
 // StartRportFwdListenerCmd - Start listener for reverse port forwarding on implant
@@ -52,11 +50,25 @@ func PrintRportFwdListeners(rportfwdListeners *sliverpb.RportFwdListeners, flags
 		con.PrintErrorf("%s\n", rportfwdListeners.Response.Err)
 		return
 	}
-	outputBuf := bytes.NewBufferString("")
-	table := tabwriter.NewWriter(outputBuf, 0, 2, 2, ' ', 0)
-	for _, listener := range rportfwdListeners.Listeners {
-		fmt.Fprintf(table, "%d\t%s -> %s\n", listener.ID, listener.BindAddress, listener.ForwardAddress)
+
+	if len(rportfwdListeners.Listeners) == 0 {
+		con.PrintInfof("No port forwards\n")
+		return
 	}
-	table.Flush()
-	con.Printf("%s\n", outputBuf.String())
+
+	tw := table.NewWriter()
+	tw.SetStyle(settings.GetTableStyle(con))
+	tw.AppendHeader(table.Row{
+		"ID",
+		"Remote Address",
+		"Bind Address",
+	})
+	for _, p := range rportfwdListeners.Listeners {
+		tw.AppendRow(table.Row{
+			p.ID,
+			p.ForwardAddress,
+			p.BindAddress,
+		})
+	}
+	con.Printf("%s\n", tw.Render())
 }

--- a/client/command/rportfwd/portfwd.go
+++ b/client/command/rportfwd/portfwd.go
@@ -52,7 +52,7 @@ func PrintRportFwdListeners(rportfwdListeners *sliverpb.RportFwdListeners, flags
 	}
 
 	if len(rportfwdListeners.Listeners) == 0 {
-		con.PrintInfof("No port forwards\n")
+		con.PrintInfof("No reverse port forwards\n")
 		return
 	}
 

--- a/implant/sliver/handlers/rportfwd-handlers.go
+++ b/implant/sliver/handlers/rportfwd-handlers.go
@@ -114,8 +114,6 @@ func rportFwdStartListenerHandler(envelope *pb.Envelope, connection *transports.
 		ID:   envelope.ID,
 		Data: data,
 	}
-	return
-	//con.PrintInfof("Port forwarding %s -> %s:%s\n", bindAddr, remoteHost, remotePort)
 }
 
 func rportFwdStopListenerHandler(envelope *pb.Envelope, connection *transports.Connection) {
@@ -132,9 +130,11 @@ func rportFwdStopListenerHandler(envelope *pb.Envelope, connection *transports.C
 		return
 	}
 
-	res := rportfwd.Portfwds.Remove(int(req.ID))
-	if res == true {
-		resp.ID = req.ID
+	rportfwd := rportfwd.Portfwds.Remove(int(req.ID))
+	if rportfwd != nil {
+		resp.ID = uint32(rportfwd.ID)
+		resp.BindAddress = rportfwd.ChannelProxy.BindAddr
+		resp.ForwardAddress = rportfwd.ChannelProxy.RemoteAddr
 	} else {
 		resp.Response.Err = err.Error()
 	}
@@ -144,5 +144,4 @@ func rportFwdStopListenerHandler(envelope *pb.Envelope, connection *transports.C
 		ID:   envelope.ID,
 		Data: data,
 	}
-	return
 }

--- a/implant/sliver/handlers/rportfwd-handlers.go
+++ b/implant/sliver/handlers/rportfwd-handlers.go
@@ -130,7 +130,7 @@ func rportFwdStartListenerHandler(envelope *pb.Envelope, connection *transports.
 
 func rportFwdStopListenerHandler(envelope *pb.Envelope, connection *transports.Connection) {
 	req := &pb.RportFwdStopListenerReq{}
-	resp := &pb.RportFwdListener{}
+	resp := &pb.RportFwdListener{Response: &commonpb.Response{}}
 	err := proto.Unmarshal(envelope.Data, req)
 	if err != nil {
 		resp.Response.Err = err.Error()

--- a/implant/sliver/handlers/rportfwd-handlers.go
+++ b/implant/sliver/handlers/rportfwd-handlers.go
@@ -35,7 +35,7 @@ import (
 
 var (
 	genericRportFwdHandlers = map[uint32]RportFwdHandler{
-		pb.MsgRportFwdListeners:        rportFwdListenersHandler,
+		pb.MsgRportFwdListenersReq:     rportFwdListenersHandler,
 		pb.MsgRportFwdStartListenerReq: rportFwdStartListenerHandler,
 		pb.MsgRportFwdStopListenerReq:  rportFwdStopListenerHandler,
 		//pb.MsgPivotPeerEnvelope:     pivotPeerEnvelopeHandler,

--- a/implant/sliver/rportfwd/portfwd.go
+++ b/implant/sliver/rportfwd/portfwd.go
@@ -90,15 +90,15 @@ func (f *portfwds) Add(tcpProxy *tcpproxy.Proxy, channelProxy *ChannelProxy) *Po
 }
 
 // Remove - Remove a TCP proxy instance
-func (f *portfwds) Remove(portfwdID int) bool {
+func (f *portfwds) Remove(portfwdID int) *Portfwd {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 	if portfwd, ok := f.forwards[portfwdID]; ok {
 		portfwd.TCPProxy.Close()
 		delete(f.forwards, portfwdID)
-		return true
+		return portfwd
 	}
-	return false
+	return nil
 }
 
 // List - List all TCP proxy instances

--- a/implant/sliver/rportfwd/portfwd.go
+++ b/implant/sliver/rportfwd/portfwd.go
@@ -241,13 +241,6 @@ func nextPortfwdID() int {
 	return portfwdID
 }
 
-// EnvelopeID - Generate random ID of 8 bytes
-func EnvelopeID() int64 {
-	randBuf := make([]byte, 8) // 64 bits of randomness
-	rand.Read(randBuf)
-	return int64(binary.LittleEndian.Uint64(randBuf))
-}
-
 // NewTunnelID - New 64-bit identifier
 func NewTunnelID() uint64 {
 	randBuf := make([]byte, 8)

--- a/server/rpc/rpc-rportfwd.go
+++ b/server/rpc/rpc-rportfwd.go
@@ -25,7 +25,7 @@ import (
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
 )
 
-// PivotSessionListeners - Get a list of all reverse port forwards listeners from an implant
+// GetRportFwdListeners - Get a list of all reverse port forwards listeners from an implant
 func (rpc *Server) GetRportFwdListeners(ctx context.Context, req *sliverpb.RportFwdListenersReq) (*sliverpb.RportFwdListeners, error) {
 	resp := &sliverpb.RportFwdListeners{Response: &commonpb.Response{}}
 	err := rpc.GenericHandler(req, resp)
@@ -35,7 +35,7 @@ func (rpc *Server) GetRportFwdListeners(ctx context.Context, req *sliverpb.Rport
 	return resp, nil
 }
 
-// PivotStartListener - Instruct the implant to start a reverse port forward
+// StartRportfwdListener - Instruct the implant to start a reverse port forward
 func (rpc *Server) StartRportfwdListener(ctx context.Context, req *sliverpb.RportFwdStartListenerReq) (*sliverpb.RportFwdListener, error) {
 	resp := &sliverpb.RportFwdListener{Response: &commonpb.Response{}}
 	err := rpc.GenericHandler(req, resp)
@@ -45,7 +45,7 @@ func (rpc *Server) StartRportfwdListener(ctx context.Context, req *sliverpb.Rpor
 	return resp, nil
 }
 
-// PivotStopListener - Instruct the implant to stop a pivot listener
+// StopRportfwdListener - Instruct the implant to stop a reverse port forward
 func (rpc *Server) StopRportfwdListener(ctx context.Context, req *sliverpb.RportFwdStopListenerReq) (*sliverpb.RportFwdListener, error) {
 	resp := &sliverpb.RportFwdListener{Response: &commonpb.Response{}}
 	err := rpc.GenericHandler(req, resp)


### PR DESCRIPTION
#### Card
With this PR it is possible to list/stop existing reverse port forwarding rules on a given implant.
#### Details
List and stop operations are provided for managing reverse port forwardings on an implant. 

The add operation was renamed to a start operation. In case of trying to start a reverse port forwarding listener on a port where it was already started a reverse port forwarding listener, this is detected and an error is returned. 

Stop is performed by passing the ID associated with the port forwarding rule. In case the ID is not valid an error is returned.
In the following screenshot are shown the feature described:
![image](https://user-images.githubusercontent.com/74059030/190859119-aba60263-f529-44e5-b33c-415a1fb7cdf8.png)

