### PR TITLE
Customization of the LURI for MSF Stager Payloads

### DIFF
--- a/server/configs/http-c2.go
+++ b/server/configs/http-c2.go
@@ -152,8 +152,10 @@ type HTTPC2ImplantConfig struct {
 	MaxPaths int `json:"max_paths"`
 	MinPaths int `json:"min_paths"`
 
-	// Stager File Extension
-	StagerFileExt string `json:"stager_file_ext"`
+	// Stager files and paths
+	StagerFileExt string   `json:"stager_file_ext"`
+	StagerFiles   []string `json:"stager_files"`
+	StagerPaths   []string `json:"stager_paths"`
 
 	// Poll files and paths
 	PollFileExt string   `json:"poll_file_ext"`
@@ -247,6 +249,14 @@ var (
 			MinPaths:          2,
 
 			StagerFileExt: ".woff",
+			StagerFiles: []string{
+				"attribute_text_w01_regular", "ZillaSlab-Regular.subset.bbc33fb47cf6",
+				"ZillaSlab-Bold.subset.e96c15f68c68", "Inter-Regular",
+				"Inter-Medium",
+			},
+			StagerPaths: []string{
+				"static", "assets", "fonts", "locales",
+			},
 
 			PollFileExt: ".js",
 			PollFiles: []string{
@@ -356,6 +366,7 @@ func generateDefaultConfig(saveTo string) error {
 var (
 	ErrMissingCookies             = errors.New("server config must specify at least one cookie")
 	ErrMissingStagerFileExt       = errors.New("implant config must specify a stager_file_ext")
+	ErrTooFewStagerFiles          = errors.New("implant config must specify at least one stager_files value")
 	ErrMissingPollFileExt         = errors.New("implant config must specify a poll_file_ext")
 	ErrTooFewPollFiles            = errors.New("implant config must specify at least one poll_files value")
 	ErrMissingKeyExchangeFileExt  = errors.New("implant config must specify a key_exchange_file_ext")
@@ -445,6 +456,10 @@ func checkImplantConfig(config *HTTPC2ImplantConfig) error {
 	config.StagerFileExt = coerceFileExt(config.StagerFileExt)
 	if config.StagerFileExt == "" {
 		return ErrMissingStagerFileExt
+	}
+	config.StagerFiles = coerceFiles(config.StagerFiles, config.StagerFileExt)
+	if len(config.StagerFiles) < 1 {
+		return ErrTooFewStagerFiles
 	}
 
 	// Poll Settings

--- a/server/rpc/rpc-msf.go
+++ b/server/rpc/rpc-msf.go
@@ -30,6 +30,7 @@ import (
 	"github.com/bishopfox/sliver/protobuf/commonpb"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
 	"github.com/bishopfox/sliver/server/codenames"
+	"github.com/bishopfox/sliver/server/configs"
 	"github.com/bishopfox/sliver/server/core"
 	"github.com/bishopfox/sliver/server/db"
 	"github.com/bishopfox/sliver/server/log"
@@ -207,16 +208,14 @@ func (rpc *Server) MsfStage(ctx context.Context, req *clientpb.MsfStagerReq) (*c
 
 // Utility functions
 func generateCallbackURI() string {
-	segments := []string{"static", "assets", "fonts", "locales"}
-	// Randomly picked font while browsing on the web
-	fontNames := []string{
-		"attribute_text_w01_regular.woff",
-		"ZillaSlab-Regular.subset.bbc33fb47cf6.woff",
-		"ZillaSlab-Bold.subset.e96c15f68c68.woff",
-		"Inter-Regular.woff",
-		"Inter-Medium.woff",
+	currentHTTPC2Config := configs.GetHTTPC2Config()
+	segments := currentHTTPC2Config.ImplantConfig.StagerPaths
+	fileNames := []string{}
+	for _, fileName := range currentHTTPC2Config.ImplantConfig.StagerFiles {
+		fileNames = append(fileNames, fileName+"."+currentHTTPC2Config.ImplantConfig.StagerFileExt)
 	}
-	return path.Join(randomPath(segments, fontNames)...)
+
+	return path.Join(randomPath(segments, fileNames)...)
 }
 
 func randomPath(segments []string, filenames []string) []string {


### PR DESCRIPTION
Addresses #1252. Added a section to the [HTTP C2 Configuration Options](https://github.com/BishopFox/sliver/wiki/HTTP(S)-C2#modifying-c2-traffic) to allow for greater customization of the LURI for MSF stager payloads. The `implant_config` property in the `http-c2.json` file now has two new properties: `stager_files` and `stager_paths`.

`stager_files` is a list of file names, and `stager_paths` is a list of directories. The URI is made up of one or more elements from `stager_paths`, a file name from `stager_files`, and `stager_file_ext`.

Here is an example:
```json
...
        "stager_file_ext": ".jpg",
        "stager_files": [
            "a_pretty_picture",
            "another_picture",
            "totally_not_a_stager",
            "a_picture_wink_wink",
            "nothing_to_see_here"
        ],
        "stager_paths": [
            "images",
            "assets",
            "static",
            "static_assets",
            "resources",
            "image"
        ],
...
```

When we run `generate stager -L 127.0.0.1 -l 8080 -r http`, we can see the file name was chosen from the JSON above if we look at the logs:
```
[sliver/server/msf/msf.go:208] /opt/metasploit-framework/bin/msfvenom --platform windows --arch x64 --format raw --payload windows/x64/custom/reverse_winhttp LHOST=127.0.0.1 LPORT=8080 EXITFUNC=thread LURI=image/static/a_pretty_picture.jpg 
```

The default config uses the font file names that were used previously.