### PR TITLE
Fix using duplicated envelope id bug

### DIFF
--- a/implant/sliver/sliver.go
+++ b/implant/sliver/sliver.go
@@ -598,6 +598,7 @@ func sessionMainLoop(connection *transports.Connection) error {
 	rportfwdHandlers := handlers.GetRportFwdHandlers()
 
 	for envelope := range connection.Recv {
+		envelope := envelope
 		if _, ok := specialHandlers[envelope.Type]; ok {
 			// {{if .Config.Debug}}
 			log.Printf("[recv] specialHandler %d", envelope.Type)


### PR DESCRIPTION
Add shadowing variable to fix using duplicated or invalid envelope id bug causing implant timeout error.

This bug could be fixed by using GOEXPERIMENT=loopvar or updating Go version to 1.22

https://go.dev/doc/faq#closures_and_goroutines
https://go.dev/blog/loopvar-preview