### PR TITLE
Adding support for killing a beacon using the short form of its ID

### DIFF
--- a/client/command/beacons/helpers.go
+++ b/client/command/beacons/helpers.go
@@ -109,7 +109,7 @@ func GetBeacon(con *console.SliverConsoleClient, beaconID string) (*clientpb.Bea
 		return nil, ErrNoBeacons
 	}
 	for _, beacon := range beacons.Beacons {
-		if beacon.ID == beaconID {
+		if beacon.ID == beaconID || strings.HasPrefix(beacon.ID, beaconID) {
 			return beacon, nil
 		}
 	}


### PR DESCRIPTION
While working with beacons, I noticed that you cannot kill a beacon using the short form of its ID. For example, if I want to kill `70a3eab9-d208-4e51-872a-f11c1d6e28b0`, I have to use its full ID instead of the short form `70a3eab9`. This PR makes it so that you can kill beacons using the short form of their ID, like you can with sessions.