### PR TITLE
Fix DNS beacon closing immediately after registering

### DIFF
--- a/implant/sliver/transports/beacon.go
+++ b/implant/sliver/transports/beacon.go
@@ -362,9 +362,6 @@ func dnsBeacon(uri *url.URL) *Beacon {
 			return client.WriteEnvelope(envelope)
 		},
 		Close: func() error {
-			if client != nil {
-				return client.CloseSession()
-			}
 			return nil
 		},
 		Cleanup: func() error {


### PR DESCRIPTION
In 1.6 versions, DNS beacons close after registering, making them stale in the console.
Debug log:
```
... snip ...
2026/01/06 21:02:00 beacon.go:86: Interval: 60000000000 Jitter: 30000000000
2026/01/06 21:02:00 beacon.go:94: Duration: 1m23.804332169s
2026/01/06 21:02:00 runner.go:210: [beacon] sleep until 2026-01-06 21:03:24.726707293 +0000 UTC m=+85.121666084
2026/01/06 21:02:00 runner.go:252: [beacon] sending check in with 0 pending results...
2026/01/06 21:02:00 beacon.go:86: Interval: 60000000000 Jitter: 30000000000
2026/01/06 21:02:00 beacon.go:94: Duration: 1m10.260851254s
2026/01/06 21:02:00 runner.go:261: [beacon] send failure dns session closed
2026/01/06 21:02:00 runner.go:233: [beacon] closing ...
2026/01/06 21:03:24 beacon.go:86: Interval: 60000000000 Jitter: 30000000000
2026/01/06 21:03:24 beacon.go:94: Duration: 1m20.170044691s
2026/01/06 21:03:24 runner.go:210: [beacon] sleep until 2026-01-06 21:04:44.979747484 +0000 UTC m=+165.374706275
2026/01/06 21:03:24 runner.go:252: [beacon] sending check in with 0 pending results...
2026/01/06 21:03:24 beacon.go:86: Interval: 60000000000 Jitter: 30000000000
2026/01/06 21:03:24 beacon.go:94: Duration: 1m14.215893973s
2026/01/06 21:03:24 runner.go:261: [beacon] send failure dns session closed
2026/01/06 21:03:24 runner.go:233: [beacon] closing ...
... snip ...
```

In `beacon.go`, the session is closed when invoking `Close`: https://github.com/BishopFox/sliver/blob/a219a97cb47dfe883c86f6f7cf32b9cd718e1b96/implant/sliver/transports/beacon.go#L364-L368
`CloseSession` is also called when cleaning up, so the beacon is effectively cleaned up immediately.
These lines have been added recently by #2070, so this PR reverts that change. I tested the reverted changes, and beacons work as expected now.