### PR TITLE
Fixing install script for Arch

### DIFF
--- a/docs/sliver-docs/public/install
+++ b/docs/sliver-docs/public/install
@@ -22,8 +22,8 @@ elif command -v yum &> /dev/null; then # Redhat-based OS (Fedora, CentOS, RHEL)
 	INSTALLER=(yum -y)
 elif command -v pacman &>/dev/null; then # Arch-based (Manjaro, Garuda, Blackarch)
 	echo "Installing dependencies using pacman..."
-	pacman -S mingw-w64-gcc mingw-w64-binutils mingw-w64-headers
-    INSTALLER=(pacman -S)
+	pacman --noconfirm -S mingw-w64-gcc mingw-w64-binutils mingw-w64-headers
+    INSTALLER=(pacman --noconfirm -S)
 else
     echo "Unsupported OS, exiting"
     exit


### PR DESCRIPTION
This PR addresses #1680. When calling `pacman`, the install script did not suppress the "Proceed with installation?" prompt which caused strange things to happen. To fix this, we can use the `--noconfirm` switch.

Tested the modified script on a fresh Arch install, and no errors:
```
Installing dependencies using pacman...
warning: mingw-w64-gcc-13.1.0-1 is up to date -- reinstalling
warning: mingw-w64-binutils-2.39-1 is up to date -- reinstalling
warning: mingw-w64-headers-11.0.0-1 is up to date -- reinstalling
resolving dependencies...
looking for conflicting packages...

Packages (3) mingw-w64-binutils-2.39-1  mingw-w64-gcc-13.1.0-1  mingw-w64-headers-11.0.0-1

Total Installed Size:  1138.08 MiB
Net Upgrade Size:         0.00 MiB

:: Proceed with installation? [Y/n] 
(3/3) checking keys in keyring                                                                                                                                                     [################################################################################################################] 100%
(3/3) checking package integrity                                                                                                                                                   [################################################################################################################] 100%
(3/3) loading package files                                                                                                                                                        [################################################################################################################] 100%
(3/3) checking for file conflicts                                                                                                                                                  [################################################################################################################] 100%
(3/3) checking available disk space                                                                                                                                                [################################################################################################################] 100%
:: Processing package changes...
(1/3) reinstalling mingw-w64-binutils                                                                                                                                              [################################################################################################################] 100%
(2/3) reinstalling mingw-w64-headers                                                                                                                                               [################################################################################################################] 100%
(3/3) reinstalling mingw-w64-gcc                                                                                                                                                   [################################################################################################################] 100%
:: Running post-transaction hooks...
(1/1) Arming ConditionNeedsUpdate...
Running from /root
Importing GPG key...
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 7DF912404449039C: public key "Sliver <sliver@bishopfox.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
Fetching latest Sliver release URLs...
Downloading https://github.com/BishopFox/sliver/releases/download/v1.5.42/sliver-client_linux
Downloading https://github.com/BishopFox/sliver/releases/download/v1.5.42/sliver-client_linux.sig
Downloading https://github.com/BishopFox/sliver/releases/download/v1.5.42/sliver-server_linux
Downloading https://github.com/BishopFox/sliver/releases/download/v1.5.42/sliver-server_linux.sig
Verifying signatures ...
gpg: Signature made Wed Feb 28 20:00:25 2024 UTC
gpg:                using RSA key 0ED3900D296CFA0283A4E4667DF912404449039C
gpg: Good signature from "Sliver <sliver@bishopfox.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 0ED3 900D 296C FA02 83A4  E466 7DF9 1240 4449 039C
gpg: Signature made Wed Feb 28 20:00:25 2024 UTC
gpg:                using RSA key 0ED3900D296CFA0283A4E4667DF912404449039C
gpg: Good signature from "Sliver <sliver@bishopfox.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 0ED3 900D 296C FA02 83A4  E466 7DF9 1240 4449 039C
Moving the Sliver server executable to /root/sliver-server...
Setting permissions for the Sliver server executable...
Unpacking the Sliver server...

Sliver  Copyright (C) 2022  Bishop Fox
This program comes with ABSOLUTELY NO WARRANTY; for details type 'licenses'.
This is free software, and you are welcome to redistribute it
under certain conditions; type 'licenses' for details.

Unpacking assets ...
Setting permissions for the Sliver client executable...
Copying the Sliver client executable to /usr/local/bin/sliver-client...
'/root/sliver-client_linux' -> '/usr/local/bin/sliver-client'
Creating a symbolic link for sliver-client at /usr/local/bin/sliver...
Setting permissions for the symbolic link /usr/local/bin/sliver...
Configuring systemd service ...
Starting the Sliver service...
Generating local configs ...
Generating operator configs ...
```