### PR TITLE
Abide generate name

### DIFF
--- a/client/command/generate/generate-beacon.go
+++ b/client/command/generate/generate-beacon.go
@@ -32,7 +32,7 @@ func GenerateBeaconCmd(cmd *cobra.Command, con *console.SliverClient, args []str
 		save, _ = os.Getwd()
 	}
 	if external, _ := cmd.Flags().GetBool("external-builder"); !external {
-		compile(config, save, con)
+		compile(name, config, save, con)
 	} else {
 		externalBuild(name, config, save, con)
 	}

--- a/client/command/generate/generate.go
+++ b/client/command/generate/generate.go
@@ -98,7 +98,7 @@ func GenerateCmd(cmd *cobra.Command, con *console.SliverClient, args []string) {
 		save, _ = os.Getwd()
 	}
 	if external, _ := cmd.Flags().GetBool("external-builder"); !external {
-		compile(config, save, con)
+		compile(name, config, save, con)
 	} else {
 		_, err := externalBuild(name, config, save, con)
 		if err != nil {
@@ -905,7 +905,7 @@ func externalBuild(name string, config *clientpb.ImplantConfig, save string, con
 	return nil, nil
 }
 
-func compile(config *clientpb.ImplantConfig, save string, con *console.SliverClient) (*commonpb.File, error) {
+func compile(name string, config *clientpb.ImplantConfig, save string, con *console.SliverClient) (*commonpb.File, error) {
 	if config.IsBeacon {
 		interval := time.Duration(config.BeaconInterval)
 		con.PrintInfof("Generating new %s/%s beacon implant binary (%v)\n", config.GOOS, config.GOARCH, interval)
@@ -923,6 +923,7 @@ func compile(config *clientpb.ImplantConfig, save string, con *console.SliverCli
 	con.SpinUntil("Compiling, please wait ...", ctrl)
 
 	generated, err := con.Rpc.Generate(context.Background(), &clientpb.GenerateReq{
+		Name:   name,
 		Config: config,
 	})
 	ctrl <- true

--- a/client/command/generate/profiles-generate.go
+++ b/client/command/generate/profiles-generate.go
@@ -46,7 +46,7 @@ func ProfilesGenerateCmd(cmd *cobra.Command, con *console.SliverClient, args []s
 		if SGNDisabled, _ := cmd.Flags().GetBool("disable-sgn"); SGNDisabled {
 			profile.Config.SGNEnabled = !SGNDisabled
 		}
-		_, err := compile(profile.Config, save, con)
+		_, err := compile(name, profile.Config, save, con)
 		if err != nil {
 			return
 		}

--- a/server/rpc/rpc-generate.go
+++ b/server/rpc/rpc-generate.go
@@ -340,7 +340,7 @@ func (rpc *Server) GenerateExternal(ctx context.Context, req *clientpb.ExternalG
 		if err != nil {
 			return nil, err
 		}
-	} else if err := util.AllowedName(name); err != nil {
+	} else if err := util.AllowedName(req.Name); err != nil {
 		return nil, err
 	} else {
 		name = req.Name

--- a/server/rpc/rpc-generate.go
+++ b/server/rpc/rpc-generate.go
@@ -68,7 +68,7 @@ func (rpc *Server) Generate(ctx context.Context, req *clientpb.GenerateReq) (*cl
 		if err != nil {
 			return nil, err
 		}
-	} else if err := util.AllowedName(name); err != nil {
+	} else if err := util.AllowedName(req.Name); err != nil {
 		return nil, err
 	} else {
 		name = req.Name


### PR DESCRIPTION
Attempt fix for:
- `generate` command not applying user-supplied implant name
- `generate` via External Builder allowing user-supplied implant name