### PR TITLE
Fix for hosts command and host IDs for loot

### DIFF
--- a/client/command/exec/execute.go
+++ b/client/command/exec/execute.go
@@ -225,7 +225,7 @@ func LootExecute(commandOutput []byte, lootName string, sliverCmdName string, cm
 		lootName = fmt.Sprintf("[%s] %s on %s (%s)", sliverCmdName, shortCommandName, hostName, timeNow)
 	}
 
-	lootMessage := loot.CreateLootMessage(fileName, lootName, clientpb.FileType_TEXT, commandOutput)
+	lootMessage := loot.CreateLootMessage(con.ActiveTarget.GetHostUUID(), fileName, lootName, clientpb.FileType_TEXT, commandOutput)
 	loot.SendLootMessage(lootMessage, con)
 }
 

--- a/client/command/processes/procdump.go
+++ b/client/command/processes/procdump.go
@@ -146,6 +146,6 @@ func LootProcessDump(dump *sliverpb.ProcessDump, lootName string, hostName strin
 		lootName = dumpFileName
 	}
 
-	lootMessage := loot.CreateLootMessage(dumpFileName, lootName, clientpb.FileType_BINARY, dump.GetData())
+	lootMessage := loot.CreateLootMessage(con.ActiveTarget.GetHostUUID(), dumpFileName, lootName, clientpb.FileType_BINARY, dump.GetData())
 	loot.SendLootMessage(lootMessage, con)
 }

--- a/client/command/screenshot/screenshot.go
+++ b/client/command/screenshot/screenshot.go
@@ -137,7 +137,7 @@ func LootScreenshot(screenshot *sliverpb.Screenshot, lootName string, hostName s
 		lootName = screenshotFileName
 	}
 
-	lootMessage := loot.CreateLootMessage(screenshotFileName, lootName, clientpb.FileType_BINARY, screenshot.GetData())
+	lootMessage := loot.CreateLootMessage(con.ActiveTarget.GetHostUUID(), screenshotFileName, lootName, clientpb.FileType_BINARY, screenshot.GetData())
 	loot.SendLootMessage(lootMessage, con)
 }
 

--- a/client/console/console.go
+++ b/client/console/console.go
@@ -689,6 +689,11 @@ func (s *ActiveTarget) IsSession() bool {
 	return s.session != nil
 }
 
+// IsBeacon - Is the current target a beacon?
+func (s *ActiveTarget) IsBeacon() bool {
+	return s.beacon != nil
+}
+
 // AddObserver - Observers to notify when the active session changes
 func (s *ActiveTarget) AddObserver(observer Observer) int {
 	s.observerID++
@@ -794,6 +799,17 @@ func (s *ActiveTarget) Background() {
 	if !s.con.IsCLI && s.con.App.ActiveMenu().Name() == consts.ImplantMenu {
 		s.con.App.SwitchMenu(consts.ServerMenu)
 	}
+}
+
+// GetHostUUID - Get the Host's UUID (ID in the database)
+func (s *ActiveTarget) GetHostUUID() string {
+	if s.IsSession() {
+		return s.session.UUID
+	} else if s.IsBeacon() {
+		return s.beacon.UUID
+	}
+
+	return ""
 }
 
 // Expose or hide commands if the active target does support them (or not).

--- a/server/db/helpers.go
+++ b/server/db/helpers.go
@@ -759,7 +759,7 @@ func HostByHostID(id uuid.UUID) (*clientpb.Host, error) {
 }
 
 // HostByHostUUID - Get host by the session's reported HostUUID
-func HostByHostUUID(id string) (*clientpb.Host, error) {
+func HostByHostUUID(id string) (*models.Host, error) {
 	if len(id) < 1 {
 		return nil, ErrRecordNotFound
 	}
@@ -774,7 +774,7 @@ func HostByHostUUID(id string) (*clientpb.Host, error) {
 	if err != nil {
 		return nil, err
 	}
-	return host.ToProtobuf(), nil
+	return &host, nil
 }
 
 // IOCByID - Select an IOC by ID

--- a/server/loot/backend.go
+++ b/server/loot/backend.go
@@ -54,8 +54,7 @@ func (l *LocalBackend) Add(loot *clientpb.Loot) (*clientpb.Loot, error) {
 		lootLog.Warnf("Failed to find host %s for loot %s", loot.OriginHostUUID, loot.ID)
 		hostID = uuid.Nil
 	} else {
-		id, _ := uuid.FromString(host.ID)
-		hostID = id
+		hostID = host.HostUUID
 	}
 	dbLoot := &models.Loot{
 		Name:         loot.GetName(),

--- a/server/rpc/rpc-filesystem.go
+++ b/server/rpc/rpc-filesystem.go
@@ -30,7 +30,6 @@ import (
 	"github.com/bishopfox/sliver/server/db/models"
 	"github.com/bishopfox/sliver/server/log"
 	"github.com/bishopfox/sliver/util/encoders"
-	"github.com/gofrs/uuid"
 )
 
 var (
@@ -221,9 +220,8 @@ func trackIOC(req *sliverpb.UploadReq, resp *sliverpb.Upload) {
 	}
 
 	sum := hashUploadData(req.Encoder, req.Data)
-	id, _ := uuid.FromString(host.HostUUID)
 	ioc := &models.IOC{
-		HostID:   id,
+		HostID:   host.HostUUID,
 		Path:     resp.Path,
 		FileHash: fmt.Sprintf("%x", sum),
 	}

--- a/server/rpc/rpc-hosts.go
+++ b/server/rpc/rpc-hosts.go
@@ -49,7 +49,7 @@ func (rpc *Server) Host(ctx context.Context, req *clientpb.Host) (*clientpb.Host
 	if err != nil {
 		return nil, err
 	}
-	return dbHost, nil
+	return dbHost.ToProtobuf(), nil
 }
 
 // HostRm - Remove a host from the database
@@ -58,7 +58,7 @@ func (rpc *Server) HostRm(ctx context.Context, req *clientpb.Host) (*commonpb.Em
 	if err != nil {
 		return nil, err
 	}
-	err = db.Session().Delete(dbHost).Error
+	err = db.Session().Delete(*dbHost).Error
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Continuing down the rabbit hole of the backend database, I was experimenting and noticed that the `hosts rm` command was not working properly. I am not sure if I caused that with my changes in either #1504 or #1507, but either way, it is working now. I also noticed poking through the database that loot was not being assigned the correct host UUID in the database. So this PR also addresses that issue.