### PR TITLE
Add armory support for private Github APIs

### DIFF
--- a/client/command/armory/armory.go
+++ b/client/command/armory/armory.go
@@ -484,7 +484,7 @@ func fetchPackageSignature(wg *sync.WaitGroup, armoryConfig *assets.ArmoryConfig
 
 	var sig *minisign.Signature
 	if pkgParser, ok := pkgParsers[repoURL.Hostname()]; ok {
-		sig, _, err = pkgParser(armoryPkg, true, clientConfig)
+		sig, _, err = pkgParser(armoryConfig, armoryPkg, true, clientConfig)
 	} else {
 		sig, _, err = DefaultArmoryPkgParser(armoryConfig, armoryPkg, true, clientConfig)
 	}

--- a/client/command/armory/install.go
+++ b/client/command/armory/install.go
@@ -143,7 +143,7 @@ func installAliasPackageByName(name string, clientConfig ArmoryHTTPConfig, con *
 	var sig *minisign.Signature
 	var tarGz []byte
 	if pkgParser, ok := pkgParsers[repoURL.Hostname()]; ok {
-		sig, tarGz, err = pkgParser(&entry.Pkg, false, clientConfig)
+		sig, tarGz, err = pkgParser(entry.ArmoryConfig, &entry.Pkg, false, clientConfig)
 	} else {
 		sig, tarGz, err = DefaultArmoryPkgParser(entry.ArmoryConfig, &entry.Pkg, false, clientConfig)
 	}
@@ -261,7 +261,7 @@ func installExtensionPackageByName(name string, clientConfig ArmoryHTTPConfig, c
 	var sig *minisign.Signature
 	var tarGz []byte
 	if pkgParser, ok := pkgParsers[repoURL.Hostname()]; ok {
-		sig, tarGz, err = pkgParser(&entry.Pkg, false, clientConfig)
+		sig, tarGz, err = pkgParser(entry.ArmoryConfig, &entry.Pkg, false, clientConfig)
 	} else {
 		sig, tarGz, err = DefaultArmoryPkgParser(entry.ArmoryConfig, &entry.Pkg, false, clientConfig)
 	}


### PR DESCRIPTION
The main purpose of the PR is to make it possible to specify authorization/credentials in conjunction with using a private Github based armory, using the existing `armories.json` config file. There is also some code clean-up to consolidate the http request functionality.

NB. as part of the change, both the API-based index and package parsers have been switched to use the API Github file download endpoint, instead of the browser based one  (`asset.BrowserDownloadURL` -> `asset.URL`), so that we can optionally use an Authorization header.