### PR TITLE
Avoid closing nill tls connection #919

### DIFF
--- a/implant/sliver/transports/beacon.go
+++ b/implant/sliver/transports/beacon.go
@@ -211,11 +211,13 @@ func mtlsBeacon(uri *url.URL) *Beacon {
 			return mtls.WriteEnvelope(conn, envelope)
 		},
 		Close: func() error {
-			err = conn.Close()
-			if err != nil {
-				return err
+			if conn != nill {
+				err = conn.Close()
+				if err != nil {
+					return err
+				}
+				conn = nil
 			}
-			conn = nil
 			return nil
 		},
 		Cleanup: func() error {


### PR DESCRIPTION
Avoid nil pointer deference when closing mtls connection.