### PR TITLE
Refactor calls to `filepath.Match` implant side

### DIFF
--- a/implant/sliver/handlers/handlers.go
+++ b/implant/sliver/handlers/handlers.go
@@ -847,7 +847,7 @@ func compressDir(path string, filter string, recurse bool, buf io.Writer) (int, 
 		for _, fileName := range directoryFiles {
 			standardFileName := strings.ReplaceAll(testPath+fileName, "\\", "/")
 			if filter != "" {
-				match, err := filepath.Match(testPath+filter, standardFileName)
+				match, err := matcher.Match(testPath+filter, standardFileName)
 				if err == nil && match {
 					matchingFiles = append(matchingFiles, standardFileName)
 				}
@@ -861,7 +861,7 @@ func compressDir(path string, filter string, recurse bool, buf io.Writer) (int, 
 			if filter != "" {
 				// Normalize paths
 				testPath := strings.ReplaceAll(filepath.Dir(file), "\\", "/") + "/"
-				match, matchErr := filepath.Match(testPath+filter, filePath)
+				match, matchErr := matcher.Match(testPath+filter, filePath)
 				if !match || matchErr != nil {
 					// If there is an error, it is because the filter is bad, so it is not a match
 					return nil

--- a/implant/sliver/handlers/handlers.go
+++ b/implant/sliver/handlers/handlers.go
@@ -37,6 +37,7 @@ import (
 	"log"
 	// {{end}}
 
+	"github.com/bishopfox/sliver/implant/sliver/handlers/matcher"
 	"github.com/bishopfox/sliver/implant/sliver/transports"
 	"github.com/bishopfox/sliver/protobuf/commonpb"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
@@ -177,7 +178,7 @@ func dirListHandler(data []byte, resp RPCResponse) {
 		if filter == "" {
 			match = true
 		} else {
-			match, err = filepath.Match(filter, dirEntry.Name())
+			match, err = matcher.Match(filter, dirEntry.Name())
 			if err != nil {
 				// Then this is a bad filter, and it will be a bad filter
 				// on every iteration of the loop, so we might as well break now

--- a/implant/sliver/handlers/matcher/matcher.go
+++ b/implant/sliver/handlers/matcher/matcher.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package matcher
+
+import "path/filepath"
+
+// PathMatch - Match a path against a pattern, generic implementation
+func Match(pattern string, s string) (bool, error) {
+	return filepath.Match(pattern, s)
+}

--- a/implant/sliver/handlers/matcher/matcher_windows.go
+++ b/implant/sliver/handlers/matcher/matcher_windows.go
@@ -1,0 +1,11 @@
+package matcher
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Match - Windows specific implementation: disregard the case
+func Match(pattern string, s string) (bool, error) {
+	return filepath.Match(strings.ToLower(pattern), strings.ToLower(s))
+}


### PR DESCRIPTION
This PR refactors the calls to `filepath.Match` to call a wrapper package that contains platform specific code for Windows, so we can keep `dirListHandler` in generic builds without having to copy/paste the same `determineDirFilePath` function in multiple files.

Fixes #1017 .