### PR TITLE
Fix C2 URL Duplication in Database

### DIFF
--- a/server/db/models/implant.go
+++ b/server/db/models/implant.go
@@ -349,9 +349,11 @@ type ImplantC2 struct {
 
 // BeforeCreate - GORM hook
 func (c2 *ImplantC2) BeforeCreate(tx *gorm.DB) (err error) {
-	c2.ID, err = uuid.NewV4()
-	if err != nil {
-		return err
+	if c2.ID == uuid.Nil {
+		c2.ID, err = uuid.NewV4()
+		if err != nil {
+			return err
+		}
 	}
 	c2.CreatedAt = time.Now()
 	return nil


### PR DESCRIPTION
This PR fixes an issue I noticed while testing some other functionality. Previously, C2 URLs for a profile were being duplicated whenever an implant was generated from that profile. This PR implements a check to only generate a new UUID for a C2 object if it does not have one.