### PR TITLE
Update `DumpCookies` method

### DIFF
--- a/client/overlord/overlord.go
+++ b/client/overlord/overlord.go
@@ -32,6 +32,7 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/cdproto/storage"
 	"github.com/chromedp/cdproto/target"
 	"github.com/chromedp/chromedp"
 )
@@ -275,7 +276,7 @@ func DumpCookies(curse *core.CursedProcess, webSocketURL string) ([]*network.Coo
 	dumpCookieTasks := chromedp.Tasks{
 		// read network values
 		chromedp.ActionFunc(func(ctx context.Context) error {
-			cookies, err = network.GetCookies().Do(ctx)
+			cookies, err = storage.GetCookies().Do(ctx)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Use `storage.GetCookies()` instead of `network.GetCookies()`. Per chrome devtools documentation, `network.GetCookies()` will ` GetCookies returns all browser cookies for the current URL. Depending on the backend support, will return detailed cookie information in the cookies field.`, which is not what we want. `storage.GetCookies()` will get us all browsers cookies.
