### PR TITLE
Fix Default Linux Host Process for Aliases

### DIFF
--- a/client/command/alias/load.go
+++ b/client/command/alias/load.go
@@ -57,7 +57,7 @@ var (
 
 	defaultHostProc = map[string]string{
 		"windows": windowsDefaultHostProc,
-		"linux":   windowsDefaultHostProc,
+		"linux":   linuxDefaultHostProc,
 		"darwin":  macosDefaultHostProc,
 	}
 )


### PR DESCRIPTION
This is a tiny PR to fix the default host process for Linux aliases. It was pointing to the Windows default (`notepad.exe`).
