### PR TITLE
fix goroutine leak

### DIFF
--- a/client/command/beacons/watch.go
+++ b/client/command/beacons/watch.go
@@ -57,7 +57,7 @@ func BeaconsWatchCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 }
 
 func waitForInput() <-chan bool {
-	done := make(chan bool)
+	done := make(chan bool, 1)
 	go func() {
 		defer close(done)
 		fmt.Scanf("\n")


### PR DESCRIPTION
#### Card

#### Details
If the timer times out first, the sender will block because `done` has no receiver and is a unbuffered chan, causing the goroutine to leak.