### PR TITLE
Add RC4 support to shellcode stager

### DIFF
--- a/client/command/server.go
+++ b/client/command/server.go
@@ -376,6 +376,7 @@ func ServerCommands(con *client.SliverConsoleClient, serverCmds func() []*cobra.
 			f.BoolP("lets-encrypt", "e", false, "attempt to provision a let's encrypt certificate (HTTPS only)")
 			f.String("aes-encrypt-key", "", "encrypt stage with AES encryption key")
 			f.String("aes-encrypt-iv", "", "encrypt stage with AES encryption iv")
+			f.String("rc4-encrypt-key", "", "encrypt stage with RC4 encryption key")
 			f.StringP("compress", "C", "none", "compress the stage before encrypting (zlib, gzip, deflate9, none)")
 			f.BoolP("prepend-size", "P", false, "prepend the size of the stage to the payload (to use with MSF stagers)")
 		})

--- a/util/cryptography.go
+++ b/util/cryptography.go
@@ -22,9 +22,23 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/rc4"
 	"errors"
 	"io"
 )
+
+// RC4 encryption - Cryptographically insecure!
+// Added for stage-listener shellcode obfuscation
+// Dont use for anything else!
+func RC4EncryptUnsafe(data []byte, key []byte) []byte {
+	cipher, err := rc4.NewCipher(key)
+	if err != nil {
+		return make([]byte, 0)
+	}
+	cipherText := make([]byte, len(data))
+	cipher.XORKeyStream(cipherText, data)
+	return cipherText
+}
 
 // PreludeEncrypt the results
 func PreludeEncrypt(data []byte, key []byte, iv []byte) []byte {


### PR DESCRIPTION
Adding RC4 encryption support to the `stage-listener` to provide an additional obfuscation method for shellcode thats easy to implement in stager code.

As described in the feature request I raised in issue [1328](https://github.com/BishopFox/sliver/issues/1328).