### PR TITLE
Fallback to Direct Connection when HTTP Proxy Connection Fails

### DIFF
--- a/client/command/generate/generate.go
+++ b/client/command/generate/generate.go
@@ -531,7 +531,7 @@ func ParseWGc2(args string) ([]*clientpb.ImplantC2, error) {
 func hasValidC2AdvancedOptions(options url.Values) (bool, error) {
 	for key, value := range options {
 		if len(value) > 1 {
-			return false, fmt.Errorf("too many values specified for advanced option %s. Only one value for %s can be specified.", key, key)
+			return false, fmt.Errorf("too many values specified for advanced option %s. Only one value for %s can be specified", key, key)
 		}
 		testValue := value[0]
 
@@ -588,13 +588,35 @@ func hasValidC2AdvancedOptions(options url.Values) (bool, error) {
 	return true, nil
 }
 
+func checkOptionValue(c2Options url.Values, option string, value string) bool {
+	if !c2Options.Has(option) {
+		return false
+	} else {
+		optionValue := c2Options.Get(option)
+		return strings.ToLower(optionValue) == value
+	}
+}
+
+func uriWithoutProxyOptions(uri *url.URL) {
+	options := uri.Query()
+	// If any of the options do not exist, there is no error
+	options.Del("proxy")
+	options.Del("proxy-username")
+	options.Del("proxy-password")
+	options.Del("ask-proxy-creds")
+	options.Del("fallback")
+
+	uri.RawQuery = options.Encode()
+}
+
 // ParseHTTPc2 - Parse HTTP connection string arg
 func ParseHTTPc2(args string) ([]*clientpb.ImplantC2, error) {
 	c2s := []*clientpb.ImplantC2{}
 	if args == "" {
 		return c2s, nil
 	}
-	for index, arg := range strings.Split(args, ",") {
+	allArguments := strings.Split(args, ",")
+	for index, arg := range allArguments {
 		var uri *url.URL
 		var err error
 		if cmp := strings.ToLower(arg); strings.HasPrefix(cmp, "http://") || strings.HasPrefix(cmp, "https://") {
@@ -619,6 +641,16 @@ func ParseHTTPc2(args string) ([]*clientpb.ImplantC2, error) {
 			Priority: uint32(index),
 			URL:      uri.String(),
 		})
+		/* If a proxy is defined and the operator wants to fallback to connecting directly, add
+		   a C2 that connects directly without the proxy settings.
+		*/
+		if checkOptionValue(uri.Query(), "fallback", "true") && uri.Query().Has("proxy") && !checkOptionValue(uri.Query(), "driver", "wininet") {
+			uriWithoutProxyOptions(uri)
+			c2s = append(c2s, &clientpb.ImplantC2{
+				Priority: uint32(index + len(allArguments)),
+				URL:      uri.String(),
+			})
+		}
 	}
 	return c2s, nil
 }


### PR DESCRIPTION
Addresses #1282. Adds a new advanced HTTP C2 option called `fallback` that tells the implant to attempt a direct connection to the C2 server if connection via a proxy server fails.

Generating the implant:
```
profiles new -b http://my-awesome-c2:8080/?proxy=http://unrealiable-proxy&fallback=true -o linux -d proxy-profile
profiles generate -s /tmp/implant proxy-profile
```

The order of the connections is as described in the documentation when `fallback` is true: HTTPS with proxy, HTTP with proxy, HTTPS direct, HTTP direct:
```
...
2023/06/12 08:20:58 transports.go:96: Yield c2 uri = 'http://my-awesome-c2:8080?proxy=http://unreliable-proxy&fallback=true'
2023/06/12 08:20:58 transports.go:96: Yield c2 uri = 'http://my-awesome-c2:8080'
2023/06/12 08:20:58 session.go:84: Next CC = http://my-awesome-c2:8080?proxy=http://unreliable-proxy&fallback=true
2023/06/12 08:20:58 session.go:84: Next CC = http://my-awesome-c2:8080
2023/06/12 08:20:58 transports.go:96: Yield c2 uri = 'http://my-awesome-c2:8080?proxy=http://unreliable-proxy&fallback=true'
2023/06/12 08:20:58 session.go:172: Connecting -> http(s)://my-awesome-c2:8080
2023/06/12 08:20:58 gohttp.go:97: Force proxy "http://unreliable-proxy"
2023/06/12 08:20:58 gohttp.go:107: Proxy URL = 'http://unreliable-proxy'
...
2023/06/12 08:21:01 httpclient.go:361: [http] http response error: Post "https://my-awesome-c2:8080/index.html?d=19i3678481398&qq=71142985": proxyconnect tcp: dial tcp unreliable-proxy:80: connect: no route to host
...
2023/06/12 08:21:04 httpclient.go:361: [http] http response error: Post "http://my-awesome-c2:8080/login.html?bt=4743l5319&v=573604007z153": proxyconnect tcp: dial tcp unreliable-proxy:80: connect: no route to host
...
2023/06/12 08:21:04 sliver.go:134: Reconnect sleep: 1m0s
2023/06/12 08:22:04 session.go:172: Connecting -> http(s)://my-awesome-c2:8080
2023/06/12 08:22:04 session.go:84: Next CC = http://my-awesome-c2:8080?proxy=http://unreliable-proxy&fallback=true
2023/06/12 08:22:04 transports.go:96: Yield c2 uri = 'http://my-awesome-c2:8080'
...
2023/06/12 08:22:04 httpclient.go:361: [http] http response error: Post "https://my-awesome-c2:8080/oauth/authenticate/index.html?up=3e3913589&z=448a423422009": http: server gave HTTP response to HTTPS client
...
2023/06/12 08:22:04 httpclient.go:355: [http] POST -> http://my-awesome-c2:8080/auth/oauth2/oauth2/login.html?bp=33913589&e=33o7578006792 (106 bytes)
2023/06/12 08:22:04 httpclient.go:404: [http] New session id: 6f5579b8b50a2f5297c877689581873e
```

The PR adds a C2 entry for a direct connection to the C2 server if the `fallback` option is set to true and the `wininet` driver is not specified. By default, `fallback` is not set. The C2 with proxy server is kept in the rotation in case the connection can go through it on future attempts.