### PR TITLE
Fix the bug of the corresponding relationship between dwLogonType and dwLogonProvider in MakeToken

### DIFF
--- a/implant/sliver/priv/priv_windows.go
+++ b/implant/sliver/priv/priv_windows.go
@@ -259,7 +259,11 @@ func MakeToken(domain string, username string, password string, logonType uint32
 	if err != nil {
 		return err
 	}
-	err = syscalls.LogonUser(pu, pd, pp, logonType, syscalls.LOGON32_PROVIDER_DEFAULT, &token)
+	if logonType == 0 {
+		err = syscalls.LogonUser(pu, pd, pp, logonType, syscalls.LOGON32_PROVIDER_WINNT50, &token)
+	} else {
+		err = syscalls.LogonUser(pu, pd, pp, logonType, syscalls.LOGON32_PROVIDER_DEFAULT, &token)
+	}
 	if err != nil {
 		// {{if .Config.Debug}}
 		log.Printf("LogonUser failed: %v\n", err)


### PR DESCRIPTION
#### Card

#### Details
Using LOGON32_LOGON_NEW_CREDENTIALS for Token verification is a very good solution, but according to the description of MSDN, there is a problem with the function call here.
When dwLogonType uses LOGON32_LOGON_NEW_CREDENTIALS, This logon type is supported only by the LOGON32_PROVIDER_WINNT50 logon provider.

https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-logonusera

![image](https://user-images.githubusercontent.com/117639542/208931734-2ae29eed-ea3b-4651-9d5d-4fee0287b3d9.png)
