### PR TITLE
Fix typo in `make-token` when no credentials are provided.

### DIFF
--- a/client/command/privilege/make-token.go
+++ b/client/command/privilege/make-token.go
@@ -58,7 +58,7 @@ func MakeTokenCmd(cmd *cobra.Command, con *console.SliverClient, args []string) 
 	}
 
 	if username == "" || password == "" {
-		con.PrintErrorf("Pou must provide a username and password\n")
+		con.PrintErrorf("You must provide a username and password\n")
 		return
 	}
 


### PR DESCRIPTION
#### Card
The error message for `make-token` has a typo when called without credentials.

#### Details
```
sliver (INJURED_DIVIDER) > make-token
[!] Pou must provide a username and password
```
🤡 