### PR TITLE
Register new hosts when beacons are received and not just sessions

### DIFF
--- a/server/core/events.go
+++ b/server/core/events.go
@@ -18,6 +18,10 @@ package core
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import (
+	"github.com/bishopfox/sliver/server/db/models"
+)
+
 const (
 	// Size is arbitrary, just want to avoid weird cases where we'd block on channel sends
 	eventBufSize = 5
@@ -29,6 +33,7 @@ type Event struct {
 	Session *Session
 	Job     *Job
 	Client  *Client
+	Beacon  *models.Beacon
 
 	EventType string
 

--- a/server/core/hosts.go
+++ b/server/core/hosts.go
@@ -39,6 +39,10 @@ func StartEventAutomation() {
 		for event := range EventBroker.Subscribe() {
 			switch event.EventType {
 
+			case consts.BeaconRegisteredEvent:
+				if event.Beacon != nil {
+					hostsBeaconCallback(event.Beacon)
+				}
 			case consts.SessionOpenedEvent:
 				if event.Session != nil {
 					hostsSessionCallback(event.Session)
@@ -67,6 +71,34 @@ func hostsSessionCallback(session *Session) {
 			Hostname:      session.Hostname,
 			OSVersion:     session.OS,
 			Locale:        session.Locale,
+			IOCs:          []models.IOC{},
+			ExtensionData: []models.ExtensionData{},
+		}).Error
+		if err != nil {
+			coreLog.Error(err)
+			return
+		}
+	}
+}
+
+// Triggered on new beacon events, checks to see if the host is in
+// the database and adds it if not.
+func hostsBeaconCallback(beacon *models.Beacon) {
+	coreLog.Debugf("Hosts beacon callback for %v", beacon.UUID)
+	dbSession := db.Session()
+	host, err := db.HostByHostUUID(beacon.UUID.String())
+	coreLog.Debugf("Hosts query result: %v %v", host, err)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		coreLog.Error(err)
+		return
+	}
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		coreLog.Infof("Beacon %v is from a new host", beacon.ID)
+		err := dbSession.Create(&models.Host{
+			HostUUID:      uuid.FromStringOrNil(beacon.UUID.String()),
+			Hostname:      beacon.Hostname,
+			OSVersion:     beacon.OS,
+			Locale:        beacon.Locale,
 			IOCs:          []models.IOC{},
 			ExtensionData: []models.ExtensionData{},
 		}).Error

--- a/server/handlers/beacons.go
+++ b/server/handlers/beacons.go
@@ -95,6 +95,7 @@ func beaconRegisterHandler(implantConn *core.ImplantConnection, data []byte) *sl
 	core.EventBroker.Publish(core.Event{
 		EventType: consts.BeaconRegisteredEvent,
 		Data:      eventData,
+		Beacon:    beacon,
 	})
 
 	go auditLogBeacon(beacon, beaconReg.Register)


### PR DESCRIPTION
#### Details
Thought it was strange to see when I was testing with only beacons.
```
[server] sliver > hosts

[*] No hosts

```
