### PR TITLE
Backport "restrict operator certificates to SHA256 to fix grpcio bugs" to V1.5.x/master

### DIFF
--- a/server/certs/ca.go
+++ b/server/certs/ca.go
@@ -60,7 +60,6 @@ func GenerateCertificateAuthority(caType string, commonName string) (*x509.Certi
 	certFilePath := filepath.Join(storageDir, fmt.Sprintf("%s-ca-cert.pem", caType))
 	if _, err := os.Stat(certFilePath); os.IsNotExist(err) {
 		certsLog.Infof("Generating certificate authority for '%s'", caType)
-		//cert, key := GenerateECCCertificate(caType, commonName, true, false)
 		cert, key := GenerateECCCertificate(caType, commonName, true, false, false)
 		SaveCertificateAuthority(caType, cert, key)
 	}

--- a/server/certs/ca.go
+++ b/server/certs/ca.go
@@ -60,7 +60,8 @@ func GenerateCertificateAuthority(caType string, commonName string) (*x509.Certi
 	certFilePath := filepath.Join(storageDir, fmt.Sprintf("%s-ca-cert.pem", caType))
 	if _, err := os.Stat(certFilePath); os.IsNotExist(err) {
 		certsLog.Infof("Generating certificate authority for '%s'", caType)
-		cert, key := GenerateECCCertificate(caType, commonName, true, false)
+		//cert, key := GenerateECCCertificate(caType, commonName, true, false)
+		cert, key := GenerateECCCertificate(caType, commonName, true, false, false)
 		SaveCertificateAuthority(caType, cert, key)
 	}
 	cert, key, err := GetCertificateAuthority(caType)

--- a/server/certs/certs.go
+++ b/server/certs/certs.go
@@ -135,7 +135,8 @@ func RemoveCertificate(caType string, keyType string, commonName string) error {
 // GenerateECCCertificate - Generate a TLS certificate with the given parameters
 // We choose some reasonable defaults like Curve, Key Size, ValidFor, etc.
 // Returns two strings `cert` and `key` (PEM Encoded).
-func GenerateECCCertificate(caType string, commonName string, isCA bool, isClient bool) ([]byte, []byte) {
+//func GenerateECCCertificate(caType string, commonName string, isCA bool, isClient bool) ([]byte, []byte) {
+func GenerateECCCertificate(caType string, commonName string, isCA bool, isClient bool, isOperator bool) ([]byte, []byte) {
 
 	certsLog.Infof("Generating TLS certificate (ECC) for '%s' ...", commonName)
 
@@ -143,7 +144,14 @@ func GenerateECCCertificate(caType string, commonName string, isCA bool, isClien
 	var err error
 
 	// Generate private key
-	curves := []elliptic.Curve{elliptic.P521(), elliptic.P384(), elliptic.P256()}
+	//curves := []elliptic.Curve{elliptic.P521(), elliptic.P384(), elliptic.P256()}
+	var curves []elliptic.Curve
+	if isOperator {
+		curves = []elliptic.Curve{elliptic.P256()}
+	} else {
+		curves = []elliptic.Curve{elliptic.P521(), elliptic.P384(), elliptic.P256()}
+	}
+
 	curve := curves[randomInt(len(curves))]
 	privateKey, err = ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {

--- a/server/certs/certs.go
+++ b/server/certs/certs.go
@@ -135,7 +135,6 @@ func RemoveCertificate(caType string, keyType string, commonName string) error {
 // GenerateECCCertificate - Generate a TLS certificate with the given parameters
 // We choose some reasonable defaults like Curve, Key Size, ValidFor, etc.
 // Returns two strings `cert` and `key` (PEM Encoded).
-//func GenerateECCCertificate(caType string, commonName string, isCA bool, isClient bool) ([]byte, []byte) {
 func GenerateECCCertificate(caType string, commonName string, isCA bool, isClient bool, isOperator bool) ([]byte, []byte) {
 
 	certsLog.Infof("Generating TLS certificate (ECC) for '%s' ...", commonName)
@@ -144,7 +143,6 @@ func GenerateECCCertificate(caType string, commonName string, isCA bool, isClien
 	var err error
 
 	// Generate private key
-	//curves := []elliptic.Curve{elliptic.P521(), elliptic.P384(), elliptic.P256()}
 	var curves []elliptic.Curve
 	if isOperator {
 		curves = []elliptic.Curve{elliptic.P256()}

--- a/server/certs/mtls.go
+++ b/server/certs/mtls.go
@@ -26,7 +26,6 @@ const (
 
 // MtlsC2ServerGenerateECCCertificate - Generate a server certificate signed with a given CA
 func MtlsC2ServerGenerateECCCertificate(host string) ([]byte, []byte, error) {
-	//cert, key := GenerateECCCertificate(MtlsServerCA, host, false, false)
 	cert, key := GenerateECCCertificate(MtlsServerCA, host, false, false, false)
 	err := saveCertificate(MtlsServerCA, ECCKey, host, cert, key)
 	return cert, key, err
@@ -34,7 +33,6 @@ func MtlsC2ServerGenerateECCCertificate(host string) ([]byte, []byte, error) {
 
 // MtlsC2ImplantGenerateECCCertificate - Generate a server certificate signed with a given CA
 func MtlsC2ImplantGenerateECCCertificate(name string) ([]byte, []byte, error) {
-	//cert, key := GenerateECCCertificate(MtlsImplantCA, name, false, true)
 	cert, key := GenerateECCCertificate(MtlsImplantCA, name, false, true, false)
 	err := saveCertificate(MtlsImplantCA, ECCKey, name, cert, key)
 	return cert, key, err

--- a/server/certs/mtls.go
+++ b/server/certs/mtls.go
@@ -26,14 +26,16 @@ const (
 
 // MtlsC2ServerGenerateECCCertificate - Generate a server certificate signed with a given CA
 func MtlsC2ServerGenerateECCCertificate(host string) ([]byte, []byte, error) {
-	cert, key := GenerateECCCertificate(MtlsServerCA, host, false, false)
+	//cert, key := GenerateECCCertificate(MtlsServerCA, host, false, false)
+	cert, key := GenerateECCCertificate(MtlsServerCA, host, false, false, false)
 	err := saveCertificate(MtlsServerCA, ECCKey, host, cert, key)
 	return cert, key, err
 }
 
 // MtlsC2ImplantGenerateECCCertificate - Generate a server certificate signed with a given CA
 func MtlsC2ImplantGenerateECCCertificate(name string) ([]byte, []byte, error) {
-	cert, key := GenerateECCCertificate(MtlsImplantCA, name, false, true)
+	//cert, key := GenerateECCCertificate(MtlsImplantCA, name, false, true)
+	cert, key := GenerateECCCertificate(MtlsImplantCA, name, false, true, false)
 	err := saveCertificate(MtlsImplantCA, ECCKey, name, cert, key)
 	return cert, key, err
 }

--- a/server/certs/operators.go
+++ b/server/certs/operators.go
@@ -37,7 +37,8 @@ const (
 
 // OperatorClientGenerateCertificate - Generate a certificate signed with a given CA
 func OperatorClientGenerateCertificate(operator string) ([]byte, []byte, error) {
-	cert, key := GenerateECCCertificate(OperatorCA, operator, false, true)
+	//cert, key := GenerateECCCertificate(OperatorCA, operator, false, true)
+	cert, key := GenerateECCCertificate(OperatorCA, operator, false, true, true)
 	err := saveCertificate(OperatorCA, ECCKey, fmt.Sprintf("%s.%s", clientNamespace, operator), cert, key)
 	return cert, key, err
 }
@@ -59,7 +60,8 @@ func OperatorServerGetCertificate(hostname string) ([]byte, []byte, error) {
 
 // OperatorServerGenerateCertificate - Generate a certificate signed with a given CA
 func OperatorServerGenerateCertificate(hostname string) ([]byte, []byte, error) {
-	cert, key := GenerateECCCertificate(OperatorCA, hostname, false, false)
+	//cert, key := GenerateECCCertificate(OperatorCA, hostname, false, false)
+	cert, key := GenerateECCCertificate(OperatorCA, hostname, false, false, true)
 	err := saveCertificate(OperatorCA, ECCKey, fmt.Sprintf("%s.%s", serverNamespace, hostname), cert, key)
 	return cert, key, err
 }

--- a/server/certs/operators.go
+++ b/server/certs/operators.go
@@ -37,7 +37,6 @@ const (
 
 // OperatorClientGenerateCertificate - Generate a certificate signed with a given CA
 func OperatorClientGenerateCertificate(operator string) ([]byte, []byte, error) {
-	//cert, key := GenerateECCCertificate(OperatorCA, operator, false, true)
 	cert, key := GenerateECCCertificate(OperatorCA, operator, false, true, true)
 	err := saveCertificate(OperatorCA, ECCKey, fmt.Sprintf("%s.%s", clientNamespace, operator), cert, key)
 	return cert, key, err
@@ -60,7 +59,6 @@ func OperatorServerGetCertificate(hostname string) ([]byte, []byte, error) {
 
 // OperatorServerGenerateCertificate - Generate a certificate signed with a given CA
 func OperatorServerGenerateCertificate(hostname string) ([]byte, []byte, error) {
-	//cert, key := GenerateECCCertificate(OperatorCA, hostname, false, false)
 	cert, key := GenerateECCCertificate(OperatorCA, hostname, false, false, true)
 	err := saveCertificate(OperatorCA, ECCKey, fmt.Sprintf("%s.%s", serverNamespace, hostname), cert, key)
 	return cert, key, err


### PR DESCRIPTION
#### Card

Backport of d07aae4d0bf5082e715e5614119b649e3c81e0c8 to the 1.5x branch 

#### Details

This is a backport of d07aae4d0bf5082e715e5614119b649e3c81e0c8 to the 1.5x branch to fix grpcio bugs and make [Sliverpy](https://github.com/moloch--/sliver-py) connectivity work again. As referenced in issue [1877](https://github.com/BishopFox/sliver/issues/1877). 

Did the backport because I needed it and thought it was worthwhile to share.