### PR TITLE
Client Side Error for Invalid / Unsupported TLS Certs for HTTPS listener

### DIFF
--- a/client/command/jobs/https.go
+++ b/client/command/jobs/https.go
@@ -20,6 +20,8 @@ package jobs
 
 import (
 	"context"
+	"crypto/tls"
+	"fmt"
 	"io/ioutil"
 	"time"
 
@@ -89,6 +91,10 @@ func getLocalCertificatePair(ctx *grumble.Context) ([]byte, []byte, error) {
 	key, err := ioutil.ReadFile(ctx.Flags.String("key"))
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if _, err := tls.X509KeyPair(cert, key); err != nil {
+		return nil, nil, fmt.Errorf("- could not parse cert or key (encrypted keys are not supported): %s", err.Error())
 	}
 	return cert, key, nil
 }


### PR DESCRIPTION
Addresses #1139. Adds an error message if the golang TLS library cannot use a cert / key combo provided for an HTTPS listener. I was looking into ways of decrypting the key client side then sending it to the server, but the functionality [crypto/x509.DecryptPEMBlock](https://pkg.go.dev/crypto/x509#DecryptPEMBlock) is deprecated, and I could not find a replacement.