### PR TITLE
Fix: correct closure capture in C2Generator to prevent loop variable bug

### DIFF
--- a/implant/sliver/transports/transports.go
+++ b/implant/sliver/transports/transports.go
@@ -45,6 +45,7 @@ func C2Generator(abort <-chan struct{}, temporaryC2 ...string) <-chan *url.URL {
 	// Any temporary C2 servers that are defined will override what is configured in the implant
 	if len(temporaryC2) > 0 {
 		for _, c2 := range temporaryC2 {
+			c2 := c2
 			c2Servers = append(c2Servers, func() string {
 				return c2
 			})


### PR DESCRIPTION
### Summary

This PR fixes a closure capture bug in the `C2Generator()` function.

Previously, the loop variable `c2` was captured by reference inside closures, causing all C2 generators to return the last element in the `temporaryC2` list. This broke multi-C2 fallback logic in the implant.

### Reproduction (before fix)

```go
for _, c2 := range temporaryC2 {
    c2Servers = append(c2Servers, func() string {
        return c2
    })
}

### Result
https://c2-3.example.com
https://c2-3.example.com
https://c2-3.example.com

### Fix
for _, c2 := range temporaryC2 {
    c2 := c2 // capture properly
    c2Servers = append(c2Servers, func() string {
        return c2
    })
}