### PR TITLE
Fix: removed implant macos and generic proxy logs when debug is disabled

### DIFF
--- a/implant/sliver/proxy/provider_darwin.go
+++ b/implant/sliver/proxy/provider_darwin.go
@@ -17,11 +17,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"net/url"
 	"regexp"
 	"strings"
 	"time"
+
+	// {{if .Config.Debug}}
+	"log"
+	// {{end}}
 )
 
 type providerDarwin struct {
@@ -137,6 +140,7 @@ Returns:
 func (p *providerDarwin) readDarwinNetworkSettingProxy(protocol string, targetUrl *url.URL) Proxy {
 	proxy, err := p.parseScutildata(protocol, targetUrl, scUtilBinary, scUtilBinaryArgument)
 	if err != nil {
+		// {{if .Config.Debug}}
 		if isNotFound(err) {
 			log.Printf("[proxy.Provider.readDarwinNetworkSettingProxy]: %s proxy is not enabled.\n", protocol)
 		} else if isTimedOut(err) {
@@ -144,6 +148,7 @@ func (p *providerDarwin) readDarwinNetworkSettingProxy(protocol string, targetUr
 		} else {
 			log.Printf("[proxy.Provider.readDarwinNetworkSettingProxy]: Failed to parse Scutil data, %s\n", err)
 		}
+		// {{end}}
 	}
 	return proxy
 }
@@ -257,7 +262,9 @@ func (p *providerDarwin) parseScutildata(protocol string, targetUrl *url.URL, na
 	}
 	if proxyBypass != "" {
 		bypass := p.isProxyBypass(targetUrl, proxyBypass, ",")
+		// {{if .Config.Debug}}
 		log.Printf("[proxy.Provider.parseProxyInfo]: ProxyBypass=\"%s\", targetUrl=%s, bypass=%t", proxyBypass, targetUrl, bypass)
+		// {{end}}
 		if bypass {
 			return nil, nil
 		}

--- a/implant/sliver/proxy/provider_generic.go
+++ b/implant/sliver/proxy/provider_generic.go
@@ -20,11 +20,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"net/url"
 	"regexp"
 	"strings"
 	"time"
+
+	// {{if .Config.Debug}}
+	"log"
+	// {{end}}
 )
 
 type providerDarwin struct {
@@ -140,6 +143,7 @@ Returns:
 func (p *providerDarwin) readDarwinNetworkSettingProxy(protocol string, targetUrl *url.URL) Proxy {
 	proxy, err := p.parseScutildata(protocol, targetUrl, scUtilBinary, scUtilBinaryArgument)
 	if err != nil {
+		// {{if .Config.Debug}}
 		if isNotFound(err) {
 			log.Printf("[proxy.Provider.readDarwinNetworkSettingProxy]: %s proxy is not enabled.\n", protocol)
 		} else if isTimedOut(err) {
@@ -147,6 +151,7 @@ func (p *providerDarwin) readDarwinNetworkSettingProxy(protocol string, targetUr
 		} else {
 			log.Printf("[proxy.Provider.readDarwinNetworkSettingProxy]: Failed to parse Scutil data, %s\n", err)
 		}
+		// {{end}}
 	}
 	return proxy
 }
@@ -260,7 +265,9 @@ func (p *providerDarwin) parseScutildata(protocol string, targetUrl *url.URL, na
 	}
 	if proxyBypass != "" {
 		bypass := p.isProxyBypass(targetUrl, proxyBypass, ",")
+		// {{if .Config.Debug}}
 		log.Printf("[proxy.Provider.parseProxyInfo]: ProxyBypass=\"%s\", targetUrl=%s, bypass=%t", proxyBypass, targetUrl, bypass)
+		// {{end}}
 		if bypass {
 			return nil, nil
 		}


### PR DESCRIPTION
#### Card

Removed logs from MACOS implant.

Removed

#### Details

Previously, a MACOS implant with debug mode disabled created some logs:
```
d00movenok@Mac-d00movenok Desktop % ./LINEAR_RACK 
2023/11/10 23:06:50 [proxy.Provider.readDarwinNetworkSettingProxy]: https proxy is not enabled.
2023/11/10 23:06:50 [proxy.Provider.readDarwinNetworkSettingProxy]: https proxy is not enabled.
2023/11/10 23:09:19 [proxy.Provider.readDarwinNetworkSettingProxy]: https proxy is not enabled.
2023/11/10 23:09:19 [proxy.Provider.readDarwinNetworkSettingProxy]: https proxy is not enabled.
```

Now this logs is disabled for non-debug implants.
