### PR TITLE
Add support for tailscale to daemon mode

### DIFF
--- a/server/cli/cli.go
+++ b/server/cli/cli.go
@@ -50,6 +50,7 @@ const (
 	saveFlagStr        = "save"
 	outputFlagStr      = "output"
 	permissionsFlagStr = "permissions"
+	tailscaleFlagStr   = "tailscale"
 
 	// Cert flags
 	caTypeFlagStr = "type"
@@ -97,6 +98,7 @@ func init() {
 	daemonCmd.Flags().StringP(lhostFlagStr, "l", daemon.BlankHost, "multiplayer listener host")
 	daemonCmd.Flags().Uint16P(lportFlagStr, "p", daemon.BlankPort, "multiplayer listener port")
 	daemonCmd.Flags().BoolP(forceFlagStr, "f", false, "force unpack and overwrite static assets")
+	daemonCmd.Flags().BoolP(tailscaleFlagStr, "t", false, "enable tailscale")
 	rootCmd.AddCommand(daemonCmd)
 
 	// Builder

--- a/server/cli/cli.go
+++ b/server/cli/cli.go
@@ -145,7 +145,7 @@ var rootCmd = &cobra.Command{
 			fmt.Println(err)
 		}
 		if serverConfig.DaemonMode {
-			daemon.Start(daemon.BlankHost, daemon.BlankPort)
+			daemon.Start(daemon.BlankHost, daemon.BlankPort, serverConfig.DaemonConfig.Tailscale)
 		} else {
 			os.Args = os.Args[:1] // Hide cli from grumble console
 			console.Start()

--- a/server/cli/daemon.go
+++ b/server/cli/daemon.go
@@ -39,6 +39,12 @@ var daemonCmd = &cobra.Command{
 			return
 		}
 
+		tailscale, err := cmd.Flags().GetBool(tailscaleFlagStr)
+		if err != nil {
+			fmt.Printf("Failed to parse --%s flag %s\n", tailscaleFlagStr, err)
+			return
+		}
+
 		appDir := assets.GetRootAppDir()
 		logFile := initConsoleLogging(appDir)
 		defer logFile.Close()
@@ -67,7 +73,7 @@ var daemonCmd = &cobra.Command{
 			fmt.Println(err)
 		}
 
-		daemon.Start(lhost, uint16(lport))
+		daemon.Start(lhost, uint16(lport), tailscale)
 	},
 }
 

--- a/server/cli/daemon.go
+++ b/server/cli/daemon.go
@@ -58,6 +58,7 @@ var daemonCmd = &cobra.Command{
 		}()
 
 		assets.Setup(force, false)
+		c2.SetupDefaultC2Profiles()
 		certs.SetupCAs()
 		certs.SetupWGKeys()
 		cryptography.AgeServerKeyPair()

--- a/server/configs/server.go
+++ b/server/configs/server.go
@@ -57,8 +57,9 @@ type LogConfig struct {
 
 // DaemonConfig - Configure daemon mode
 type DaemonConfig struct {
-	Host string `json:"host"`
-	Port int    `json:"port"`
+	Host      string `json:"host"`
+	Port      int    `json:"port"`
+	Tailscale bool   `json:"tailscale"`
 }
 
 // JobConfig - Restart Jobs on Load

--- a/server/daemon/daemon.go
+++ b/server/daemon/daemon.go
@@ -20,6 +20,7 @@ package daemon
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/signal"
 	"syscall"
@@ -40,8 +41,11 @@ var (
 )
 
 // Start - Start as daemon process
-func Start(host string, port uint16) {
-
+func Start(host string, port uint16, tailscale bool) {
+	var (
+		ln  net.Listener
+		err error
+	)
 	// cli args take president over config
 	if host == BlankHost {
 		daemonLog.Info("No cli lhost, using config file or default value")
@@ -53,7 +57,12 @@ func Start(host string, port uint16) {
 	}
 
 	daemonLog.Infof("Starting Sliver daemon %s:%d ...", host, port)
-	_, ln, err := transport.StartMtlsClientListener(host, port)
+	if tailscale {
+		_, ln, err = transport.StartTsNetClientListener(host, port)
+	} else {
+		_, ln, err = transport.StartMtlsClientListener(host, port)
+
+	}
 	if err != nil {
 		fmt.Printf("[!] Failed to start daemon %s", err)
 		daemonLog.Errorf("Error starting client listener %s", err)

--- a/server/daemon/daemon.go
+++ b/server/daemon/daemon.go
@@ -61,7 +61,6 @@ func Start(host string, port uint16, tailscale bool) {
 		_, ln, err = transport.StartTsNetClientListener(host, port)
 	} else {
 		_, ln, err = transport.StartMtlsClientListener(host, port)
-
 	}
 	if err != nil {
 		fmt.Printf("[!] Failed to start daemon %s", err)


### PR DESCRIPTION
Add support for tailscale when running in daemon mode. The `TS_AUTHKEY` environment variable needs to be set.