### PR TITLE
Adds the "permissions" flag to operator cmd in cli

### DIFF
--- a/server/cli/cli.go
+++ b/server/cli/cli.go
@@ -79,6 +79,7 @@ func init() {
 	operatorCmd.Flags().StringP(lhostFlagStr, "l", "", "multiplayer listener host")
 	operatorCmd.Flags().Uint16P(lportFlagStr, "p", uint16(31337), "multiplayer listener port")
 	operatorCmd.Flags().StringP(saveFlagStr, "s", "", "save file to ...")
+	operatorCmd.Flags().StringSliceP(permissionsFlagStr, "P", []string{}, "grant permissions to the operator profile (all, builder, crackstation)")
 	rootCmd.AddCommand(operatorCmd)
 
 	// Certs


### PR DESCRIPTION
The pull request adds the `--permissions` flag to the CLI.

Fixes #1480 