### PR TITLE
autoremove socks proxies

### DIFF
--- a/client/command/kill/kill.go
+++ b/client/command/kill/kill.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/bishopfox/sliver/client/console"
+	"github.com/bishopfox/sliver/client/core"
 	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/bishopfox/sliver/protobuf/commonpb"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
@@ -73,6 +74,16 @@ func KillSession(session *clientpb.Session, cmd *cobra.Command, con *console.Sli
 	}
 	timeout, _ := cmd.Flags().GetInt64("timeout")
 	force, _ := cmd.Flags().GetBool("force")
+
+	// remove any active socks proxies
+	socks := core.SocksProxies.List()
+	if len(socks) != 0 {
+		for _, p := range socks {
+			if p.SessionID == session.ID {
+				core.SocksProxies.Remove(p.ID)
+			}
+		}
+	}
 
 	_, err := con.Rpc.Kill(context.Background(), &sliverpb.KillReq{
 		Request: &commonpb.Request{

--- a/client/command/sessions/close.go
+++ b/client/command/sessions/close.go
@@ -22,6 +22,7 @@ import (
 	"context"
 
 	"github.com/bishopfox/sliver/client/console"
+	"github.com/bishopfox/sliver/client/core"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
 	"github.com/spf13/cobra"
 )
@@ -33,6 +34,16 @@ func CloseSessionCmd(cmd *cobra.Command, con *console.SliverClient, args []strin
 	if session == nil {
 		con.PrintErrorf("No active session\n")
 		return
+	}
+
+	// remove any active socks proxies
+	socks := core.SocksProxies.List()
+	if len(socks) != 0 {
+		for _, p := range socks {
+			if p.SessionID == session.ID {
+				core.SocksProxies.Remove(p.ID)
+			}
+		}
 	}
 
 	// Close the session


### PR DESCRIPTION
Check if a session has any active socks proxies before killing/closing it and terminate those first. This should also take care of issue #1290 