### PR TITLE
Fix pstree

### DIFF
--- a/client/command/processes/pstree.go
+++ b/client/command/processes/pstree.go
@@ -65,6 +65,7 @@ func (n *node) findParent(proc *commonpb.Process) *node {
 }
 
 func reorder(root *node) {
+	toDelete := make([]int32, 0)
 	for pid, child := range root.Children {
 		// skip root node
 		if child.Value.Pid == -1 {
@@ -83,10 +84,14 @@ func reorder(root *node) {
 				}
 				// copy to new parent
 				parent.Children[pid] = child
-				// remove from root node
-				delete(root.Children, pid)
+				// mark for deletion
+				toDelete = append(toDelete, pid)
 			}
 		}
+	}
+	// delete children that were moved
+	for _, pid := range toDelete {
+		delete(root.Children, pid)
 	}
 }
 

--- a/client/command/processes/pstree.go
+++ b/client/command/processes/pstree.go
@@ -138,7 +138,11 @@ func (t *PsTree) addToTree(tree treeprint.Tree, procs map[int32]*node) {
 
 		procNode := tree.FindByMeta(pid)
 		if procNode == nil {
-			procNode = tree.AddMetaBranch(pid, procName)
+			if len(proc.Children) > 0 {
+				procNode = tree.AddMetaBranch(pid, procName)
+			} else {
+				procNode = tree.AddMetaNode(pid, procName)
+			}
 		}
 		t.addToTree(procNode, proc.Children)
 	}

--- a/client/command/processes/pstree.go
+++ b/client/command/processes/pstree.go
@@ -2,6 +2,7 @@ package processes
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/bishopfox/sliver/client/console"
 	"github.com/bishopfox/sliver/protobuf/commonpb"
@@ -10,38 +11,130 @@ import (
 
 // A PsTree is a tree of *commonpb.Process
 type PsTree struct {
-	tree       treeprint.Tree
-	implantPID int32
+	printableTree treeprint.Tree // only used for rendering
+	implantPID    int32
+	procTree      *node // used to hold the tree structure
+}
+
+type node struct {
+	Value    *commonpb.Process // The process information
+	Children map[int32]*node   // The children of this node
+	Parent   *node             // The parent of this node
 }
 
 // NewPsTree creates a new PsTree
 func NewPsTree(pid int32) *PsTree {
 	return &PsTree{
-		tree:       treeprint.New(),
-		implantPID: pid,
+		printableTree: treeprint.New(),
+		implantPID:    pid,
+		procTree:      &node{Value: &commonpb.Process{Pid: -1}},
 	}
 }
 
-func (t *PsTree) AddProcess(process *commonpb.Process) {
-	if existingParent := t.tree.FindByMeta(process.Ppid); existingParent != nil {
-		procName := t.filterProc(process)
-		existingParent.AddMetaBranch(process.Pid, procName)
+func (n *node) insert(proc *commonpb.Process) {
+	if n.Value == nil {
+		n.Value = proc
+		return
+	}
+	if parent := n.findParent(proc); parent != nil {
+		if parent.Children == nil {
+			parent.Children = make(map[int32]*node)
+		}
+		parent.Children[proc.Pid] = &node{Value: proc, Parent: parent}
 	} else {
-		t.tree.AddMetaBranch(process.Pid, process.Executable)
+		if n.Children == nil {
+			n.Children = make(map[int32]*node)
+		}
+		n.Children[proc.Pid] = &node{Value: proc, Parent: n}
 	}
 }
 
-func (t *PsTree) filterProc(process *commonpb.Process) string {
+func (n *node) findParent(proc *commonpb.Process) *node {
+	if n.Value == nil {
+		return nil
+	}
+	if n.Value.Pid == proc.Ppid {
+		return n
+	}
+	for _, child := range n.Children {
+		if p := child.findParent(proc); p != nil {
+			return p
+		}
+	}
+	return nil
+}
+
+func reorder(root *node) {
+	for pid, child := range root.Children {
+		// skip root node
+		if child.Value.Pid == -1 {
+			continue
+		}
+		// Skip edge case of [System Process] on Windows
+		if child.Value.Ppid == pid {
+			continue
+		}
+		// only focus on children without parent
+		if child.Parent.Value.Pid == -1 {
+			if parent := root.findParent(child.Value); parent != nil {
+				child.Parent = parent
+				if parent.Children == nil {
+					parent.Children = make(map[int32]*node)
+				}
+				// copy to new parent
+				parent.Children[pid] = child
+				// remove from root node
+				delete(root.Children, pid)
+			}
+		}
+	}
+}
+
+func (t *PsTree) AddProcess(proc *commonpb.Process) {
+	t.procTree.insert(proc)
+}
+
+func (t *PsTree) filterProc(proc *commonpb.Process) string {
 	color := console.Normal
-	if process.Pid == t.implantPID {
+	if proc.Pid == t.implantPID {
 		color = console.Green
 	}
-	if secTool, ok := knownSecurityTools[process.Executable]; ok {
+	if secTool, ok := knownSecurityTools[proc.Executable]; ok {
 		color = secTool[0]
 	}
-	return fmt.Sprintf(color+"%s"+console.Normal, process.Executable)
+	return fmt.Sprintf(color+"%s"+console.Normal, proc.Executable)
 }
 
 func (t *PsTree) String() string {
-	return t.tree.String()
+	reorder(t.procTree)
+	return t.Print()
+}
+
+func (t *PsTree) Print() string {
+	topLevelPIDs := make([]int, 0, len(t.procTree.Children))
+	for k := range t.procTree.Children {
+		topLevelPIDs = append(topLevelPIDs, int(k))
+	}
+	sort.Ints(topLevelPIDs)
+	for _, pid := range topLevelPIDs {
+		current := t.printableTree.AddMetaBranch(pid, t.filterProc(t.procTree.Children[int32(pid)].Value))
+		t.addToTree(current, t.procTree.Children[int32(pid)].Children)
+	}
+	return t.printableTree.String()
+
+}
+
+func (t *PsTree) addToTree(tree treeprint.Tree, procs map[int32]*node) {
+	for pid, proc := range procs {
+		if proc.Value.Pid == -1 {
+			continue
+		}
+		procName := t.filterProc(proc.Value)
+
+		procNode := tree.FindByMeta(pid)
+		if procNode == nil {
+			procNode = tree.AddMetaBranch(pid, procName)
+		}
+		t.addToTree(procNode, proc.Children)
+	}
 }


### PR DESCRIPTION
Fix process tree display. I didn't account to the fact that processes could have PPID superior to their own PID, and sorting processes was not enough to ensure a proper placement of the nodes in the tree. This PR fixes that, and reorders the tree to fix parent/child relationships before displaying it.