### PR TITLE
Bof flag args

### DIFF
--- a/client/command/extensions/argparser.go
+++ b/client/command/extensions/argparser.go
@@ -1,0 +1,413 @@
+package extensions
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/bishopfox/sliver/client/core"
+	"github.com/spf13/cobra"
+)
+
+// ParseFlagArgumentsToBuffer parses flag-style arguments based on extension manifest
+// and converts them to a BOF-compatible binary buffer
+func ParseFlagArgumentsToBuffer(_ *cobra.Command, args []string, _ string, ext *ExtCommand) ([]byte, error) {
+	// Create a flag set and parse the arguments
+	fs, stringValues, wstringValues, intValues, shortValues, fileValues, err := bofSetupAndParseFlags(args, ext)
+	if err != nil {
+		return nil, err
+	}
+
+	// Print debug information about parsed flags
+	//bofDebugPrintParsedFlags(fs, ext, stringValues, wstringValues, intValues, shortValues, fileValues)
+
+	// Initialize the BOF arguments buffer
+	argsBuffer := core.BOFArgsBuffer{
+		Buffer: new(bytes.Buffer),
+	}
+
+	// Process arguments and build the buffer
+	missingRequiredArgs, err := bofProcessArgumentsToBuffer(fs, ext, argsBuffer,
+		stringValues, wstringValues, intValues, shortValues, fileValues)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return error if we have missing required arguments
+	if len(missingRequiredArgs) > 0 {
+		return nil, fmt.Errorf("required arguments %s were not provided", strings.Join(missingRequiredArgs, ", "))
+	}
+
+	// Get the final binary buffer
+	parsedArgs, err := argsBuffer.GetBuffer()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buffer: %v", err)
+	}
+
+	return parsedArgs, nil
+}
+
+// bofSetupAndParseFlags creates a flag set, defines expected flags based on the extension manifest,
+// and parses the provided arguments
+func bofSetupAndParseFlags(args []string, ext *ExtCommand) (*flag.FlagSet,
+	map[string]*string, map[string]*string, map[string]*int, map[string]*int, map[string]*string, error) {
+
+	// Create a new FlagSet
+	fs := flag.NewFlagSet("sliver-bof", flag.ContinueOnError)
+
+	// Maps to store flag value pointers
+	stringValues := make(map[string]*string)
+	intValues := make(map[string]*int)
+	shortValues := make(map[string]*int)
+	fileValues := make(map[string]*string) // Path to file data
+	wstringValues := make(map[string]*string)
+
+	// Define expected flags based on manifest arguments
+	for _, arg := range ext.Arguments {
+		flagName := arg.Name
+		flagDesc := arg.Desc
+
+		switch arg.Type {
+		case "string":
+			stringValues[flagName] = fs.String(flagName, "", flagDesc)
+		case "wstring":
+			wstringValues[flagName] = fs.String(flagName, "", flagDesc)
+		case "int", "integer":
+			intValues[flagName] = fs.Int(flagName, 0, flagDesc)
+		case "short":
+			shortValues[flagName] = fs.Int(flagName, 0, flagDesc)
+		case "file":
+			fileValues[flagName] = fs.String(flagName, "", flagDesc)
+		default:
+			return nil, nil, nil, nil, nil, nil, fmt.Errorf("unsupported argument type: %s", arg.Type)
+		}
+	}
+
+	// Parse the arguments
+	if err := fs.Parse(args); err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+
+	return fs, stringValues, wstringValues, intValues, shortValues, fileValues, nil
+}
+
+// bofProcessArgumentsToBuffer processes each argument and adds its value to the buffer
+// Returns a list of missing required arguments and any error encountered
+func bofProcessArgumentsToBuffer(fs *flag.FlagSet, ext *ExtCommand, argsBuffer core.BOFArgsBuffer,
+	stringValues, wstringValues map[string]*string,
+	intValues, shortValues map[string]*int,
+	fileValues map[string]*string) ([]string, error) {
+
+	missingRequiredArgs := make([]string, 0)
+
+	for _, argDef := range ext.Arguments {
+		var provided bool
+		var err error
+
+		// Process based on argument type
+		switch argDef.Type {
+		case "string":
+			provided, err = bofProcessStringArg(fs, argDef, stringValues, argsBuffer)
+		case "wstring":
+			provided, err = bofProcessWStringArg(fs, argDef, wstringValues, argsBuffer)
+		case "int", "integer":
+			provided, err = bofProcessIntArg(fs, argDef, intValues, argsBuffer)
+		case "short":
+			provided, err = bofProcessShortArg(fs, argDef, shortValues, argsBuffer)
+		case "file":
+			provided, err = bofProcessFileArg(fs, argDef, fileValues, argsBuffer)
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		// If argument not provided, handle according to rules
+		if !provided {
+			if argDef.Optional {
+				// Try to apply default or type-appropriate zero value
+				err = bofApplyDefaultValue(argDef, argsBuffer)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				// Required argument was not provided
+				missingRequiredArgs = append(missingRequiredArgs, "`"+argDef.Name+"`")
+			}
+		}
+	}
+
+	return missingRequiredArgs, nil
+}
+
+// bofProcessStringArg processes a string argument
+func bofProcessStringArg(fs *flag.FlagSet, argDef *extensionArgument, stringValues map[string]*string,
+	argsBuffer core.BOFArgsBuffer) (bool, error) {
+
+	ptr := stringValues[argDef.Name]
+	flagWasSet := *ptr != "" && bofFlagWasProvided(fs, argDef.Name)
+
+	if flagWasSet {
+		err := argsBuffer.AddString(*ptr)
+		if err != nil {
+			return false, fmt.Errorf("failed to add string argument %s: %v", argDef.Name, err)
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// bofProcessWStringArg processes a wide string argument
+func bofProcessWStringArg(fs *flag.FlagSet, argDef *extensionArgument, wstringValues map[string]*string,
+	argsBuffer core.BOFArgsBuffer) (bool, error) {
+
+	ptr := wstringValues[argDef.Name]
+	flagWasSet := *ptr != "" && bofFlagWasProvided(fs, argDef.Name)
+
+	if flagWasSet {
+		err := argsBuffer.AddWString(*ptr)
+		if err != nil {
+			return false, fmt.Errorf("failed to add wstring argument %s: %v", argDef.Name, err)
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// bofProcessIntArg processes an integer argument
+func bofProcessIntArg(fs *flag.FlagSet, argDef *extensionArgument, intValues map[string]*int,
+	argsBuffer core.BOFArgsBuffer) (bool, error) {
+
+	ptr := intValues[argDef.Name]
+	flagWasSet := bofFlagWasProvided(fs, argDef.Name)
+
+	if flagWasSet {
+		err := argsBuffer.AddInt(uint32(*ptr))
+		if err != nil {
+			return false, fmt.Errorf("failed to add int argument %s: %v", argDef.Name, err)
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// bofProcessShortArg processes a short integer argument
+func bofProcessShortArg(fs *flag.FlagSet, argDef *extensionArgument, shortValues map[string]*int,
+	argsBuffer core.BOFArgsBuffer) (bool, error) {
+
+	ptr := shortValues[argDef.Name]
+	flagWasSet := bofFlagWasProvided(fs, argDef.Name)
+
+	if flagWasSet {
+		err := argsBuffer.AddShort(uint16(*ptr))
+		if err != nil {
+			return false, fmt.Errorf("failed to add short argument %s: %v", argDef.Name, err)
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// bofProcessFileArg processes a file argument
+func bofProcessFileArg(fs *flag.FlagSet, argDef *extensionArgument, fileValues map[string]*string,
+	argsBuffer core.BOFArgsBuffer) (bool, error) {
+
+	ptr := fileValues[argDef.Name]
+	flagWasSet := *ptr != "" && bofFlagWasProvided(fs, argDef.Name)
+
+	if flagWasSet {
+		// Validate file exists and read it
+		data, err := os.ReadFile(*ptr)
+		if err != nil {
+			return false, fmt.Errorf("error reading file for argument %s: %v", argDef.Name, err)
+		}
+		err = argsBuffer.AddData(data)
+		if err != nil {
+			return false, fmt.Errorf("failed to add file data for argument %s: %v", argDef.Name, err)
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// bofApplyDefaultValue applies a default value based on the argument definition
+func bofApplyDefaultValue(argDef *extensionArgument, argsBuffer core.BOFArgsBuffer) error {
+	// Try to use default value from manifest if available
+	if argDef.Default != nil {
+		switch argDef.Type {
+		case "string":
+			// Handle string default - could be string literal or numeric in JSON
+			defaultVal, ok := argDef.Default.(string)
+			if !ok {
+				// Try to convert from other types
+				defaultVal = fmt.Sprintf("%v", argDef.Default)
+			}
+			err := argsBuffer.AddString(defaultVal)
+			if err != nil {
+				return fmt.Errorf("failed to add default string: %v", err)
+			}
+			fmt.Printf("  -%s:%s (default)\n", argDef.Name, defaultVal)
+
+		case "wstring":
+			// Handle wstring default
+			defaultVal, ok := argDef.Default.(string)
+			if !ok {
+				defaultVal = fmt.Sprintf("%v", argDef.Default)
+			}
+			err := argsBuffer.AddWString(defaultVal)
+			if err != nil {
+				return fmt.Errorf("failed to add default wstring: %v", err)
+			}
+			fmt.Printf("  -%s:%s (default)\n", argDef.Name, defaultVal)
+
+		case "int", "integer":
+			// Handle int default - could be number or string in JSON
+			var defaultInt uint32
+
+			// Try as number first
+			numVal, ok := argDef.Default.(float64) // JSON unmarshals numbers as float64
+			if ok {
+				defaultInt = uint32(numVal)
+			} else {
+				// Try as string
+				strVal, ok := argDef.Default.(string)
+				if ok {
+					val, err := strconv.Atoi(strVal)
+					if err == nil {
+						defaultInt = uint32(val)
+					}
+				}
+			}
+
+			err := argsBuffer.AddInt(defaultInt)
+			if err != nil {
+				return fmt.Errorf("failed to add default int: %v", err)
+			}
+			fmt.Printf("  -%s:%d (default)\n", argDef.Name, defaultInt)
+
+		case "short":
+			// Handle short default - could be number or string in JSON
+			var defaultShort uint16
+
+			// Try as number first
+			numVal, ok := argDef.Default.(float64) // JSON unmarshals numbers as float64
+			if ok {
+				defaultShort = uint16(numVal)
+			} else {
+				// Try as string
+				strVal, ok := argDef.Default.(string)
+				if ok {
+					val, err := strconv.Atoi(strVal)
+					if err == nil {
+						defaultShort = uint16(val)
+					}
+				}
+			}
+
+			err := argsBuffer.AddShort(defaultShort)
+			if err != nil {
+				return fmt.Errorf("failed to add default short: %v", err)
+			}
+			fmt.Printf("  -%s:%d (default)\n", argDef.Name, defaultShort)
+
+		case "file":
+			// Default for file doesn't really make sense, but handle for completeness
+			err := argsBuffer.AddData([]byte{})
+			if err != nil {
+				return fmt.Errorf("failed to add default file data: %v", err)
+			}
+			fmt.Printf("  -%s:<empty> (default)\n", argDef.Name)
+		}
+	} else {
+		// No default specified in manifest, use type-appropriate zero values
+		switch argDef.Type {
+		case "string":
+			err := argsBuffer.AddString("")
+			if err != nil {
+				return fmt.Errorf("failed to add default string: %v", err)
+			}
+			fmt.Printf("  -%s:<empty> (default)\n", argDef.Name)
+
+		case "wstring":
+			err := argsBuffer.AddWString("")
+			if err != nil {
+				return fmt.Errorf("failed to add default wstring: %v", err)
+			}
+			fmt.Printf("  -%s:<empty> (default)\n", argDef.Name)
+
+		case "int", "integer":
+			err := argsBuffer.AddInt(0)
+			if err != nil {
+				return fmt.Errorf("failed to add default int: %v", err)
+			}
+			fmt.Printf("  -%s:0 (default)\n", argDef.Name)
+
+		case "short":
+			err := argsBuffer.AddShort(0)
+			if err != nil {
+				return fmt.Errorf("failed to add default short: %v", err)
+			}
+			fmt.Printf("  -%s:0 (default)\n", argDef.Name)
+
+		case "file":
+			// Empty data for optional file
+			err := argsBuffer.AddData([]byte{})
+			if err != nil {
+				return fmt.Errorf("failed to add default file data: %v", err)
+			}
+			fmt.Printf("  -%s:<empty> (default)\n", argDef.Name)
+		}
+	}
+
+	return nil
+}
+
+// bofDebugPrintParsedFlags prints information about the parsed flags
+func bofDebugPrintParsedFlags(fs *flag.FlagSet, ext *ExtCommand,
+	stringValues map[string]*string,
+	wstringValues map[string]*string,
+	intValues map[string]*int,
+	shortValues map[string]*int,
+	fileValues map[string]*string) {
+
+	fmt.Println("parsed flags:")
+
+	for _, arg := range ext.Arguments {
+		flagName := arg.Name
+		wasProvided := bofFlagWasProvided(fs, flagName)
+
+		if wasProvided {
+			switch arg.Type {
+			case "string":
+				fmt.Printf("  -%s:%s\n", flagName, *stringValues[flagName])
+			case "wstring":
+				fmt.Printf("  -%s:%s\n", flagName, *wstringValues[flagName])
+			case "int", "integer":
+				fmt.Printf("  -%s:%d\n", flagName, *intValues[flagName])
+			case "short":
+				fmt.Printf("  -%s:%d\n", flagName, *shortValues[flagName])
+			case "file":
+				fmt.Printf("  -%s:%s\n", flagName, *fileValues[flagName])
+			}
+		}
+	}
+}
+
+// bofFlagWasProvided checks if a flag was explicitly set
+func bofFlagWasProvided(fs *flag.FlagSet, name string) bool {
+	provided := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			provided = true
+		}
+	})
+	return provided
+}

--- a/client/command/extensions/argparser.go
+++ b/client/command/extensions/argparser.go
@@ -280,7 +280,7 @@ func bofApplyDefaultValue(argDef *extensionArgument, argsBuffer core.BOFArgsBuff
 				// Try as string
 				strVal, ok := argDef.Default.(string)
 				if ok {
-					val, err := strconv.Atoi(strVal)
+					val, err := strconv.ParseUint(strVal, 10, 32)
 					if err == nil {
 						defaultInt = uint32(val)
 					}
@@ -305,7 +305,7 @@ func bofApplyDefaultValue(argDef *extensionArgument, argsBuffer core.BOFArgsBuff
 				// Try as string
 				strVal, ok := argDef.Default.(string)
 				if ok {
-					val, err := strconv.Atoi(strVal)
+					val, err := strconv.ParseUint(strVal, 10, 16)
 					if err == nil {
 						defaultShort = uint16(val)
 					}

--- a/client/command/extensions/install.go
+++ b/client/command/extensions/install.go
@@ -43,7 +43,22 @@ func ExtensionsInstallCmd(cmd *cobra.Command, con *console.SliverClient, args []
 	InstallFromDir(extLocalPath, true, con, strings.HasSuffix(extLocalPath, ".tar.gz"))
 }
 
-// Install an extension from a directory
+// InstallFromDir installs a Sliver extension from either a local directory or gzipped archive.
+// It reads the extension manifest, validates it, and copies all required files to the extensions
+// directory. If an extension with the same name already exists, it can optionally prompt for
+// overwrite confirmation.
+//
+// Parameters:
+//   - extLocalPath: Path to the source directory or gzipped archive containing the extension
+//   - promptToOverwrite: If true, prompts for confirmation before overwriting existing extension
+//   - con: Sliver console client for displaying status and error messages
+//   - isGz: Whether the source is a gzipped archive (true) or directory (false)
+//
+// The function will return early with error messages printed to console if:
+//   - The manifest cannot be read or parsed
+//   - Required directories cannot be created
+//   - File copy operations fail
+//   - User declines overwrite when prompted
 func InstallFromDir(extLocalPath string, promptToOverwrite bool, con *console.SliverClient, isGz bool) {
 	var manifestData []byte
 	var err error
@@ -64,8 +79,15 @@ func InstallFromDir(extLocalPath string, promptToOverwrite bool, con *console.Sl
 		return
 	}
 
+	// Use package name if available, otherwise use extension name
+	// (Note, for v1 manifests this will actually be command_name)
+	packageID := manifestF.Name
+	if manifestF.PackageName != "" {
+		packageID = manifestF.PackageName
+	}
+
 	//create repo path
-	minstallPath := filepath.Join(assets.GetExtensionsDir(), filepath.Base(manifestF.Name))
+	minstallPath := filepath.Join(assets.GetExtensionsDir(), filepath.Base(packageID))
 	if _, err := os.Stat(minstallPath); !os.IsNotExist(err) {
 		if promptToOverwrite {
 			con.PrintInfof("Extension '%s' already exists", manifestF.Name)

--- a/client/command/extensions/list.go
+++ b/client/command/extensions/list.go
@@ -20,11 +20,115 @@ package extensions
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
 
+	"github.com/bishopfox/sliver/client/command/settings"
 	"github.com/bishopfox/sliver/client/console"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 )
+
+// ExtensionMatch holds the details of a matched extension
+
+type ExtensionMatch struct {
+	CommandName string
+	Hash        string
+	BinPath     string
+}
+
+// FindExtensionMatches searches through loaded extensions for matching hashes
+// Returns a map of hash to ExtensionMatch (match will be nil if hash wasn't found)
+func FindExtensionMatches(targetHashes []string) map[string]*ExtensionMatch {
+	results := make(map[string]*ExtensionMatch)
+	pathCache := make(map[string]*ExtensionMatch)
+
+	// Initialize results map with all target hashes
+	for _, hash := range targetHashes {
+		results[hash] = nil
+	}
+
+	// Search for matches
+	for targetHash := range results {
+		for _, extCmd := range loadedExtensions {
+			if extCmd == nil || len(extCmd.Files) == 0 {
+				continue
+			}
+
+			for _, file := range extCmd.Files {
+				fullPath := filepath.Join(extCmd.Manifest.RootPath, file.Path)
+
+				// Check cache first
+				var match *ExtensionMatch
+				if cached, exists := pathCache[fullPath]; exists {
+					match = cached
+				} else {
+					// Calculate hash if not cached
+					fileData, err := os.ReadFile(fullPath)
+					if err != nil {
+						continue
+					}
+
+					hashBytes := sha256.Sum256(fileData)
+					fileHash := hex.EncodeToString(hashBytes[:])
+
+					match = &ExtensionMatch{
+						CommandName: extCmd.CommandName,
+						Hash:        fileHash,
+						BinPath:     fullPath,
+					}
+					pathCache[fullPath] = match
+				}
+
+				if match.Hash == targetHash {
+					results[targetHash] = match
+					break
+				}
+			}
+
+			if results[targetHash] != nil {
+				break
+			}
+		}
+	}
+
+	return results
+}
+
+// PrintExtensionMatches prints the extension matches in a formatted table
+func PrintExtensionMatches(matches map[string]*ExtensionMatch, con *console.SliverClient) {
+	tw := table.NewWriter()
+	tw.SetStyle(settings.GetTableStyle(con))
+	tw.AppendHeader(table.Row{
+		"Command Name",
+		"Sha256 Hash",
+		"Bin Path",
+	})
+	tw.SortBy([]table.SortBy{
+		{Name: "Command Name", Mode: table.Asc},
+	})
+
+	for hash, match := range matches {
+		if match != nil {
+			tw.AppendRow(table.Row{
+				match.CommandName,
+				hash,
+				match.BinPath,
+			})
+		} else {
+			tw.AppendRow(table.Row{
+				"",
+				hash,
+				"",
+			})
+		}
+	}
+
+	con.Println(tw.Render())
+}
 
 // ExtensionsListCmd - List all extension loaded on the active session/beacon.
 func ExtensionsListCmd(cmd *cobra.Command, con *console.SliverClient, args []string) {
@@ -45,10 +149,12 @@ func ExtensionsListCmd(cmd *cobra.Command, con *console.SliverClient, args []str
 		con.PrintErrorf("%s\n", extList.Response.Err)
 		return
 	}
-	if len(extList.Names) > 0 {
-		con.PrintInfof("Loaded extensions:\n")
-		for _, ext := range extList.Names {
-			con.Printf("- %s\n", ext)
-		}
+
+	if len(extList.Names) == 0 {
+		return
 	}
+
+	con.PrintInfof("Loaded extensions:\n\n")
+	matches := FindExtensionMatches(extList.Names)
+	PrintExtensionMatches(matches, con)
 }

--- a/client/command/extensions/load.go
+++ b/client/command/extensions/load.go
@@ -80,6 +80,7 @@ type ExtensionManifest_ struct {
 
 type ExtensionManifest struct {
 	Name            string `json:"name"`
+	PackageName     string `json:"package_name"`
 	Version         string `json:"version"`
 	ExtensionAuthor string `json:"extension_author"`
 	OriginalAuthor  string `json:"original_author"`
@@ -125,7 +126,13 @@ func (e *ExtCommand) getFileForTarget(targetOS string, targetArch string) (strin
 	filePath := ""
 	for _, extFile := range e.Files {
 		if targetOS == extFile.OS && targetArch == extFile.Arch {
-			filePath = path.Join(assets.GetExtensionsDir(), e.Manifest.Name, extFile.Path)
+			if e.Manifest.RootPath != "" {
+				// Use RootPath for temporarily loaded extensions
+				filePath = path.Join(e.Manifest.RootPath, extFile.Path)
+			} else {
+				// Fall back to extensions dir for installed extensions
+				filePath = path.Join(assets.GetExtensionsDir(), e.Manifest.Name, extFile.Path)
+			}
 			break
 		}
 	}
@@ -140,10 +147,19 @@ func (e *ExtCommand) getFileForTarget(targetOS string, targetArch string) (strin
 	return filePath, nil
 }
 
-// ExtensionLoadCmd - Load extension command.
+// ExtensionLoadCmd - Temporarily installs an extension from a local directory into the client.
+// The extension must contain a valid manifest file. If commands from the extension
+// already exist, the user will be prompted to overwrite them.
 func ExtensionLoadCmd(cmd *cobra.Command, con *console.SliverClient, args []string) {
 	dirPath := args[0]
-	// dirPath := ctx.Args.String("dir-path")
+
+	// Add directory check
+	fileInfo, err := os.Stat(dirPath)
+	if err != nil || !fileInfo.IsDir() {
+		con.PrintErrorf("Path is not a directory: %s\n", dirPath)
+		return
+	}
+
 	manifest, err := LoadExtensionManifest(filepath.Join(dirPath, ManifestFileName))
 	if err != nil {
 		return
@@ -165,7 +181,11 @@ func ExtensionLoadCmd(cmd *cobra.Command, con *console.SliverClient, args []stri
 	}
 }
 
-// LoadExtensionManifest - Parse extension files.
+// LoadExtensionManifest loads and parses an extension manifest file from the given path.
+// It registers each command defined in the manifest into the loadedExtensions map
+// and registers the complete manifest into loadedManifests. A single manifest may
+// contain multiple extension commands. The manifest's RootPath is set to its containing
+// directory. Returns the parsed manifest and any errors encountered.
 func LoadExtensionManifest(manifestPath string) (*ExtensionManifest, error) {
 	data, err := os.ReadFile(manifestPath)
 	if err != nil {
@@ -279,7 +299,13 @@ func validManifest(manifest *ExtensionManifest) error {
 	return nil
 }
 
-// ExtensionRegisterCommand - Register a new extension command
+// ExtensionRegisterCommand adds an extension command to the cobra command system.
+// It validates the extension's arguments, updates the loadedExtensions map, and
+// creates a cobra.Command with proper usage text, help documentation, and argument
+// handling. The command is added as a subcommand to the provided parent cobra.Command.
+// Arguments are displayed in the help text as uppercase, with optional args in square
+// brackets. The help text includes sections for command usage, description, and detailed
+// argument specifications.
 func ExtensionRegisterCommand(extCmd *ExtCommand, cmd *cobra.Command, con *console.SliverClient) {
 	if errInvalidArgs := checkExtensionArgs(extCmd); errInvalidArgs != nil {
 		con.PrintErrorf(errInvalidArgs.Error())
@@ -287,7 +313,6 @@ func ExtensionRegisterCommand(extCmd *ExtCommand, cmd *cobra.Command, con *conso
 	}
 
 	loadedExtensions[extCmd.CommandName] = extCmd
-	//helpMsg := extCmd.Help
 
 	usage := strings.Builder{}
 	usage.WriteString(extCmd.CommandName)
@@ -339,9 +364,9 @@ func ExtensionRegisterCommand(extCmd *ExtCommand, cmd *cobra.Command, con *conso
 
 	// Command
 	extensionCmd := &cobra.Command{
-		Use: usage.String(), //extCmd.CommandName,
-		//Short: helpMsg.String(), doesn't appear to be used?
-		Long: help.FormatHelpTmpl(longHelp.String()),
+		Use:   usage.String(),
+		Short: extCmd.Help,
+		Long:  help.FormatHelpTmpl(longHelp.String()),
 		Run: func(cmd *cobra.Command, args []string) {
 			runExtensionCmd(cmd, con, args)
 		},

--- a/client/command/extensions/load.go
+++ b/client/command/extensions/load.go
@@ -584,11 +584,11 @@ func runExtensionCmd(cmd *cobra.Command, con *console.SliverClient, args []strin
 		extName = ext.DependsOn
 		entryPoint = loadedExtensions[extName].Entrypoint // should exist at this point
 	} else {
-		// Regular DLL
-		extensionArgs, err = getExtArgs(cmd, args, binPath, ext)
-		if err != nil {
-			con.PrintErrorf("ext args error: %s\n", err)
-			return
+		// Regular DLL - Just join the arguments with spaces
+		if len(args) > 0 {
+			extensionArgs = []byte(strings.Join(args, " "))
+		} else {
+			extensionArgs = []byte{}
 		}
 		extName = ext.CommandName
 		entryPoint = ext.Entrypoint

--- a/client/command/extensions/load.go
+++ b/client/command/extensions/load.go
@@ -116,10 +116,11 @@ type extensionFile struct {
 }
 
 type extensionArgument struct {
-	Name     string `json:"name"`
-	Type     string `json:"type"`
-	Desc     string `json:"desc"`
-	Optional bool   `json:"optional"`
+	Name     string      `json:"name"`
+	Type     string      `json:"type"`
+	Desc     string      `json:"desc"`
+	Optional bool        `json:"optional"`
+	Default  interface{} `json:"default,omitempty"`
 }
 
 func (e *ExtCommand) getFileForTarget(targetOS string, targetArch string) (string, error) {
@@ -796,7 +797,7 @@ func getBOFArgs(cmd *cobra.Command, args []string, binPath string, ext *ExtComma
 	if err != nil {
 		return nil, err
 	}
-	parsedArgs, err := getExtArgs(cmd, args, binPath, ext)
+	parsedArgs, err := ParseFlagArgumentsToBuffer(cmd, args, binPath, ext)
 	if err != nil {
 		return nil, err
 	}

--- a/client/command/extensions/remove.go
+++ b/client/command/extensions/remove.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/bishopfox/sliver/client/assets"
@@ -86,12 +87,35 @@ func RemoveExtensionByManifestName(manifestName string, con *console.SliverClien
 		return false, errors.New("command name is required")
 	}
 	if man, ok := loadedManifests[manifestName]; ok {
-		//foudn the manifest
-		//delet it
-		extPath := filepath.Join(assets.GetExtensionsDir(), filepath.Base(manifestName))
+		// Found the manifest
+		var extPath string
+		if man.RootPath != "" {
+			// Use RootPath for temporarily loaded extensions
+			extPath = man.RootPath
+		} else {
+			// Fall back to extensions dir for installed extensions
+			extPath = filepath.Join(assets.GetExtensionsDir(), filepath.Base(manifestName))
+		}
+
 		if _, err := os.Stat(extPath); os.IsNotExist(err) {
 			return true, nil
 		}
+
+		// If path is outside extensions directory, prompt for confirmation
+		if !strings.HasPrefix(extPath, assets.GetExtensionsDir()) {
+			confirm := false
+			prompt := &survey.Confirm{Message: fmt.Sprintf("Remove '%s' extension directory from filesystem?", manifestName)}
+			survey.AskOne(prompt, &confirm)
+			if !confirm {
+				// Skip the forceRemoveAll but continue with the rest
+				delete(loadedManifests, manifestName)
+				for _, cmd := range man.ExtCommand {
+					delete(loadedExtensions, cmd.CommandName)
+				}
+				return true, nil
+			}
+		}
+
 		forceRemoveAll(extPath)
 		delete(loadedManifests, manifestName)
 		for _, cmd := range man.ExtCommand {

--- a/client/command/server.go
+++ b/client/command/server.go
@@ -19,6 +19,7 @@ package command
 */
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/bishopfox/sliver/client/command/alias"
@@ -31,6 +32,7 @@ import (
 	"github.com/bishopfox/sliver/client/command/crack"
 	"github.com/bishopfox/sliver/client/command/creds"
 	"github.com/bishopfox/sliver/client/command/exit"
+	"github.com/bishopfox/sliver/client/command/extensions"
 	"github.com/bishopfox/sliver/client/command/generate"
 	"github.com/bishopfox/sliver/client/command/hosts"
 	"github.com/bishopfox/sliver/client/command/info"
@@ -91,6 +93,7 @@ func ServerCommands(con *client.SliverClient, serverCmds func() []*cobra.Command
 			licenses.Commands,
 			settings.Commands,
 			alias.Commands,
+			extensions.Commands,
 			armory.Commands,
 			update.Commands,
 			operators.Commands,
@@ -130,6 +133,26 @@ func ServerCommands(con *client.SliverClient, serverCmds func() []*cobra.Command
 		)
 
 		// [ Post-command declaration setup ]-----------------------------------------
+
+		// Load Extensions
+		// Similar to the SliverCommand loading, without adding the commands to the
+		// Server command tree. This is done to ensure that the extensions are loaded
+		// before the server is started, so that the extensions are registered.
+		extensionManifests := extensions.GetAllExtensionManifests()
+		for _, manifest := range extensionManifests {
+			_, err := extensions.LoadExtensionManifest(manifest)
+			// Absorb error in case there's no extensions manifest
+			if err != nil {
+				//con doesn't appear to be initialised here?
+				//con.PrintErrorf("Failed to load extension: %s", err)
+				fmt.Printf("Failed to load extension: %s\n", err)
+				continue
+			}
+
+			//for _, ext := range mext.ExtCommand {
+			//	extensions.ExtensionRegisterCommand(ext, sliver, con)
+			//}
+		}
 
 		// Everything below this line should preferably not be any command binding
 		// (although you can do so without fear). If there are any final modifications

--- a/client/command/sliver.go
+++ b/client/command/sliver.go
@@ -87,6 +87,7 @@ func SliverCommands(con *client.SliverClient) console.Commands {
 			screenshot.Commands,
 			environment.Commands,
 			registry.Commands,
+			extensions.SliverCommands,
 		)
 
 		// [ Filesystem ]
@@ -127,9 +128,7 @@ func SliverCommands(con *client.SliverClient) console.Commands {
 		bind(consts.AliasHelpGroup)
 
 		// [ Extensions ]
-		bind(consts.ExtensionHelpGroup,
-			extensions.Commands,
-		)
+		bind(consts.ExtensionHelpGroup)
 
 		// [ Post-command declaration setup ]----------------------------------------
 
@@ -144,7 +143,7 @@ func SliverCommands(con *client.SliverClient) console.Commands {
 		}
 
 		// Load Extensions
-		extensionManifests := assets.GetInstalledExtensionManifests()
+		extensionManifests := extensions.GetAllExtensionManifests()
 		for _, manifest := range extensionManifests {
 			mext, err := extensions.LoadExtensionManifest(manifest)
 			// Absorb error in case there's no extensions manifest


### PR DESCRIPTION
Adds flag-based argument parsing for Beacon Object Files (BOFs) using Go's standard flag package. This implementation:

- Converts user-friendly flag-style inputs to BOF-compatible positional argument buffers
- Adds new default field to extension manifests for specifying argument defaults
- Handles optional arguments by applying manifest-defined defaults when available
- Falls back to type-appropriate zero values for optional args without defaults
- Maintains argument type integrity (string, wstring, int, short, file)
- Backwards compatible with existing BOF extensions and manifests

The code processes manifest-defined arguments, parses user-provided flags, and builds the binary buffer structure BOFs expect.

This PR also includes unmerged changes from https://github.com/BishopFox/sliver/pull/1862 (extensions_cmd_improvements) and https://github.com/BishopFox/sliver/pull/1923 (dll_extension_arg_fix).