### PR TITLE
install script- use users' primary group name

### DIFF
--- a/docs/install
+++ b/docs/install
@@ -170,6 +170,6 @@ for USER_DIR in "${USER_DIRS[@]}"; do
     if id -u $USER >/dev/null 2>&1; then
         mkdir -p $USER_DIR/.sliver-client/configs
         /root/sliver-server operator --name $USER --lhost localhost --save $USER_DIR/.sliver-client/configs
-        chown -R $USER:$USER $USER_DIR/.sliver-client/
+        chown -R $USER:"$(id -gn $USER)" $USER_DIR/.sliver-client/
     fi
 done


### PR DESCRIPTION
#### Details
The install script previously assumed that users were each a member of a group named the same as their username. While this is a convention on some systems, it's not universal. This change determines users' primary group name for chown'ing their client config directory instead of making this assumption.

