### PR TITLE
Reworked staging

### DIFF
--- a/client/command/commands.go
+++ b/client/command/commands.go
@@ -483,6 +483,7 @@ func BindCommands(con *console.SliverConsoleClient) {
 			f.StringL("aes-encrypt-key", "", "encrypt stage with AES encryption key")
 			f.StringL("aes-encrypt-iv", "", "encrypt stage with AES encryption iv")
 			f.String("C", "compress", "none", "compress the stage before encrypting (zlib, gzip, deflate9, none)")
+			f.Bool("P", "prepend-size", false, "prepend the size of the stage to the payload (to use with MSF stagers)")
 		},
 		Run: func(ctx *grumble.Context) error {
 			con.Println()

--- a/client/command/jobs/stage.go
+++ b/client/command/jobs/stage.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"compress/zlib"
 	"context"
+	"encoding/binary"
 	"net/url"
 	"strconv"
 	"strings"
@@ -39,6 +40,7 @@ func StageListenerCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 	listenerURL := ctx.Flags.String("url")
 	aesEncryptKey := ctx.Flags.String("aes-encrypt-key")
 	aesEncryptIv := ctx.Flags.String("aes-encrypt-iv")
+	prependSize := ctx.Flags.Bool("prepend-size")
 	compress := strings.ToLower(ctx.Flags.String("compress"))
 
 	if profileName == "" || listenerURL == "" {
@@ -115,8 +117,18 @@ func StageListenerCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		stage2 = util.PreludeEncrypt(stage2, []byte(aesEncryptKey), []byte(aesEncryptIv))
 	}
 
+	// if prependSize {
+	// 	payloadSize := uint32(len(stage2))
+	// 	lenBuf := make([]byte, 4)
+	// 	binary.LittleEndian.PutUint32(lenBuf, payloadSize)
+	// 	stage2 = append(lenBuf, stage2...)
+	// }
+
 	switch stagingURL.Scheme {
 	case "http":
+		if prependSize {
+			stage2 = prependPayloadSize(stage2)
+		}
 		ctrl := make(chan bool)
 		con.SpinUntil("Starting HTTP staging listener...", ctrl)
 		stageListener, err := con.Rpc.StartHTTPStagerListener(context.Background(), &clientpb.StagerListenerReq{
@@ -133,6 +145,9 @@ func StageListenerCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		}
 		con.PrintInfof("Job %d (http) started\n", stageListener.GetJobID())
 	case "https":
+		if prependSize {
+			stage2 = prependPayloadSize(stage2)
+		}
 		cert, key, err := getLocalCertificatePair(ctx)
 		if err != nil {
 			con.Println()
@@ -158,6 +173,8 @@ func StageListenerCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		}
 		con.PrintInfof("Job %d (https) started\n", stageListener.GetJobID())
 	case "tcp":
+		// Always prepend payload size for TCP stagers
+		stage2 = prependPayloadSize(stage2)
 		ctrl := make(chan bool)
 		con.SpinUntil("Starting TCP staging listener...", ctrl)
 		stageListener, err := con.Rpc.StartTCPStagerListener(context.Background(), &clientpb.StagerListenerReq{
@@ -183,4 +200,11 @@ func StageListenerCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		con.PrintInfof("AES KEY: %v\n", aesEncryptKey)
 		con.PrintInfof("AES IV: %v\n", aesEncryptIv)
 	}
+}
+
+func prependPayloadSize(payload []byte) []byte {
+	payloadSize := uint32(len(payload))
+	lenBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(lenBuf, payloadSize)
+	return append(lenBuf, payload...)
 }

--- a/client/command/jobs/stage.go
+++ b/client/command/jobs/stage.go
@@ -117,13 +117,6 @@ func StageListenerCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 		stage2 = util.PreludeEncrypt(stage2, []byte(aesEncryptKey), []byte(aesEncryptIv))
 	}
 
-	// if prependSize {
-	// 	payloadSize := uint32(len(stage2))
-	// 	lenBuf := make([]byte, 4)
-	// 	binary.LittleEndian.PutUint32(lenBuf, payloadSize)
-	// 	stage2 = append(lenBuf, stage2...)
-	// }
-
 	switch stagingURL.Scheme {
 	case "http":
 		if prependSize {

--- a/server/c2/tcp-stager.go
+++ b/server/c2/tcp-stager.go
@@ -57,12 +57,6 @@ func acceptConnections(ln net.Listener, data []byte) {
 
 func handleConnection(conn net.Conn, data []byte) {
 	mtlsLog.Infof("Accepted incoming connection: %s", conn.RemoteAddr())
-	// Send shellcode size
-	// dataSize := uint32(len(data))
-	// lenBuf := make([]byte, 4)
-	// binary.LittleEndian.PutUint32(lenBuf, dataSize)
-	// tcpLog.Infof("Shellcode size: %d\n", dataSize)
-	// final := append(lenBuf, data...)
 	tcpLog.Infof("Sending shellcode (%d)\n", len(data))
 	// Send shellcode
 	conn.Write(data)

--- a/server/c2/tcp-stager.go
+++ b/server/c2/tcp-stager.go
@@ -19,7 +19,6 @@ package c2
 */
 
 import (
-	"encoding/binary"
 	"fmt"
 	"net"
 
@@ -59,14 +58,14 @@ func acceptConnections(ln net.Listener, data []byte) {
 func handleConnection(conn net.Conn, data []byte) {
 	mtlsLog.Infof("Accepted incoming connection: %s", conn.RemoteAddr())
 	// Send shellcode size
-	dataSize := uint32(len(data))
-	lenBuf := make([]byte, 4)
-	binary.LittleEndian.PutUint32(lenBuf, dataSize)
-	tcpLog.Infof("Shellcode size: %d\n", dataSize)
-	final := append(lenBuf, data...)
-	tcpLog.Infof("Sending shellcode (%d)\n", len(final))
+	// dataSize := uint32(len(data))
+	// lenBuf := make([]byte, 4)
+	// binary.LittleEndian.PutUint32(lenBuf, dataSize)
+	// tcpLog.Infof("Shellcode size: %d\n", dataSize)
+	// final := append(lenBuf, data...)
+	tcpLog.Infof("Sending shellcode (%d)\n", len(data))
 	// Send shellcode
-	conn.Write(final)
+	conn.Write(data)
 	// Closing connection
 	conn.Close()
 }

--- a/server/msf/msf.go
+++ b/server/msf/msf.go
@@ -59,6 +59,8 @@ var (
 			"meterpreter/reverse_tcp":   true,
 			"meterpreter/reverse_http":  true,
 			"meterpreter/reverse_https": true,
+			"custom/reverse_winhttp":    true,
+			"custom/reverse_tcp":        true,
 		},
 		"linux": {
 			"meterpreter_reverse_http":  true,

--- a/server/rpc/rpc-msf.go
+++ b/server/rpc/rpc-msf.go
@@ -166,10 +166,9 @@ func (rpc *Server) MsfStage(ctx context.Context, req *clientpb.MsfStagerReq) (*c
 	case clientpb.StageProtocol_TCP:
 		payload = "meterpreter/reverse_tcp"
 	case clientpb.StageProtocol_HTTP:
-		payload = "meterpreter/reverse_http"
-		uri = generateCallbackURI()
+		fallthrough
 	case clientpb.StageProtocol_HTTPS:
-		payload = "meterpreter/reverse_https"
+		payload = "custom/reverse_winhttp"
 		uri = generateCallbackURI()
 	default:
 		return MSFStage, errors.New("protocol not supported")


### PR DESCRIPTION
Modified the way staging works, adding a new flag `prepend-size` to `stage-listener` so we can be compatible with Metasploit's new `custom` payload types and staging protocol: https://www.rapid7.com/blog/post/2022/09/16/metasploit-weekly-wrap-up-176/.

We're now defaulting to `custom/reverse_winhttp` in the `MsfStage` RPC because it's the only one working at the moment (`custom/reverse_http` uses wininet on Windows, and doesn't seem to pick up the whole payload).
