### PR TITLE
Add info about potential causes for sliver daemon port binding error

### DIFF
--- a/server/daemon/daemon.go
+++ b/server/daemon/daemon.go
@@ -63,7 +63,9 @@ func Start(host string, port uint16, tailscale bool) {
 		_, ln, err = transport.StartMtlsClientListener(host, port)
 	}
 	if err != nil {
-		fmt.Printf("[!] Failed to start daemon %s", err)
+		fmt.Printf("[!] Failed to start daemon %s\n", err)
+		fmt.Printf("[*] If you previously run the multiplayer command, that automatically starts a listener which might conflict with the daemon execution (default port 31337)\n")
+		fmt.Printf("[*] If you want to use the daemon mode kill the multiplayer job and try to start the daemon again.\n")
 		daemonLog.Errorf("Error starting client listener %s", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
#### Card
Provide additional information about port binding error when running running sliver daemon

#### Details
https://github.com/BishopFox/sliver/issues/1984

It was unclear to me why I was getting a port binding error when running `sliver-server daemon` (or using the `./server/config/server.json` file) since nothing appeared to be listening on port 31337. I added a comment to explain that the multiplayer command creates a persistent listener job that gets restored when the server starts (even in daemon mode), causing the daemon to find the binding port already occupied by the multiplayer listener. I tried different approaches with code changes, but those introduced additional edge cases.