### PR TITLE
Add new event WireGuardNewPeer to get peer configured immediately

### DIFF
--- a/client/constants/constants.go
+++ b/client/constants/constants.go
@@ -91,6 +91,9 @@ const (
 
 	// ExternalBuildEvent
 	ExternalBuildEvent = "external-build"
+
+	// WireGuardNewPeer - New Wireguard peer added
+	WireGuardNewPeer = "wireguard-newpeer"
 )
 
 // Commands

--- a/server/certs/wireguard.go
+++ b/server/certs/wireguard.go
@@ -21,7 +21,10 @@ package certs
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 
+	consts "github.com/bishopfox/sliver/client/constants"
+	"github.com/bishopfox/sliver/server/core"
 	"github.com/bishopfox/sliver/server/db"
 	"github.com/bishopfox/sliver/server/db/models"
 	"github.com/bishopfox/sliver/server/log"
@@ -147,6 +150,11 @@ func saveWGKeys(isPeer bool, wgPeerTunIP string, privKey string, pubKey string) 
 		}
 		result = dbSession.Create(&wgKeysModel)
 	}
+	core.EventBroker.Publish(core.Event{
+		EventType: consts.WireGuardNewPeer,
+		Data: []byte(fmt.Sprintf("public_key=%s\nallowed_ip=%s/32", pubKey, wgPeerTunIP)),
+	})
+
 
 	return result.Error
 }

--- a/server/certs/wireguard.go
+++ b/server/certs/wireguard.go
@@ -152,7 +152,7 @@ func saveWGKeys(isPeer bool, wgPeerTunIP string, privKey string, pubKey string) 
 	}
 	core.EventBroker.Publish(core.Event{
 		EventType: consts.WireGuardNewPeer,
-		Data: []byte(fmt.Sprintf("public_key=%s\nallowed_ip=%s/32", pubKey, wgPeerTunIP)),
+		Data: []byte(fmt.Sprintf("public_key=%s\nallowed_ip=%s/32\n", pubKey, wgPeerTunIP)),
 	})
 
 


### PR DESCRIPTION
#### Details
Eliminates the 5 second delay on Wireguard connections

I just noticed the Event interface today and realized it's a way better solution than every 5 seconds checking for new peers.