### PR TITLE
Cursed Chrome Cookie Fix

### DIFF
--- a/client/command/cursed/cursed-cookies.go
+++ b/client/command/cursed/cursed-cookies.go
@@ -21,8 +21,9 @@ package cursed
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
+
+	"encoding/json"
 
 	"github.com/bishopfox/sliver/client/console"
 	"github.com/bishopfox/sliver/client/overlord"
@@ -46,24 +47,24 @@ func CursedCookiesCmd(cmd *cobra.Command, con *console.SliverClient, args []stri
 	if len(cookies) == 0 {
 		return
 	}
+
 	saveFile, _ := cmd.Flags().GetString("save")
 	if saveFile == "" {
 		saveFile = fmt.Sprintf("cookies-%s.json", time.Now().Format("20060102150405"))
 	}
-	jsonCookies := []string{}
-	for _, cookie := range cookies {
-		jsonCookie, err := cookie.MarshalJSON()
-		if err != nil {
-			con.PrintErrorf("Failed to marshal cookie: %s\n", err)
-			continue
-		}
-		jsonCookies = append(jsonCookies, string(jsonCookie))
+
+	jsonBytes, err := json.MarshalIndent(cookies, "", "  ")
+	if err != nil {
+		con.PrintErrorf("Failed to marshal cookies: %s\n", err)
+		return
 	}
-	err = os.WriteFile(saveFile, []byte(strings.Join(jsonCookies, "\n")), 0o600)
+
+	err = os.WriteFile(saveFile, jsonBytes, 0o600)
 	if err != nil {
 		con.PrintErrorf("Failed to save cookies: %s\n", err)
 		return
 	}
+
 	con.PrintInfof("Saved to %s", saveFile)
 	con.Println()
 }


### PR DESCRIPTION
Fix for https://github.com/BishopFox/sliver/issues/1758.

This Pull Request does a few things. It eliminates using a string to gather the JSON array from the remote site debugger. It now leverages the built-in library. It then takes the output and uses the ChromeDP Struct for JSON Marshalling items. 

Please note that to make this work, a few other things had to be done, including running the following commands on the CLI. 

```
go get -u github.com/chromedp/cdproto@latest
go get -u github.com/chromedp/chromedp@latest
go mod tidy
go mod vendor
```

Due to the many changes this introduces, I can make the changes part of this PR or the maintainers can attempt it. Will look at backporting this to 1.5.X.