### PR TITLE
Fixing new line discrepancy when the Sliver Client is Windows and the implant is not Windows

### DIFF
--- a/client/command/exec/execute-shellcode.go
+++ b/client/command/exec/execute-shellcode.go
@@ -154,7 +154,7 @@ func executeInteractive(ctx *grumble.Context, hostProc string, shellcode []byte,
 		return
 	}
 
-	tunnel := core.GetTunnels().Start(rpcTunnel.GetTunnelID(), rpcTunnel.GetSessionID())
+	tunnel := core.GetTunnels().Start(rpcTunnel.GetTunnelID(), rpcTunnel.GetSessionID(), false)
 
 	shell, err := con.Rpc.Shell(context.Background(), &sliverpb.ShellReq{
 		Request:   con.ActiveTarget.Request(ctx),

--- a/client/core/portfwd.go
+++ b/client/core/portfwd.go
@@ -205,7 +205,7 @@ func (p *ChannelProxy) dialImplant(ctx context.Context) (*TunnelIO, error) {
 	}
 
 	log.Printf("[tcpproxy] Created new tunnel with id %d (session %s)", rpcTunnel.TunnelID, p.Session.ID)
-	tunnel := GetTunnels().Start(rpcTunnel.TunnelID, rpcTunnel.SessionID)
+	tunnel := GetTunnels().Start(rpcTunnel.TunnelID, rpcTunnel.SessionID, false)
 
 	log.Printf("[tcpproxy] Binding tunnel to portfwd %d", p.Port())
 	portfwdResp, err := p.Rpc.Portfwd(ctx, &sliverpb.PortfwdReq{

--- a/client/core/tunnels.go
+++ b/client/core/tunnels.go
@@ -96,7 +96,7 @@ func (t *tunnels) send(tunnelData *sliverpb.TunnelData) error {
 }
 
 // Start - Add a tunnel to the core mapper
-func (t *tunnels) Start(tunnelID uint64, sessionID string) *TunnelIO {
+func (t *tunnels) Start(tunnelID uint64, sessionID string, newLineFix bool) *TunnelIO {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
@@ -109,6 +109,15 @@ func (t *tunnels) Start(tunnelID uint64, sessionID string) *TunnelIO {
 		log.Printf("Tunnel now is open, %d", tunnelID)
 
 		for data := range tunnel.Send {
+
+			// Replace Windows new line "\r\n" with "\n"
+			if newLineFix && len(data) >= 2 {
+				if data[len(data)-2] == byte('\r') {
+					data = data[0 : len(data)-2]
+					data = append(data, byte('\n'))
+				}
+			}
+
 			log.Printf("Send %d bytes on tunnel %d", len(data), tunnel.ID)
 
 			err := t.send(&sliverpb.TunnelData{


### PR DESCRIPTION
#### Card
Related to issue: #1056 
Essentially the Windows Sliver client send "\r\n" to the implant even when its Linux session.

#### Details
I had to give tunnels.go `Start` function an additional parameter.
Because I only wanted the newline fix to be applied when it's actually required to prevent other workflows from breaking who are also using tunnels. Might as well not be necessary. 

Also I am not a Golang Guru but did try to find an efficient way to remove the `\r` from the data.

Hopefully this commit is somewhat decent, if not I am happy to receive any feedback and learn some things.
