### PR TITLE
Ensure beacon tries to connect the same as session

### DIFF
--- a/implant/sliver/transports/beacon.go
+++ b/implant/sliver/transports/beacon.go
@@ -341,7 +341,7 @@ func dnsBeacon(uri *url.URL) *Beacon {
 		ActiveC2: uri.String(),
 		Init: func() error {
 			opts := dnsclient.ParseDNSOptions(uri)
-			client, err = dnsclient.DNSStartSession(uri.Host, opts)
+			client, err = dnsclient.DNSStartSession(uri.Hostname(), opts)
 			if err != nil {
 				// {{if .Config.Debug}}
 				log.Printf("[beacon] dns connection error %s", err)


### PR DESCRIPTION
#### Details
If you specify a port with a DNS transport the behavior is different with a session vs beacon.
```
[server] sliver > generate beacon  --os linux --save implant_test --debug --skip-symbols --dns test.example.com:53
```
```
2022/09/28 15:48:07 dnsclient.go:150: DNS client connecting to 'test.example.com:53' (timeout: 5s) ...
2022/09/28 15:48:07 dnsclient.go:295: [dns] found resolvers: [127.0.0.53]
2022/09/28 15:48:07 crypto.go:199: TOTP Code: 38892461
2022/09/28 15:48:07 dnsclient.go:713: [dns] Fetching dns session id via 'baakbgjer0fa.test.example.com:53.' ...
```

```
[server] sliver > generate  --os linux --save implant_test --debug --skip-symbols --dns test.example.com:53
```

```
2022/09/28 15:49:04 session.go:171: Attempting to connect via DNS via parent: test.example.com
2022/09/28 15:49:04 dnsclient.go:150: DNS client connecting to 'test.example.com' (timeout: 5s) ...
2022/09/28 15:49:04 dnsclient.go:295: [dns] found resolvers: [127.0.0.53]
2022/09/28 15:49:04 crypto.go:199: TOTP Code: 06370943
2022/09/28 15:49:04 dnsclient.go:713: [dns] Fetching dns session id via 'baakbzz688b8.test.example.com.' ...
2022/09/28 15:49:04 resolver-generic.go:92: [dns] 127.0.0.53:53->A record of baakbzz688b8.test.example.com. ?
```