### PR TITLE
Verbose error when msfvenom fails in `generate starger`

### DIFF
--- a/client/command/generate/generate-stager.go
+++ b/client/command/generate/generate-stager.go
@@ -106,7 +106,7 @@ func GenerateStagerCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 	<-ctrl
 
 	if err != nil {
-		con.PrintErrorf("Error: %v", err)
+		con.PrintErrorf("Error: %v - Please make sure Metasploit framework >= v6.2 is installed and msfvenom/msfconsole are in your PATH", err)
 		return
 	}
 

--- a/server/msf/msf.go
+++ b/server/msf/msf.go
@@ -123,7 +123,10 @@ func Version() (string, error) {
 
 // VenomPayload - Generates an MSFVenom payload
 func VenomPayload(config VenomConfig) ([]byte, error) {
-
+	// Check if msfvenom is in the path
+	if _, err := exec.LookPath(venomBin); err != nil {
+		return nil, fmt.Errorf("msfvenom not found in PATH")
+	}
 	// OS
 	if _, ok := validPayloads[config.Os]; !ok {
 		return nil, fmt.Errorf(fmt.Sprintf("Invalid operating system: %s", config.Os))
@@ -164,7 +167,7 @@ func VenomPayload(config VenomConfig) ([]byte, error) {
 		"--payload", payload,
 		fmt.Sprintf("LHOST=%s", config.LHost),
 		fmt.Sprintf("LPORT=%d", config.LPort),
-		fmt.Sprintf("EXITFUNC=thread"),
+		"EXITFUNC=thread",
 	}
 
 	if luri != "" {


### PR DESCRIPTION
Add a more verbose error message in the client and checks whether `msfvenom` is present in the `PATH` server side in the `msf.VenomPayload` function.

Fixes #1236 