### PR TITLE
Refactor `migrate`

### DIFF
--- a/client/command/commands.go
+++ b/client/command/commands.go
@@ -1205,12 +1205,10 @@ func BindCommands(con *console.SliverConsoleClient) {
 			con.Println()
 			return nil
 		},
-		Args: func(a *grumble.Args) {
-			a.Uint("pid", "pid")
-		},
 		Flags: func(f *grumble.Flags) {
 			f.Bool("S", "disable-sgn", true, "disable shikata ga nai shellcode encoder")
-
+			f.Uint("p", "pid", 0, "process id to migrate into")
+			f.String("n", "process-name", "", "name of the process to migrate into")
 			f.Int("t", "timeout", defaultTimeout, "command timeout in seconds")
 		},
 		HelpGroup: consts.SliverWinHelpGroup,


### PR DESCRIPTION
Refactor the `migrate` command to allow to use process names with the `--process-name/-n` flag or a PID with `--pid/-p`.

The command will stop on the first process matching the process name passed, so it is up to the operator to be careful here.