### PR TITLE
IOC Fixes

### DIFF
--- a/server/db/models/host.go
+++ b/server/db/models/host.go
@@ -36,8 +36,8 @@ type Host struct {
 	OSVersion string // Verbose OS version
 	Locale    string // Detected language code
 
-	IOCs          []IOC
-	ExtensionData []ExtensionData
+	IOCs          []IOC           `gorm:"foreignKey:HostID;references:HostUUID"`
+	ExtensionData []ExtensionData `gorm:"foreignKey:HostID;references:HostUUID"`
 }
 
 // BeforeCreate - GORM hook

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -115,10 +115,6 @@ func (rpc *Server) GenericHandler(req GenericRequest, resp GenericResponse) erro
 		return ErrInvalidSessionID
 	}
 
-	// Overwrite unused implant fields before re-serializing
-	request.SessionID = ""
-	request.BeaconID = ""
-
 	reqData, err := proto.Marshal(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
Addresses an issue brought up in #1491. IOCs were not associated with hosts and were therefore not recorded properly. The stored file hash also reflected the hash of the uploaded data which is gzipped and does not reflect the hash of the actual file. This PR addresses both of those issues.

Here are the changes in action.

Creating the file to upload (`hello.txt`):
```
$ echo "Hello!" > hello.txt
$ sha256sum hello.txt
b22b009134622b6508d756f1062455d71a7026594eacb0badf81f4f677929ebe   hello.txt
```

Uploading `hello.txt` as an IOC and checking IOCs for the host:
```
sliver (CONSERVATION_COLLEGE) > upload -i hello.txt /tmp/hello.txt

[*] Wrote 1 file successfully to /tmp/hello.txt

sliver (CONSERVATION_COLLEGE) > background

[*] Background ...

sliver > hosts ioc

? Select a host: dev                   linux    
┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ FILE PATH      ┃ SHA-256                                                          ┃
┣━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
┃ /tmp/hello.txt ┃ b22b009134622b6508d756f1062455d71a7026594eacb0badf81f4f677929ebe ┃
┗━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
```