### PR TITLE
"profiles info" subcommand and saving poll timeout in profile

### DIFF
--- a/client/command/generate/profiles.go
+++ b/client/command/generate/profiles.go
@@ -21,6 +21,7 @@ package generate
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -118,6 +119,305 @@ func GetImplantProfileByName(name string, con *console.SliverConsoleClient) *cli
 		}
 	}
 	return nil
+}
+
+func populateProfileProperties(config *clientpb.ImplantConfig) map[string]string {
+	properties := make(map[string]string)
+
+	var plural string
+
+	properties["osarch"] = fmt.Sprintf("%s %s", strings.Title(config.GOOS), strings.ToUpper(config.GOARCH))
+	if config.IsBeacon {
+		properties["implanttype"] = "Beacon"
+		jitter := int(config.BeaconJitter / int64(math.Pow10(9)))
+		plural = "s"
+		if jitter == 1 {
+			plural = ""
+		}
+		properties["beaconjitter"] = fmt.Sprintf("%d second%s", jitter, plural)
+		interval := int(config.BeaconInterval / int64(math.Pow10(9)))
+		plural = "s"
+		if interval == 1 {
+			plural = ""
+		}
+		properties["beaconinterval"] = fmt.Sprintf("%d second%s", interval, plural)
+	} else {
+		properties["implanttype"] = "Session"
+	}
+	if config.Debug {
+		properties["debugging"] = "enabled"
+	} else {
+		properties["debugging"] = "disabled"
+	}
+
+	if config.Evasion {
+		properties["evasion"] = "enabled"
+	} else {
+		properties["evasion"] = "disabled"
+	}
+
+	if config.ObfuscateSymbols {
+		properties["obsymbols"] = "enabled"
+	} else {
+		properties["obsymbols"] = "disabled"
+	}
+
+	if config.SGNEnabled {
+		properties["sgn"] = "enabled"
+	} else {
+		properties["sgn"] = "disabled"
+	}
+
+	reconnect := int(config.ReconnectInterval / int64(math.Pow10(9)))
+	if reconnect == 1 {
+		plural = ""
+	} else {
+		plural = "s"
+	}
+	properties["reconnect"] = fmt.Sprintf("%d second%s", reconnect, plural)
+
+	properties["maxerrors"] = fmt.Sprintf("%d", config.MaxConnectionErrors)
+
+	poll := int(config.PollTimeout / int64(math.Pow10(9)))
+	if poll == 1 {
+		plural = ""
+	} else {
+		plural = "s"
+	}
+	properties["polltimeout"] = fmt.Sprintf("%d second%s", poll, plural)
+
+	c2URLs := []string{}
+	for index, c2 := range config.C2 {
+		c2URLs = append(c2URLs, fmt.Sprintf("[%d] %s", index+1, c2.URL))
+	}
+	properties["implantC2"] = strings.Join(c2URLs, "\n")
+	properties["canary"] = strings.Join(config.CanaryDomains, "\n")
+	if config.ConnectionStrategy == "" {
+		properties["connectstrat"] = "Sequential"
+	} else if config.ConnectionStrategy == "r" {
+		properties["connectstrat"] = "Random"
+	} else if config.ConnectionStrategy == "rd" {
+		properties["connectstrat"] = "Random Domain"
+	} else {
+		properties["connectstrat"] = config.ConnectionStrategy
+	}
+	properties["outputlimits"] = "n"
+	if config.LimitDomainJoined {
+		properties["limit-domjoin"] = "Yes"
+		properties["outputlimits"] = "y"
+	} else {
+		properties["limit-domjoin"] = "No"
+	}
+
+	if config.LimitDatetime != "" {
+		properties["limit-dt"] = config.LimitDatetime
+		properties["outputlimits"] = "y"
+	} else {
+		properties["limit-dt"] = "No restriction"
+	}
+
+	if config.LimitFileExists != "" {
+		properties["limit-file"] = config.LimitFileExists
+		properties["outputlimits"] = "y"
+	} else {
+		properties["limit-file"] = "No restriction"
+	}
+
+	if config.LimitHostname != "" {
+		properties["limit-host"] = config.LimitHostname
+		properties["outputlimits"] = "y"
+	} else {
+		properties["limit-host"] = "No restriction"
+	}
+
+	if config.LimitLocale != "" {
+		properties["limit-locale"] = config.LimitLocale
+		properties["outputlimits"] = "y"
+	} else {
+		properties["limit-locale"] = "No restriction"
+	}
+
+	if config.LimitUsername != "" {
+		properties["limit-user"] = config.LimitUsername
+		properties["outputlimits"] = "y"
+	} else {
+		properties["limit-user"] = "No restriction"
+	}
+
+	switch config.Format {
+	case clientpb.OutputFormat_EXECUTABLE:
+		properties["format"] = "Executable"
+	case clientpb.OutputFormat_SHARED_LIB:
+		properties["format"] = "Shared Library"
+	case clientpb.OutputFormat_SERVICE:
+		properties["format"] = "Service"
+	case clientpb.OutputFormat_SHELLCODE:
+		properties["format"] = "Shellcode"
+	case clientpb.OutputFormat_THIRD_PARTY:
+		properties["format"] = "Third Party"
+	}
+	if config.TrafficEncodersEnabled {
+		properties["trafficencoders"] = strings.Join(config.TrafficEncoders, "\n")
+	}
+
+	return properties
+}
+
+// PrintProfileInfo - Print detailed information about a given profile
+func PrintProfileInfo(name string, con *console.SliverConsoleClient) {
+	profile := GetImplantProfileByName(name, con)
+	if profile == nil {
+		con.PrintErrorf("Could not find a profile with the name \"%s\"", name)
+		return
+	}
+
+	config := profile.Config
+	properties := populateProfileProperties(config)
+	//con.Printf("--- Details for profile %s ---\n", profile.Name)
+	tw := table.NewWriter()
+
+	// Implant Basics
+	tw.AppendRow(table.Row{
+		"OS / Architecture",
+		properties["osarch"],
+	})
+	tw.AppendRow(table.Row{
+		"Implant Type",
+		properties["implanttype"],
+	})
+	tw.AppendRow(table.Row{
+		"Implant Format",
+		properties["format"],
+	})
+
+	con.PrintInfof("Implant Basics\n")
+	con.Printf("%s\n\n", tw.Render())
+
+	tw.ResetRows()
+	// Obfuscation Options
+	tw.AppendRow(table.Row{
+		"Evasion is",
+		properties["evasion"],
+	})
+	tw.AppendRow(table.Row{
+		"Debugging is",
+		properties["debugging"],
+	})
+	tw.AppendRow(table.Row{
+		"Obfuscation of symbols is",
+		properties["obsymbols"],
+	})
+	tw.AppendRow(table.Row{
+		"Shikata Ga Nai (SGN) is",
+		properties["sgn"],
+	})
+
+	con.PrintInfof("Obfuscation\n")
+	con.Printf("%s\n\n", tw.Render())
+
+	// Timeouts and Intervals
+	tw.ResetRows()
+	if config.IsBeacon {
+		tw.AppendRow(table.Row{
+			"Beacon Interval",
+			properties["beaconinterval"],
+		})
+		tw.AppendRow(table.Row{
+			"Beacon Jitter",
+			properties["beaconjitter"],
+		})
+	}
+	tw.AppendRow(table.Row{
+		"Reconnect Interval",
+		properties["reconnect"],
+	})
+	tw.AppendRow(table.Row{
+		"Maximum Connection Errors",
+		properties["maxerrors"],
+	})
+	tw.AppendRow(table.Row{
+		"Poll Timeout",
+		properties["polltimeout"],
+	})
+
+	con.PrintInfof("Timeouts and Intervals\n")
+	con.Printf("%s\n\n", tw.Render())
+
+	// C2
+	tw.ResetRows()
+	tw.AppendRow(table.Row{
+		"Endpoints",
+		properties["implantC2"],
+	})
+	if len(config.CanaryDomains) > 0 {
+		plural := "s"
+		if len(config.CanaryDomains) == 1 {
+			plural = ""
+		}
+		tw.AppendRow(table.Row{
+			fmt.Sprintf("Canary Domain%s", plural),
+			properties["canary"],
+		})
+	}
+	tw.AppendRow(table.Row{
+		"Connection Strategy",
+		properties["connectstrat"],
+	})
+
+	con.PrintInfof("Command and Control\n")
+	con.Printf("%s\n\n", tw.Render())
+
+	// Connection Restrictions
+	if properties["outputlimits"] == "y" {
+		tw.ResetRows()
+		tw.AppendRow(table.Row{
+			"Device must be domain joined",
+			properties["limit-domjoin"],
+		})
+		tw.AppendRow(table.Row{
+			"Execution will only occur before the following date/time",
+			properties["limit-dt"],
+		})
+		tw.AppendRow(table.Row{
+			"Files that must be present",
+			properties["limit-file"],
+		})
+		tw.AppendRow(table.Row{
+			"Device has the hostname",
+			properties["limit-host"],
+		})
+		tw.AppendRow(table.Row{
+			"Device uses the locale",
+			properties["limit-locale"],
+		})
+		tw.AppendRow(table.Row{
+			"The implant must be running under the context of specified user",
+			properties["limit-user"],
+		})
+
+		con.PrintInfof("Execution is subject to the following restrictions\n")
+		con.Printf("%s\n\n", tw.Render())
+	}
+
+	// Traffic encoders
+	if config.TrafficEncodersEnabled {
+		tw.ResetRows()
+		tw.AppendRow(table.Row{
+			"Traffic encoders",
+			properties["trafficencoders"],
+		})
+		con.PrintInfof("Traffic Encoders\n")
+		con.Printf("%s\n\n", tw.Render())
+	}
+
+	// Output messages that would otherwise get lost in between the tables
+	if properties["outputlimits"] == "n" {
+		con.PrintInfof("Execution is not subject to any restrictions\n")
+	}
+
+	if !config.TrafficEncodersEnabled {
+		con.PrintInfof("Traffic encoders are not enabled\n")
+	}
 }
 
 // ProfileNameCompleter - Completer for implant build names

--- a/client/command/server.go
+++ b/client/command/server.go
@@ -1014,6 +1014,18 @@ func ServerCommands(con *client.SliverConsoleClient, serverCmds func() []*cobra.
 		carapace.Gen(profilesRmCmd).PositionalCompletion(generate.ProfileNameCompleter(con))
 		profilesCmd.AddCommand(profilesRmCmd)
 
+		profilesInfoCmd := &cobra.Command{
+			Use:   consts.InfoStr,
+			Short: "Details about a profile",
+			Long:  help.GetHelpFor([]string{consts.ProfilesStr, consts.RmStr}),
+			Args:  cobra.ExactArgs(1),
+			Run: func(cmd *cobra.Command, args []string) {
+				generate.PrintProfileInfo(args[0], con)
+			},
+		}
+		carapace.Gen(profilesInfoCmd).PositionalCompletion(generate.ProfileNameCompleter(con))
+		profilesCmd.AddCommand(profilesInfoCmd)
+
 		implantBuildsCmd := &cobra.Command{
 			Use:   consts.ImplantBuildsStr,
 			Short: "List implant builds",

--- a/server/db/models/implant.go
+++ b/server/db/models/implant.go
@@ -92,6 +92,7 @@ type ImplantConfig struct {
 	Evasion             bool
 	ObfuscateSymbols    bool
 	ReconnectInterval   int64
+	PollTimeout         int64
 	MaxConnectionErrors uint32
 	ConnectionStrategy  string
 	SGNEnabled          bool
@@ -176,6 +177,7 @@ func (ic *ImplantConfig) ToProtobuf() *clientpb.ImplantConfig {
 
 		ReconnectInterval:   ic.ReconnectInterval,
 		MaxConnectionErrors: ic.MaxConnectionErrors,
+		PollTimeout:         ic.PollTimeout,
 		ConnectionStrategy:  ic.ConnectionStrategy,
 
 		LimitDatetime:     ic.LimitDatetime,

--- a/server/generate/binaries.go
+++ b/server/generate/binaries.go
@@ -174,6 +174,7 @@ func ImplantConfigFromProtobuf(pbConfig *clientpb.ImplantConfig) (string, *model
 	cfg.WGTcpCommsPort = pbConfig.WGTcpCommsPort
 	cfg.ReconnectInterval = pbConfig.ReconnectInterval
 	cfg.MaxConnectionErrors = pbConfig.MaxConnectionErrors
+	cfg.PollTimeout = pbConfig.PollTimeout
 
 	cfg.LimitDomainJoined = pbConfig.LimitDomainJoined
 	cfg.LimitDatetime = pbConfig.LimitDatetime


### PR DESCRIPTION
This PR adds a subcommand called `info` to the `profiles` command. The purpose is to give nitty gritty detail about a profile that is not shown in the normal profile view. It was useful for debugging some profile-related issues, so I figured it would not hurt to clean up the code a bit and submit it as a PR.

While I was working on this, I noticed that the `poll-timeout` setting was not saved in profiles and was defaulting to 0. I added `poll-timeout` to the information stored with a profile, and the setting appears to keep now.

Here is what `profiles info` looks like:
```
profiles info basicprofile 

[*] Implant Basics
+-------------------+------------+
| OS / Architecture | Linux 386  |
| Implant Type      | Session    |
| Implant Format    | Executable |
+-------------------+------------+

[*] Obfuscation
+---------------------------+----------+
| Evasion is                | disabled |
| Debugging is              | disabled |
| Obfuscation of symbols is | enabled  |
| Shikata Ga Nai (SGN) is   | disabled |
+---------------------------+----------+

[*] Timeouts and Intervals
+---------------------------+-------------+
| Reconnect Interval        | 60 seconds  |
| Maximum Connection Errors | 1000        |
| Poll Timeout              | 360 seconds |
+---------------------------+-------------+

[*] Command and Control
+---------------------+----------------------------------------------------------+
| Endpoints           | [1] http://evildomain.com:8080                           |
|                     | [2] https://backupdomain.com?proxy=http://proxy.com:1234 |
| Connection Strategy | Sequential                                               |
+---------------------+----------------------------------------------------------+

[*] Execution is not subject to any restrictions
[*] Traffic encoders are not enabled
```

Here is a beacon with execution restrictions:
```
profiles info beacon-with-restrictions 

[*] Implant Basics
+-------------------+---------------+
| OS / Architecture | Windows AMD64 |
| Implant Type      | Beacon        |
| Implant Format    | Shellcode     |
+-------------------+---------------+

[*] Obfuscation
+---------------------------+----------+
| Evasion is                | disabled |
| Debugging is              | disabled |
| Obfuscation of symbols is | enabled  |
| Shikata Ga Nai (SGN) is   | enabled  |
+---------------------------+----------+

[*] Timeouts and Intervals
+---------------------------+-------------+
| Beacon Interval           | 60 seconds  |
| Beacon Jitter             | 30 seconds  |
| Reconnect Interval        | 60 seconds  |
| Maximum Connection Errors | 1000        |
| Poll Timeout              | 360 seconds |
+---------------------------+-------------+

[*] Command and Control
+---------------------+-----------------------------------+
| Endpoints           | [1] https://www.myevildomain.com  |
|                     | [2] https://myotherevildomain.com |
| Connection Strategy | Sequential                        |
+---------------------+-----------------------------------+

[*] Execution is subject to the following restrictions
+-----------------------------------------------------------------+----------------+
| Device must be domain joined                                    | Yes            |
| Execution will only occur before the following date/time        | No restriction |
| Files that must be present                                      | file.ext       |
| Device has the hostname                                         | No restriction |
| Device uses the locale                                          | No restriction |
| The implant must be running under the context of specified user | User           |
+-----------------------------------------------------------------+----------------+

[*] Traffic encoders are not enabled
```