### PR TITLE
Fixing issue with User Agent in Implant Generation

### DIFF
--- a/implant/sliver/transports/httpclient/httpclient.go
+++ b/implant/sliver/transports/httpclient/httpclient.go
@@ -48,7 +48,7 @@ import (
 var (
 	goHTTPDriver = "go"
 
-	userAgent      = "{{GenerateUserAgent}}"
+	userAgent      = `{{GenerateUserAgent}}`
 	nonceQueryArgs = "{{.HTTPC2ImplantConfig.NonceQueryArgs}}" // "abcdefghijklmnopqrstuvwxyz"
 
 	ErrClosed                             = errors.New("http session closed")


### PR DESCRIPTION
Addresses #1444 . Makes the User Agent a string literal so that characters that are normally escaped, like double quote, can be inserted into that field. Here is what it looks like in Wireshark:

![image](https://github.com/BishopFox/sliver/assets/84349012/6e0e40c2-0a4d-4e10-9d7a-6f0971e2452f)

Default UA strings seem to work fine as well, so this should not cause any regressions.