### PR TITLE
Backported Commit to fix Cursed Chrome Cookies

### DIFF
--- a/client/command/cursed/cursed-cookies.go
+++ b/client/command/cursed/cursed-cookies.go
@@ -19,6 +19,7 @@ package cursed
 */
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -46,24 +47,28 @@ func CursedCookiesCmd(ctx *grumble.Context, con *console.SliverConsoleClient) {
 	if len(cookies) == 0 {
 		return
 	}
+
 	saveFile := ctx.Flags.String("save")
 	if saveFile == "" {
 		saveFile = fmt.Sprintf("cookies-%s.json", time.Now().Format("20060102150405"))
 	}
+
 	jsonCookies := []string{}
 	for _, cookie := range cookies {
-		jsonCookie, err := cookie.MarshalJSON()
+		jsonCookie, err := json.Marshal(cookie)
 		if err != nil {
 			con.PrintErrorf("Failed to marshal cookie: %s\n", err)
 			continue
 		}
 		jsonCookies = append(jsonCookies, string(jsonCookie))
 	}
+
 	err = ioutil.WriteFile(saveFile, []byte(strings.Join(jsonCookies, "\n")), 0600)
 	if err != nil {
 		con.PrintErrorf("Failed to save cookies: %s\n", err)
 		return
 	}
+
 	con.PrintInfof("Saved to %s", saveFile)
 	con.Println()
 }


### PR DESCRIPTION
This change fixes the single Cursed Chrome Cookies utility. It switches the value obtained from a string value to a structure. It also switches the JSON parser to the built-in JSON parser instead of a 3rd party library.