### PR TITLE
Update install

### DIFF
--- a/docs/install
+++ b/docs/install
@@ -15,9 +15,15 @@ if command -v apt &> /dev/null; then
     DEBIAN_FRONTEND=noninteractive apt install -yqq \
         gpg curl build-essential git \
         mingw-w64 binutils-mingw-w64 g++-mingw-w64
+    	INSTALLER=(apt install -yqq)
 elif command -v yum &> /dev/null; then # Redhat-based OS (Fedora, CentOS, RHEL)
     echo "Installing dependencies using yum..."
     yum -y install gnupg curl gcc gcc-c++ make mingw64-gcc git
+	INSTALLER=(yum -y)
+elif command -v pacman &>/dev/null; then # Arch-based (Manjaro, Garuda, Blackarch)
+	echo "Installing dependencies using pacman..."
+	pacman -S mingw-w64-gcc mingw-w64-binutils mingw-w64-headers
+    INSTALLER=(pacman -S)
 else
     echo "Unsupported OS, exiting"
     exit
@@ -25,9 +31,9 @@ fi
 
 # Verify if necessary tools are installed
 for cmd in curl awk gpg; do
-    if ! command -v "$cmd" &> /dev/null; then
-        echo "$cmd could not be found, exiting"
-        exit 1
+    if ! command -v "$cmd" &> /dev/null; then		
+        echo "$cmd could not be found, installing..."
+		${INSTALLER[@]} "$cmd"
     fi
 done
 


### PR DESCRIPTION
Hello!
I wanted to commit these changes because I'd love to see official support for Arch Linux. I modified this script and installed Sliver on my system using it, so I know it works. Nevertheless, please do check it and try it yourselves! :)

### Details

As you can see, I added the INSTALLER variable, which stores the package manager in an array which will be used in case the user doesn't have awk. gpg or curl. After that, I added a new elif that will check the availability of the Pacman binary, and if it exists it will install the mingw-w64 packages for cross-compiling.

Apart from that, instead of exiting the script when awk,gpg,curl isn't found, now it'll install the missing packages.

Have a great day!!!!
