### PR TITLE
Implement --rc for scripting initial inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /artifacts
 /artifacts/**
 
+*.rc
 
 /Dockerfile.*
 /*.sdk.tar.xz

--- a/client/cli/cli.go
+++ b/client/cli/cli.go
@@ -51,6 +51,7 @@ func init() {
 	defer logFile.Close()
 
 	rootCmd.TraverseChildren = true
+	rootCmd.Flags().String(RCFlagName, "", "path to rc script file")
 
 	// Create the console client, without any RPC or commands bound to it yet.
 	// This created before anything so that multiple commands can make use of

--- a/client/cli/rc.go
+++ b/client/cli/rc.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+const RCFlagName = "rc"
+
+func ReadRCScript(cmd *cobra.Command) (string, error) {
+	if cmd == nil {
+		return "", nil
+	}
+	if cmd.Flags().Lookup(RCFlagName) == nil {
+		return "", nil
+	}
+	rcPath, err := cmd.Flags().GetString(RCFlagName)
+	if err != nil {
+		return "", err
+	}
+	if rcPath == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(rcPath)
+	if err != nil {
+		return "", fmt.Errorf("read rc script %q: %w", rcPath, err)
+	}
+	return string(data), nil
+}

--- a/server/cli/cli.go
+++ b/server/cli/cli.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	clientcli "github.com/bishopfox/sliver/client/cli"
 	"github.com/bishopfox/sliver/server/assets"
 	"github.com/bishopfox/sliver/server/c2"
 	"github.com/bishopfox/sliver/server/certs"
@@ -72,6 +73,8 @@ func initConsoleLogging(appDir string) *os.File {
 }
 
 func init() {
+	rootCmd.Flags().String(clientcli.RCFlagName, "", "path to rc script file")
+
 	// Unpack
 	unpackCmd.Flags().BoolP(forceFlagStr, "f", false, "Force unpack and overwrite")
 	rootCmd.AddCommand(unpackCmd)
@@ -147,8 +150,14 @@ var rootCmd = &cobra.Command{
 		if serverConfig.DaemonMode {
 			daemon.Start(daemon.BlankHost, daemon.BlankPort, serverConfig.DaemonConfig.Tailscale)
 		} else {
+			rcScript, err := clientcli.ReadRCScript(cmd)
+			if err != nil {
+				fmt.Printf("Failed to read rc script: %s\n", err)
+				return
+			}
+
 			os.Args = os.Args[:1] // Hide cli from grumble console
-			console.Start()
+			console.Start(rcScript)
 		}
 	},
 }

--- a/server/console/console.go
+++ b/server/console/console.go
@@ -38,7 +38,7 @@ import (
 )
 
 // Start - Starts the server console
-func Start() {
+func Start(rcScript string) {
 	_, ln, _ := transport.LocalListener()
 	ctxDialer := grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 		return ln.Dial()
@@ -57,7 +57,7 @@ func Start() {
 	defer conn.Close()
 	localRPC := rpcpb.NewSliverRPCClient(conn)
 	con := console.NewConsole(false)
-	console.StartClient(con, localRPC, command.ServerCommands(con, serverOnlyCmds), command.SliverCommands(con), true)
+	console.StartClient(con, localRPC, command.ServerCommands(con, serverOnlyCmds), command.SliverCommands(con), true, rcScript)
 
 	con.App.Start()
 }


### PR DESCRIPTION
Adds an `--rc` flag for scripted inputs to address issue #2089

```
➜  sliver git:(feature/rc) cat test.rc 
jobs

➜  sliver git:(feature/rc) ./sliver-server --rc test.rc
 ID   Name   Protocol   Port   Domains 
==== ====== ========== ====== =========
 1    mtls   tcp        8888           

...

All hackers gain haste
[*] Server v1.6.1 - dc736f60954cca9ccce7fd15c805606b4335efb3 - Dirty
[*] Welcome to the sliver shell, please type 'help' for options
sliver > 
```