### PR TITLE
Fixing new line issue for shell commands with windows sliver client

### DIFF
--- a/client/command/shell/filter-reader_generic.go
+++ b/client/command/shell/filter-reader_generic.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package shell
+
+import "io"
+
+type filterReader struct {
+	reader io.Reader
+}
+
+func newFilterReader(reader io.Reader) *filterReader {
+	return &filterReader{reader}
+}
+
+func (r *filterReader) Read(data []byte) (int, error) {
+	n, err := r.reader.Read(data)
+	if err != nil {
+		return n, err
+	}
+
+	return n, nil
+}

--- a/client/command/shell/filter-reader_windows.go
+++ b/client/command/shell/filter-reader_windows.go
@@ -1,0 +1,31 @@
+package shell
+
+import (
+	"io"
+)
+
+type filterReader struct {
+	reader io.Reader
+}
+
+func newFilterReader(reader io.Reader) *filterReader {
+	return &filterReader{reader}
+}
+
+func (r *filterReader) Read(data []byte) (int, error) {
+	n, err := r.reader.Read(data)
+	if err != nil {
+		return n, err
+	}
+
+	// Remove Windows new line
+	if n >= 2 {
+		if data[n-2] == byte('\r') {
+			data = data[0 : n-2]
+			data = append(data, byte('\n'))
+			n -= 1
+		}
+	}
+
+	return n, nil
+}

--- a/client/command/shell/shell.go
+++ b/client/command/shell/shell.go
@@ -131,7 +131,7 @@ func runInteractive(cmd *cobra.Command, shellPath string, noPty bool, con *conso
 		}
 	}()
 	log.Printf("Reading from stdin ...")
-	n, err := io.Copy(tunnel, os.Stdin)
+	n, err := io.Copy(tunnel, newFilterReader(os.Stdin))
 	log.Printf("Read %d bytes from stdin", n)
 	if err != nil && err != io.EOF {
 		con.PrintErrorf("Error reading from stdin: %s\n", err)


### PR DESCRIPTION
#### Card
Related to issue: https://github.com/BishopFox/sliver/issues/1056
Essentially the Windows Sliver Client sends "\r\n" to the implant even when its Linux implant. 

#### Details
Thanks @moloch-- for helping me out on how to implement the fix better.
Hopefully I did what you expected in the PR, if not I can iterate again ^^