### PR TITLE
Add the ability to generate .exe MSF stagers from Sliver

### DIFF
--- a/server/msf/msf.go
+++ b/server/msf/msf.go
@@ -82,6 +82,7 @@ var (
 		"csharp":        true,
 		"dw":            true,
 		"dword":         true,
+		"exe":           true,
 		"hex":           true,
 		"java":          true,
 		"js_be":         true,


### PR DESCRIPTION
As it is right now, one is only able to generate .exe stagers for Sliver via `msfvenom` due to a missing format in the format validation table.

Current behavior:
```
raise _create_rpc_error(self._cython_call._initial_metadata,
grpc.aio._call.AioRpcError: <AioRpcError of RPC that terminated with:
	status = StatusCode.UNKNOWN
	details = "Invalid format: exe"
	debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"Invalid format: exe", grpc_status:2, created_time:"2023-08-08T13:17:32.306018362+02:00"}"
```

Expected behavior:
```
<nothing :)>
```