### PR TITLE
Automatically run go-assets.sh from Makefile if it hasn't been run already

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ sliver-server-windows.zip
 .DS_Store
 
 dist/
+
+#Flag to show that go-assets.sh has been run
+.downloaded_assets

--- a/Makefile
+++ b/Makefile
@@ -118,32 +118,32 @@ endif
 # Targets
 #
 .PHONY: default
-default: clean validate-go-version
+default: clean .downloaded_assets validate-go-version
 	$(ENV) $(GO) build -mod=vendor -trimpath $(TAGS),server $(LDFLAGS) -o sliver-server$(ARTIFACT_SUFFIX) ./server
 	$(ENV) $(GO) build -mod=vendor -trimpath $(TAGS),client $(LDFLAGS) -o sliver-client$(ARTIFACT_SUFFIX) ./client
 
 .PHONY: macos
-macos: clean validate-go-version
+macos: clean .downloaded_assets validate-go-version
 	GOOS=darwin GOARCH=amd64 $(ENV) $(GO) build -mod=vendor -trimpath $(TAGS),server $(LDFLAGS) -o sliver-server$(ARTIFACT_SUFFIX) ./server
 	GOOS=darwin GOARCH=amd64 $(ENV) $(GO) build -mod=vendor -trimpath $(TAGS),client $(LDFLAGS) -o sliver-client$(ARTIFACT_SUFFIX) ./client
 
 .PHONY: macos-arm64
-macos-arm64: clean validate-go-version
+macos-arm64: clean .downloaded_assets validate-go-version
 	GOOS=darwin GOARCH=arm64 $(ENV) $(GO) build -mod=vendor -trimpath $(TAGS),server $(LDFLAGS) -o sliver-server$(ARTIFACT_SUFFIX) ./server
 	GOOS=darwin GOARCH=arm64 $(ENV) $(GO) build -mod=vendor -trimpath $(TAGS),client $(LDFLAGS) -o sliver-client$(ARTIFACT_SUFFIX) ./client
 
 .PHONY: linux
-linux: clean validate-go-version
+linux: clean .downloaded_assets validate-go-version
 	GOOS=linux GOARCH=amd64 $(ENV) $(GO) build -mod=vendor -trimpath $(TAGS),server $(LDFLAGS) -o sliver-server$(ARTIFACT_SUFFIX) ./server
 	GOOS=linux GOARCH=amd64 $(ENV) $(GO) build -mod=vendor -trimpath $(TAGS),client $(LDFLAGS) -o sliver-client$(ARTIFACT_SUFFIX) ./client
 
 .PHONY: linux-arm64
-linux-arm64: clean validate-go-version
+linux-arm64: clean .downloaded_assets validate-go-version
 	GOOS=linux GOARCH=arm64 $(ENV) $(GO) build -mod=vendor -trimpath $(TAGS),server $(LDFLAGS) -o sliver-server$(ARTIFACT_SUFFIX) ./server
 	GOOS=linux GOARCH=arm64 $(ENV) $(GO) build -mod=vendor -trimpath $(TAGS),client $(LDFLAGS) -o sliver-client$(ARTIFACT_SUFFIX) ./client
 
 .PHONY: windows
-windows: clean validate-go-version
+windows: clean .downloaded_assets validate-go-version
 	GOOS=windows $(ENV) $(GO) build -mod=vendor -trimpath $(TAGS),server $(LDFLAGS) -o sliver-server$(ARTIFACT_SUFFIX).exe ./server
 	GOOS=windows $(ENV) $(GO) build -mod=vendor -trimpath $(TAGS),client $(LDFLAGS) -o sliver-client$(ARTIFACT_SUFFIX).exe ./client
 
@@ -182,3 +182,6 @@ clean-all: clean
 .PHONY: clean
 clean:
 	rm -f sliver-client sliver-server sliver-*.exe
+
+.downloaded_assets:
+	./go-assets.sh

--- a/go-assets.sh
+++ b/go-assets.sh
@@ -190,6 +190,8 @@ curl -L --fail --output $OUTPUT_DIR/darwin/$GO_ARCH_1/sgn.zip https://github.com
 echo "curl -L --fail --output $OUTPUT_DIR/darwin/$GO_ARCH_2/sgn.zip https://github.com/moloch--/sgn/releases/download/v$SGN_VER/sgn_macos-$GO_ARCH_2.zip"
 curl -L --fail --output $OUTPUT_DIR/darwin/$GO_ARCH_2/sgn.zip https://github.com/moloch--/sgn/releases/download/v$SGN_VER/sgn_macos-$GO_ARCH_2.zip
 
+# Create this file so the Makefile will know we have been run once
+touch $REPO_DIR/.downloaded_assets
 
 # end
 echo -e "clean up: $WORK_DIR"


### PR DESCRIPTION
Was starting with a clean branch and forgot to manually run go-assets.sh.  
