### PR TITLE
Addressing Migrate "record not found"

### DIFF
--- a/client/command/exec/migrate.go
+++ b/client/command/exec/migrate.go
@@ -81,6 +81,7 @@ func MigrateCmd(cmd *cobra.Command, con *console.SliverConsoleClient, args []str
 		Config:  config,
 		Request: con.ActiveTarget.Request(cmd),
 		Encoder: encoder,
+		Name: session.Name,
 	})
 	ctrl <- true
 	<-ctrl


### PR DESCRIPTION
Addresses #1532. It looks like the name of the implant was not sent with requests to migrate, and that resulted in an error when the server went to pull the implant build information from the database.