### PR TITLE
fix: add missing newline

### DIFF
--- a/client/command/wireguard/wg-config.go
+++ b/client/command/wireguard/wg-config.go
@@ -88,7 +88,7 @@ func WGConfigCmd(cmd *cobra.Command, con *console.SliverClient, args []string) {
 
 	save, _ := cmd.Flags().GetString("save")
 	if save == "" {
-		con.PrintInfof("New client config:")
+		con.PrintInfof("New client config:\n")
 		con.Println(output.String())
 	} else {
 		if !strings.HasSuffix(save, ".conf") {


### PR DESCRIPTION
#### Card
Adds a simple missing newline

#### Details
`wg-config` command is missing a newline, resulting the config to be in the same line with the info message:
```
sliver (ULTIMATE_BOUDOIR) > wg-config

[*] New client config:[Interface]
Address = 100.64.0.2/16
ListenPort = 51902
PrivateKey = verysecret
MTU = 1420

[Peer]
PublicKey = zma1fIpkBqVN6eClvrBzi4na9DtHikmOsmtTymjZ4DA=
AllowedIPs = 100.64.0.0/16
Endpoint = <configure yourself>
```
so this pr simply adds the missing newline