### PR TITLE
Add RC4 support to shellcode stager 1.5x backport

### DIFF
--- a/client/command/commands.go
+++ b/client/command/commands.go
@@ -484,6 +484,7 @@ func BindCommands(con *console.SliverConsoleClient) {
 			f.Bool("e", "lets-encrypt", false, "attempt to provision a let's encrypt certificate (HTTPS only)")
 			f.StringL("aes-encrypt-key", "", "encrypt stage with AES encryption key")
 			f.StringL("aes-encrypt-iv", "", "encrypt stage with AES encryption iv")
+			f.StringL("rc4-encrypt-key", "", "encrypt stage with RC4 encryption key")
 			f.String("C", "compress", "none", "compress the stage before encrypting (zlib, gzip, deflate9, none)")
 			f.Bool("P", "prepend-size", false, "prepend the size of the stage to the payload (to use with MSF stagers)")
 		},

--- a/util/cryptography.go
+++ b/util/cryptography.go
@@ -22,9 +22,23 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/rc4"
 	"errors"
 	"io"
 )
+
+// RC4 encryption - Cryptographically insecure!
+// Added for stage-listener shellcode obfuscation
+// Dont use for anything else!
+func RC4EncryptUnsafe(data []byte, key []byte) []byte {
+	cipher, err := rc4.NewCipher(key)
+	if err != nil {
+		return make([]byte, 0)
+	}
+	cipherText := make([]byte, len(data))
+	cipher.XORKeyStream(cipherText, data)
+	return cipherText
+}
 
 // PreludeEncrypt the results
 func PreludeEncrypt(data []byte, key []byte, iv []byte) []byte {


### PR DESCRIPTION
#### Card

Backport of my previous [PR to add RC4 support to shellcode stager 1332](https://github.com/BishopFox/sliver/pull/1332) 

#### Details

As per issue [#1328](https://github.com/BishopFox/sliver/issues/1328), backport of my [PR to add RC4 support to shellcode stager 1332](https://github.com/BishopFox/sliver/pull/1332) to provide RC4 shellcode obfuscation to 1.5.x branch of sliver