### PR TITLE
Further stabilization of extensions in beacon mode

### DIFF
--- a/implant/sliver/sliver.go
+++ b/implant/sliver/sliver.go
@@ -395,26 +395,20 @@ func beaconMain(beacon *transports.Beacon, nextCheckin time.Time) error {
 	}
 
 	var tasksExtensionRegister []*sliverpb.Envelope
-	var tasksExtensionCall []*sliverpb.Envelope
 	var tasksOther []*sliverpb.Envelope
 
 	for _, task := range tasks.Tasks {
 		switch task.Type {
 		case sliverpb.MsgRegisterExtensionReq:
 			tasksExtensionRegister = append(tasksExtensionRegister, task)
-		case sliverpb.MsgCallExtensionReq:
-			tasksExtensionCall = append(tasksExtensionCall, task)
 		default:
 			tasksOther = append(tasksOther, task)
 		}
 	}
 
-	// execute task lists sequentially, ensure all extensions are registered before they are called
+	// ensure extensions are registered before they are called
 	var results []*sliverpb.Envelope
 	for _, r := range beaconHandleTasklist(tasksExtensionRegister) {
-		results = append(results, r)
-	}
-	for _, r := range beaconHandleTasklist(tasksExtensionCall) {
 		results = append(results, r)
 	}
 	for _, r := range beaconHandleTasklist(tasksOther) {


### PR DESCRIPTION
#### Card

Beacons still crash when some extensions are called or are called too often within a single beacon check in. This code does two things:
- ensure all beacon registration tasks are executed before any other task gets executed, to prevent calling an extension that has not been registered yet
- ensure the wait group counter for beacon task execution cannot become negative, which could and does cause panics (c.f. https://github.com/BishopFox/sliver/issues/679)

#### Details

