### PR TITLE
fix useragent variable in implant generation

### DIFF
--- a/server/generate/binaries.go
+++ b/server/generate/binaries.go
@@ -482,7 +482,7 @@ func renderSliverGoCode(name string, build *clientpb.ImplantBuild, config *clien
 		sliverCode := template.New("sliver")
 		sliverCode, err = sliverCode.Funcs(template.FuncMap{
 			"GenerateUserAgent": func() string {
-				return "" // renerateUserAgent(config.GOOS, config.GOARCH)
+				return pbC2Implant.UserAgent
 			},
 		}).Parse(sliverGoCode)
 		if err != nil {


### PR DESCRIPTION
It appears as though implants generated in 1.6 don't have a useragent set - so they are likely using the default Go user agent. If trying to use a winhttp/wininet driver, this will crash the beacon. Fixed by using the useragent value from the protobuf, unsure if this is the right way of doing it...

Fixes #1584 