### PR TITLE
Fix make token test

### DIFF
--- a/implant/sliver/priv/priv_windows.go
+++ b/implant/sliver/priv/priv_windows.go
@@ -259,7 +259,7 @@ func MakeToken(domain string, username string, password string, logonType uint32
 	if err != nil {
 		return err
 	}
-	if logonType == 0 {
+	if logonType == syscalls.LOGON32_LOGON_NEW_CREDENTIALS {
 		err = syscalls.LogonUser(pu, pd, pp, logonType, syscalls.LOGON32_PROVIDER_WINNT50, &token)
 	} else {
 		err = syscalls.LogonUser(pu, pd, pp, logonType, syscalls.LOGON32_PROVIDER_DEFAULT, &token)


### PR DESCRIPTION
Minor fix to `make-token`: PR #1043 introduced a bug that didn't take into account that `logonType` was never `0` at the time of the test (because we set it to a default value if it's 0).
This PR fixes that.