### PR TITLE
Enrich client logging in implant sessions

### DIFF
--- a/client/console/log.go
+++ b/client/console/log.go
@@ -78,6 +78,24 @@ func (con *SliverClient) logCommand(args []string) ([]string, error) {
 		return args, nil
 	}
 	logger := slog.New(con.jsonHandler).With(slog.String("type", "command"))
+
+	// Attach active target context if available
+	if session:= con.ActiveTarget.GetSession(); session != nil {
+		logger = logger.With(
+			slog.String("id", session.ID),
+			slog.String("name", session.Name),
+			slog.String("hostname", session.Hostname),
+			slog.String("username", session.Username),			
+		)
+	} else if beacon := con.ActiveTarget.GetBeacon(); beacon != nil {
+		logger = logger.With(
+			slog.String("id", beacon.ID),
+			slog.String("name", beacon.Name),			
+			slog.String("hostname", beacon.Hostname),
+			slog.String("username", beacon.Username),
+		)
+	}
+	
 	logger.Debug(strings.Join(args, " "))
 	return args, nil
 }


### PR DESCRIPTION
#### Card
Enhanced client console logging to include session context for better operational tracking and debugging

#### Details
Issue https://github.com/BishopFox/sliver/issues/1982

#### What
This change enriches the client-side logging functionality in Sliver by automatically attaching session or beacon context to command logs. When a command is executed in the client console, the logging system now adds the following  information:
- Session/Beacon ID
- Session name
- Target hostname
- Username

#### Output
```
15bc33b29ba3:~/.sliver/logs/clients$ jq 'select(.level == "DEBUG")' op1/json_2025-08-10_17-13-22.log
{
  "time": "2025-08-10T17:13:22.020149625Z",
  "level": "DEBUG",
  "msg": "sessions",
  "type": "command"
}
{
  "time": "2025-08-10T17:14:50.478982692Z",
  "level": "DEBUG",
  "msg": "use 76786dac",
  "type": "command"
}
{
  "time": "2025-08-10T17:14:51.608264598Z",
  "level": "DEBUG",
  "msg": "ls",
  "type": "command",
  "id": "76786dac-8b68-4687-82c5-dcd420881d92",
  "name": "CAREFUL_CRECHE",
  "hostname": "8348762f646b",
  "username": "appuser"
}
{
  "time": "2025-08-10T17:15:14.799464988Z",
  "level": "DEBUG",
  "msg": "info",
  "type": "command",
  "id": "76786dac-8b68-4687-82c5-dcd420881d92",
  "name": "CAREFUL_CRECHE",
  "hostname": "8348762f646b",
  "username": "appuser"
}
{
  "time": "2025-08-10T17:15:53.481887348Z",
  "level": "DEBUG",
  "msg": "exit",
  "type": "command",
  "id": "76786dac-8b68-4687-82c5-dcd420881d92",
  "name": "CAREFUL_CRECHE",
  "hostname": "8348762f646b",
  "username": "appuser"
}
{
  "time": "2025-08-10T17:15:55.729773798Z",
  "level": "DEBUG",
  "msg": "background",
  "type": "command",
  "id": "76786dac-8b68-4687-82c5-dcd420881d92",
  "name": "CAREFUL_CRECHE",
  "hostname": "8348762f646b",
  "username": "appuser"
}
{
  "time": "2025-08-10T17:15:58.089559737Z",
  "level": "DEBUG",
  "msg": "sessions",
  "type": "command"
}
{
  "time": "2025-08-10T17:15:59.08704388Z",
  "level": "DEBUG",
  "msg": "info",
  "type": "command"
}
{
  "time": "2025-08-10T17:16:06.570321461Z",
  "level": "DEBUG",
  "msg": "exit",
  "type": "command"
}
```

