### PR TITLE
Fix Windows network adapter retrieval for DNS C2, add additional logging

### DIFF
--- a/client/command/jobs/commands.go
+++ b/client/command/jobs/commands.go
@@ -163,5 +163,5 @@ func Commands(con *console.SliverClient) []*cobra.Command {
 		(*comp)["compress"] = carapace.ActionValues([]string{"zlib", "gzip", "deflate9", "none"}...).Tag("compression formats")
 	})
 
-	return []*cobra.Command{jobsCmd, mtlsCmd, wgCmd, httpCmd, httpsCmd, stageCmd}
+	return []*cobra.Command{jobsCmd, mtlsCmd, wgCmd, dnsCmd, httpCmd, httpsCmd, stageCmd}
 }

--- a/implant/sliver/transports/dnsclient/conf_windows.go
+++ b/implant/sliver/transports/dnsclient/conf_windows.go
@@ -36,6 +36,7 @@ import (
 	"unsafe"
 
 	// {{if .Config.Debug}}
+	"fmt"
 	"log"
 	// {{end}}
 
@@ -46,46 +47,82 @@ import (
 // dnsClientConfig - returns all DNS server addresses associated with the given address
 // using various windows fuckery.
 func dnsClientConfig() (*dns.ClientConfig, error) {
-	l := uint32(20000)
+	l := uint32(1000000)
 	b := make([]byte, l)
 
 	// Windows is an utter fucking trash fire of an operating system.
 	if err := windows.GetAdaptersAddresses(windows.AF_UNSPEC, windows.GAA_FLAG_INCLUDE_PREFIX, 0, (*windows.IpAdapterAddresses)(unsafe.Pointer(&b[0])), &l); err != nil {
+		// {{if .Config.Debug}}
+		log.Printf("[dns] error getting Windows network adapter addresses: %v. If the error message is 'The file name is too long', this indicates a buffer overflow due to the data exceeding the size of the buffer allocated in the dnsClientConfig function of sliver/implant/sliver/transports/dnsclient/conf_windows.go.", err)
+		// {{end}}
 		return nil, err
 	}
 	var adapters []*windows.IpAdapterAddresses
 	for addr := (*windows.IpAdapterAddresses)(unsafe.Pointer(&b[0])); addr != nil; addr = addr.Next {
-		adapters = append(adapters, addr)
+		adapters = append(adapters, addr)		
+		// {{if .Config.Debug}}
+		adapterName := windows.BytePtrToString(addr.AdapterName)
+		adapterAddressString := ""
+		adapterIPAddress := addr.FirstUnicastAddress.Address.IP()
+		if adapterIPAddress != nil {
+			adapterAddressString = fmt.Sprintf(" with address %s", adapterIPAddress.To16())
+		}
+		log.Printf("[dns] found Windows network adapter '%s'%s", adapterName, adapterAddressString)
+		// {{end}}
 	}
 
 	resolvers := map[string]bool{}
 	for _, adapter := range adapters {
 		if adapter.OperStatus != windows.IfOperStatusUp {
+			// {{if .Config.Debug}}
+			adapterName := windows.BytePtrToString(adapter.AdapterName)
+			log.Printf("[dns] skipping adapter '%s' because it is down", adapterName)
+			// {{end}}
 			continue // Skip down interfaces
 		}
 		for next := adapter.FirstUnicastAddress; next != nil; next = next.Next {
-			if next.Address.IP() != nil {
+			// {{if .Config.Debug}}
+			if next.Address.IP() == nil {
+				adapterName := windows.BytePtrToString(adapter.AdapterName)
+				log.Printf("[dns] skipping adapter '%s' because it has no IP address", adapterName)
+			} else {
+			// {{end}}
 				for dnsServer := adapter.FirstDnsServerAddress; dnsServer != nil; dnsServer = dnsServer.Next {
 					ip := dnsServer.Address.IP()
+					// {{if .Config.Debug}}
+					adapterName := windows.BytePtrToString(adapter.AdapterName)
+					log.Printf("[dns] found DNS server IP address %v for adapter '%s'", ip, adapterName)
+					// {{end}}
 					if ip.IsMulticast() || ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() {
+						// {{if .Config.Debug}}
+						log.Printf("[dns] Skipping DNS server IP address %v for adapter '%s' because its type is multicast, link-local unicast, or unspecified", ip, adapterName)
+						// {{end}}
 						continue
 					}
 					if ip.To16() != nil && strings.HasPrefix(ip.To16().String(), "fec0:") {
+						// {{if .Config.Debug}}
+						log.Printf("[dns] Skipping DNS server IP address %v for adapter '%s' because its address begins with 'fec0:'", ip, adapterName)
+						// {{end}}
 						continue
 					}
 					// {{if .Config.Debug}}
-					log.Printf("Possible resolver: %v", ip)
+					log.Printf("[dns] Possible resolver: %v", ip)
 					// {{end}}
 					resolvers[ip.String()] = true
 				}
 				break
+			// {{if .Config.Debug}}
 			}
+			// {{end}}
 		}
 	}
 
 	// Take unique values only
 	servers := []string{}
 	for server := range resolvers {
+		// {{if .Config.Debug}}
+		log.Printf("[dns] Adding DNS server '%s' to the list of resolvers", server)
+		// {{end}}
 		servers = append(servers, server)
 	}
 

--- a/implant/sliver/transports/dnsclient/resolver-generic.go
+++ b/implant/sliver/transports/dnsclient/resolver-generic.go
@@ -82,7 +82,7 @@ func (r *GenericResolver) A(domain string) ([]byte, time.Duration, error) {
 			break
 		}
 		// {{if .Config.Debug}}
-		log.Printf("[dns] query error: %s (retry wait: %s)", err, r.retryWait)
+		log.Printf("[dns] error retrieving A records for '%s' using a(): %v (retry wait: %s)", domain, err, r.retryWait)
 		// {{end}}
 		time.Sleep(r.retryWait)
 	}
@@ -95,11 +95,14 @@ func (r *GenericResolver) a(domain string) ([]byte, time.Duration, error) {
 	// {{end}}
 	resp, rtt, err := r.localQuery(domain, dns.TypeA)
 	if err != nil {
+		// {{if .Config.Debug}}
+		log.Printf("[dns] error retrieving A records using localQuery() for '%s': %v", domain, err)
+		// {{end}}
 		return nil, rtt, err
 	}
 	if resp.Rcode != dns.RcodeSuccess {
 		// {{if .Config.Debug}}
-		log.Printf("[dns] error response status: %v", resp.Rcode)
+		log.Printf("[dns] error response received when attempting to resolve A records for '%s', status: %v", domain, resp.Rcode)
 		// {{end}}
 		return nil, rtt, ErrInvalidRcode
 	}
@@ -127,7 +130,7 @@ func (r *GenericResolver) AAAA(domain string) ([]byte, time.Duration, error) {
 			break
 		}
 		// {{if .Config.Debug}}
-		log.Printf("[dns] query error: %s (retry wait: %s)", err, r.retryWait)
+		log.Printf("[dns] query error when resolving AAAA records for '%s' using aaaa(): %v (retry wait: %s)", domain, err, r.retryWait)
 		// {{end}}
 		time.Sleep(r.retryWait)
 	}
@@ -140,11 +143,14 @@ func (r *GenericResolver) aaaa(domain string) ([]byte, time.Duration, error) {
 	// {{end}}
 	resp, rtt, err := r.localQuery(domain, dns.TypeAAAA)
 	if err != nil {
+		// {{if .Config.Debug}}
+		log.Printf("[dns] error retrieving AAAA records using localQuery() for '%s': %v", domain, err)
+		// {{end}}
 		return nil, rtt, err
 	}
 	if resp.Rcode != dns.RcodeSuccess {
 		// {{if .Config.Debug}}
-		log.Printf("[dns] error response status: %v", resp.Rcode)
+		log.Printf("[dns] error response received when attempting to resolve AAAA records for '%s', status: %v", domain, resp.Rcode)
 		// {{end}}
 		return nil, rtt, ErrInvalidRcode
 	}
@@ -208,7 +214,7 @@ func (r *GenericResolver) TXT(domain string) ([]byte, time.Duration, error) {
 			break
 		}
 		// {{if .Config.Debug}}
-		log.Printf("[dns] query error: %s (retry wait: %s)", err, r.retryWait)
+		log.Printf("[dns] error retrieving TXT records using txt() for '%s': %v (retry wait: %s)", domain, err, r.retryWait)
 		// {{end}}
 		time.Sleep(r.retryWait)
 	}
@@ -218,11 +224,14 @@ func (r *GenericResolver) TXT(domain string) ([]byte, time.Duration, error) {
 func (r *GenericResolver) txt(domain string) ([]byte, time.Duration, error) {
 	resp, rtt, err := r.localQuery(domain, dns.TypeTXT)
 	if err != nil {
+		// {{if .Config.Debug}}
+		log.Printf("[dns] error retrieving TXT records using localQuery() for '%s': %v", domain, err)
+		// {{end}}
 		return nil, rtt, err
 	}
 	if resp.Rcode != dns.RcodeSuccess {
 		// {{if .Config.Debug}}
-		log.Printf("[dns] error response status: %v", resp.Rcode)
+		log.Printf("[dns] error response received when attempting to resolve TXT records for '%s' using localQuery(), status: %v", domain, resp.Rcode)
 		// {{end}}
 		return nil, rtt, ErrInvalidRcode
 	}
@@ -241,6 +250,12 @@ func (r *GenericResolver) txt(domain string) ([]byte, time.Duration, error) {
 		}
 		if 0 < len(records) {
 			data, err = r.base64.Decode([]byte(records))
+			if err != nil {
+				// {{if .Config.Debug}}
+				log.Printf("[dns] error base64-decoding TXT record response: %v", err)
+				// {{end}}
+				return nil, rtt, err
+			}
 		}
 		// {{if .Config.Debug}}
 	} else {
@@ -264,6 +279,9 @@ func (r *GenericResolver) localQuery(qName string, qType uint16) (*dns.Msg, time
 	log.Printf("[dns] rtt->%s %s (err: %v)", r.address, rtt, err)
 	// {{end}}
 	if err != nil {
+		// {{if .Config.Debug}}
+		log.Printf("[dns] error resolving '%s': %v", qName, err)
+		// {{end}}
 		return nil, rtt, err
 	}
 	return resp, rtt, nil


### PR DESCRIPTION
This is a squashed, signed version of [PR 1963](https://github.com/BishopFox/sliver/pull/1963). Trying to sign the historical commits was going to be a massive ordeal, and creating a new branch/PR was much faster.

Here is the text from the original PR:

This PR increases the size of the buffer that's used to retrieve Windows network adapter information as part of establishing a DNS C2 connection. In prior versions, the buffer was 20K in size, which was insufficient. When windows.IpAdapterAddresses encounters this situation, it returns the POSIX error code for "The file name is too long", because that's the closest POSIX has to a "buffer overflow" code.[1]

This was the cause of https://github.com/BishopFox/sliver/issues/1411

I imagine it was hard to reproduce because it only occurred on systems with a sufficient number of network adapters.

I increased the buffer size to 1MB, which I think would be enough on just about any Windows system.

I also added some additional logging and more information to a few existing messages to make troubleshooting DNS C2 easier.

The PR also re-adds the `dns` command, since that was necessary to do the dev work.

[1] See this discussion related to MSYS from 2011 for the same symptom: https://groups.google.com/g/msysgit/c/e9dkPpl2C8E/m/P0cpB8KS8oAJ