### PR TITLE
always display updated info 

### DIFF
--- a/client/command/info/info.go
+++ b/client/command/info/info.go
@@ -43,6 +43,14 @@ func InfoCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 	if idArg != "" {
 		// ID passed via argument takes priority
 		session, beacon, err = use.SessionOrBeaconByID(idArg, con)
+	} else if session != nil || beacon != nil {
+		var currID = ""
+		if session != nil {
+			currID = session.ID
+		} else {
+			currID = beacon.ID
+		}
+		session, beacon, err = use.SessionOrBeaconByID(currID, con)
 	} else {
 		if session == nil && beacon == nil {
 			session, beacon, err = use.SelectSessionOrBeacon(con)


### PR DESCRIPTION
pull latest beacon or session configuration on info command even if a beacon or session is currently selected, otherwise outdated values are displayed after a reconfig command