### PR TITLE
enables generation of exe-service stagers

### DIFF
--- a/server/msf/msf.go
+++ b/server/msf/msf.go
@@ -83,6 +83,7 @@ var (
 		"dw":            true,
 		"dword":         true,
 		"exe":           true,
+		"exe-service":   true,
 		"hex":           true,
 		"java":          true,
 		"js_be":         true,


### PR DESCRIPTION
#### Details
msfvenom allows for service-exe stagers to be generated.
this PR adds to the list of allowed formats in the server code.