### PR TITLE
fix psexec help

### DIFF
--- a/client/command/help/long-help.go
+++ b/client/command/help/long-help.go
@@ -455,7 +455,7 @@ The profile must be created with the [[.Bold]]service[[.Normal]] format, so that
 
 To create such a profile, use the [[.Bold]]profiles new[[.Normal]] command:
 
-profiles new --format service --skip-symbols --mtls a.bc.de --profile-name win-svc64
+profiles new --format service --skip-symbols --mtls a.bc.de win-svc64
 
 Once the profile has been created, run the [[.Bold]]psexec[[.Normal]] command:
 


### PR DESCRIPTION
#### Card

#### Details
The help for psexec shows an example of setting up a profile. Profiles does not take the stated command line flag.