### PR TITLE
fix defunct processes on nix

### DIFF
--- a/implant/sliver/handlers/handlers.go
+++ b/implant/sliver/handlers/handlers.go
@@ -607,6 +607,7 @@ func executeHandler(data []byte, resp RPCResponse) {
 		}
 	} else {
 		err = cmd.Start()
+		cmd.Wait()
 		if err != nil {
 			execResp.Response = &commonpb.Response{
 				Err: fmt.Sprintf("%s", err),


### PR DESCRIPTION
I apologize for the lack of a branch w/ proper name. I'll also admit that I don't exactly know how this works, but I tried it based on the suggestion Dominic Breuker on the BH Slack, and it appears to fix the issue after some testing. With this one line addition,  execute works without creating a ton of defunct children processes. 
![sliver_exec_defunct](https://user-images.githubusercontent.com/8229583/222971982-1b176261-e850-45dd-8c2b-fc541323955d.png)
