### PR TITLE
Fixes for removing IOCs

### DIFF
--- a/client/command/hosts/hosts-ioc-rm.go
+++ b/client/command/hosts/hosts-ioc-rm.go
@@ -26,7 +26,7 @@ import (
 	"github.com/bishopfox/sliver/client/console"
 )
 
-// HostsIOCRmCmd - Remove a host from the database
+// HostsIOCRmCmd - Remove an IOC from the database
 func HostsIOCRmCmd(cmd *cobra.Command, con *console.SliverConsoleClient, args []string) {
 	host, err := SelectHost(con)
 	if err != nil {
@@ -43,5 +43,5 @@ func HostsIOCRmCmd(cmd *cobra.Command, con *console.SliverConsoleClient, args []
 		con.PrintErrorf("%s\n", err)
 		return
 	}
-	con.PrintInfof("Removed host from database\n")
+	con.PrintInfof("Removed IOC from database\n")
 }

--- a/client/command/hosts/hosts-ioc.go
+++ b/client/command/hosts/hosts-ioc.go
@@ -62,6 +62,10 @@ func hostIOCsTable(host *clientpb.Host, con *console.SliverConsoleClient) string
 }
 
 func SelectHostIOC(host *clientpb.Host, con *console.SliverConsoleClient) (*clientpb.IOC, error) {
+	if len(host.IOCs) == 0 {
+		return nil, ErrNoIOCs
+	}
+
 	// Sort the keys because maps have a randomized order, these keys must be ordered for the selection
 	// to work properly since we rely on the index of the user's selection to find the session in the map
 	var keys []string

--- a/client/command/hosts/hosts.go
+++ b/client/command/hosts/hosts.go
@@ -42,6 +42,8 @@ import (
 var (
 	// ErrNoHosts - No hosts in database
 	ErrNoHosts = errors.New("no hosts")
+	// ErrNoIOCs - No IOCs in database
+	ErrNoIOCs = errors.New("no IOCs in database for selected host")
 	// ErrNoSelection - No selection made
 	ErrNoSelection = errors.New("no selection")
 )

--- a/server/db/models/host.go
+++ b/server/db/models/host.go
@@ -107,6 +107,7 @@ func (i *IOC) ToProtobuf() *clientpb.IOC {
 	return &clientpb.IOC{
 		Path:     i.Path,
 		FileHash: i.FileHash,
+		ID:       i.ID.String(),
 	}
 }
 


### PR DESCRIPTION
This is a continuation of the work done in #1504. The ID of the IOC was not populated in the protobuf objects used to represent IOCs, so deleting IOCs was not working. Addressed that and changed a couple of error messages to be a bit clearer. 