### PR TITLE
Allow info command to work with active sessions again

### DIFF
--- a/client/command/info/info.go
+++ b/client/command/info/info.go
@@ -34,20 +34,23 @@ import (
 
 // InfoCmd - Display information about the active session
 func InfoCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
-	var session *clientpb.Session
-	var beacon *clientpb.Beacon
 	var err error
 
-	idArg := ctx.Args.String("session")
+	// Check if we have an active target via 'use'
+	session, beacon := con.ActiveTarget.Get()
 
+	idArg := ctx.Args.String("session")
 	if idArg != "" {
+		// ID passed via argument takes priority
 		session, beacon, err = use.SessionOrBeaconByID(idArg, con)
 	} else {
-		session, beacon, err = use.SelectSessionOrBeacon(con)
-	}
-	if err != nil {
-		con.PrintErrorf("%s\n", err)
-		return
+		if session == nil && beacon == nil {
+			session, beacon, err = use.SelectSessionOrBeacon(con)
+			if err != nil {
+				con.PrintErrorf("%s\n", err)
+				return
+			}
+		}
 	}
 
 	if session != nil {


### PR DESCRIPTION
#### Details
After the last PR, if you ran `info` while inside an active session it would use the selector.  Now if you specify an ID as an argument it will always be looked up, then if you have an active session/becon, and finally use the selector.