### PR TITLE
build Dockerfile: use uppercase FROM / AS combination 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ ENTRYPOINT [ "/opt/sliver-server" ]
 
 
 # STAGE: production-slim (about 1Gb smaller)
-FROM debian:bookworm-slim as production-slim
+FROM debian:bookworm-slim AS production-slim
 
 ### Install production packages
 RUN apt-get update --fix-missing \


### PR DESCRIPTION
Issue:

#1913 

#### Details

fixing from as casting in Dockerfile

Fixes `WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 94)`