### PR TITLE
check session mode correctly in windows exec

### DIFF
--- a/client/command/exec/execute.go
+++ b/client/command/exec/execute.go
@@ -64,7 +64,7 @@ func ExecuteCmd(cmd *cobra.Command, con *console.SliverClient, args []string) {
 	ctrl := make(chan bool)
 	con.SpinUntil(fmt.Sprintf("Executing %s %s ...", cmdPath, strings.Join(args, " ")), ctrl)
 	if token || hidden || ppid != 0 {
-		if session.OS != "windows" {
+		if (session != nil && session.OS != "windows") || (beacon != nil && beacon.OS != "windows") {
 			con.PrintErrorf("The token, hide window, and ppid options are not valid on %s\n", session.OS)
 			return
 		}


### PR DESCRIPTION
Previously would crash the client if interacting with a beacon mode implant and trying to do windows exec with PPID/hidden window/weird token set. Fix checks both session and implant, and ensures the session/beacon mode is not nil to avoid crash.
