### PR TITLE
Add Palo Alto Cortex XDR binaries to `knownSecurityTools`

### DIFF
--- a/client/command/processes/ps.go
+++ b/client/command/processes/ps.go
@@ -103,7 +103,7 @@ var knownSecurityTools = map[string][]string{
 	"cortex-xdr-payload.exe":          {console.Red, "Palo Alto Cortex"},             // Cortex XDR - offline triage
 	"cysandbox.exe":                   {console.Red, "Palo Alto Cortex"},             // Cortex XDR - sandbox
 	"cyuserservice.exe":               {console.Red, "Palo Alto Cortex"},             // Cortex XDR - user service
-	"cywscsvc.exe":                    {console.Red, "Palo Alto Cortex"},             // Cortex XDR - security senter service
+	"cywscsvc.exe":                    {console.Red, "Palo Alto Cortex"},             // Cortex XDR - security center service
 	"tlaworker.exe":                   {console.Red, "Palo Alto Cortex"},             // Cortex XDR - local analysis worker
 }
 

--- a/client/command/processes/ps.go
+++ b/client/command/processes/ps.go
@@ -100,6 +100,11 @@ var knownSecurityTools = map[string][]string{
 	"CrAmTray.exe":                    {console.Red, "Cybereason ActiveProbe"},       // Cybereason ActiveProbe
 	"CrsSvc.exe":                      {console.Red, "Cybereason ActiveProbe"},       // Cybereason ActiveProbe
 	"CybereasonAV.exe":                {console.Red, "Cybereason ActiveProbe"},       // Cybereason ActiveProbe
+	"cortex-xdr-payload.exe":          {console.Red, "Palo Alto Cortex"},             // Cortex XDR - offline triage
+	"cysandbox.exe":                   {console.Red, "Palo Alto Cortex"},             // Cortex XDR - sandbox
+	"cyuserservice.exe":               {console.Red, "Palo Alto Cortex"},             // Cortex XDR - user service
+	"cywscsvc.exe":                    {console.Red, "Palo Alto Cortex"},             // Cortex XDR - security senter service
+	"tlaworker.exe":                   {console.Red, "Palo Alto Cortex"},             // Cortex XDR - local analysis worker
 }
 
 // PsCmd - List processes on the remote system


### PR DESCRIPTION
Add Palo Alto Cortex XDR detections to `knownSecurityTools` variable for the following binaries:
* `cortex-xdr-payload.exe` - offline triage process
* `cysandbox.exe` - sandbox service
* `cyuserservice.exe` - user service
* `cywscsvc.exe` - security center service
* `tlaworker.exe` - local analysis worker