### PR TITLE
Complete tearing down Wireguard listener before marking the job as complete

### DIFF
--- a/server/c2/jobs.go
+++ b/server/c2/jobs.go
@@ -108,7 +108,7 @@ func StartWGListenerJob(listenPort uint16, nListenPort uint16, keyExchangeListen
 		<-job.JobCtrl
 		jobLog.Infof("Stopping wg listener (%d) ...", job.ID)
 		ticker.Stop()
-		done <- true
+		
 		err = ln.Close() // Kills listener GoRoutines in StartWGListener()
 		if err != nil {
 			jobLog.Fatal("Error closing listener", err)
@@ -118,6 +118,7 @@ func StartWGListenerJob(listenPort uint16, nListenPort uint16, keyExchangeListen
 			jobLog.Fatal("Error closing wg tunnel", err)
 		}
 		core.Jobs.Remove(job)
+		done <- true
 	}()
 	core.Jobs.Add(job)
 


### PR DESCRIPTION
Addresses #1192 . Moved the statement to close the channel to after all of the connection teardown for a Wireguard listener is done.