### PR TITLE
Add --loot flag to extension commands

### DIFF
--- a/client/command/extensions/load.go
+++ b/client/command/extensions/load.go
@@ -668,11 +668,13 @@ func runExtensionCmd(cmd *cobra.Command, con *console.SliverClient, args []strin
 
 // PrintExtOutput - Print the ext execution output.
 func PrintExtOutput(extName string, commandName string, outputSchema *packages.OutputSchema, callExtension *sliverpb.CallExtension, cmd *cobra.Command, hostName string, con *console.SliverClient) {
-	saveLoot, _ := cmd.Flags().GetBool("loot")
-	lootName, _ := cmd.Flags().GetString("name")
+	if cmd != nil {
+		saveLoot, _ := cmd.Flags().GetBool("loot")
+		lootName, _ := cmd.Flags().GetString("name")
 
-	if saveLoot {
-		LootExtension(callExtension.Output, lootName, commandName, hostName, con)
+		if saveLoot {
+			LootExtension(callExtension.Output, lootName, commandName, hostName, con)
+		}
 	}
 
 	if extName == commandName {

--- a/client/command/tasks/fetch.go
+++ b/client/command/tasks/fetch.go
@@ -227,7 +227,7 @@ func renderTaskResponse(task *clientpb.BeaconTask, con *console.SliverClient) {
 			con.PrintErrorf("Failed to decode task response: %s\n", err)
 			return
 		}
-		extensions.PrintExtOutput("", "", nil, callExtension, con)
+		extensions.PrintExtOutput("", "", nil, callExtension, nil, "", con)
 
 	// ---------------------
 	// Exec commands


### PR DESCRIPTION
## Summary
- Add `--loot` (`-X`) and `--name` (`-n`) flags to extension commands
- Allow users to save extension output directly to the loot store
- Mirrors existing loot functionality from the `execute` command

## Changes
- `client/command/extensions/load.go`: Added loot saving support with new `LootExtension()` function
- `client/command/tasks/fetch.go`: Updated `PrintExtOutput` call to match new signature