### PR TITLE
Add flag to disable sgn when generating beacon shellcode

### DIFF
--- a/client/command/commands.go
+++ b/client/command/commands.go
@@ -1388,6 +1388,7 @@ func BindCommands(con *console.SliverConsoleClient) {
 			f.Bool("l", "skip-symbols", false, "skip symbol obfuscation")
 			f.String("I", "template", "sliver", "implant code template")
 			f.Bool("E", "external-builder", false, "use an external builder")
+			f.Bool("G", "disable-sgn", false, "disable shikata ga nai shellcode encoder")
 
 			f.String("c", "canary", "", "canary domain(s)")
 

--- a/client/command/generate/generate.go
+++ b/client/command/generate/generate.go
@@ -346,6 +346,7 @@ func parseCompileFlags(ctx *grumble.Context, con *console.SliverConsoleClient) *
 		C2:               c2s,
 		CanaryDomains:    canaryDomains,
 		TemplateName:     ctx.Flags.String("template"),
+		DisableSGN:       ctx.Flags.Bool("disable-sgn"),
 
 		WGPeerTunIP:       tunIP.String(),
 		WGKeyExchangePort: uint32(ctx.Flags.Int("key-exchange")),
@@ -791,9 +792,9 @@ func compile(config *clientpb.ImplantConfig, save string, con *console.SliverCon
 
 	fileData := generated.File.Data
 	if config.IsShellcode {
-		confirm := false
-		survey.AskOne(&survey.Confirm{Message: "Encode shellcode with shikata ga nai?"}, &confirm)
-		if confirm {
+		if config.DisableSGN  {
+			con.PrintErrorf("Shikata ga nai encoder is %sdisabled%s\n", console.Bold, console.Normal)
+		} else {
 			con.PrintInfof("Encoding shellcode with shikata ga nai ... ")
 			resp, err := con.Rpc.ShellcodeEncoder(context.Background(), &clientpb.ShellcodeEncodeReq{
 				Encoder:      clientpb.ShellcodeEncoder_SHIKATA_GA_NAI,

--- a/protobuf/clientpb/client.pb.go
+++ b/protobuf/clientpb/client.pb.go
@@ -1220,6 +1220,7 @@ type ImplantConfig struct {
 	Evasion                 bool   `protobuf:"varint,9,opt,name=Evasion,proto3" json:"Evasion,omitempty"`
 	ObfuscateSymbols        bool   `protobuf:"varint,10,opt,name=ObfuscateSymbols,proto3" json:"ObfuscateSymbols,omitempty"`
 	TemplateName            string `protobuf:"bytes,11,opt,name=TemplateName,proto3" json:"TemplateName,omitempty"`
+	DisableSGN              bool   `protobuf:"varint,12,opt,name=DisableSGN,proto3" json:"DisableSGN,omitempty"`
 	MtlsCACert              string `protobuf:"bytes,20,opt,name=MtlsCACert,proto3" json:"MtlsCACert,omitempty"`
 	MtlsCert                string `protobuf:"bytes,21,opt,name=MtlsCert,proto3" json:"MtlsCert,omitempty"`
 	MtlsKey                 string `protobuf:"bytes,22,opt,name=MtlsKey,proto3" json:"MtlsKey,omitempty"`


### PR DESCRIPTION
#### What
This PR will enable operators to auto generate shellcode without prompting for SGN encoding.  You can pass `--disable-sgn` to disable SGN or, omit to encode by default.  You will be notified during generation, whether or not its enabled.

![image](https://user-images.githubusercontent.com/22455009/210426274-8f44486a-b922-4fde-9a75-db97e72614ca.png)

#### Why
This flag was already available for `migrate.go` and lateral movement, but not for beacon generation.  At the beginning of my assessments, I pre-generate all shellcode automatically.  When Sliver prompts for user input after I had issued the generate comand, I have a coronary embolism.  The `--disable-sgn` flag enables a safe worksite.  :-) 