### PR TITLE
Fix: getsystem shellcode generation

### DIFF
--- a/client/command/privilege/getsystem.go
+++ b/client/command/privilege/getsystem.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/bishopfox/sliver/client/console"
+	consts "github.com/bishopfox/sliver/client/constants"
 	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
 )
@@ -44,6 +45,17 @@ func GetSystemCmd(cmd *cobra.Command, con *console.SliverClient, args []string) 
 
 	process, _ := cmd.Flags().GetString("process")
 	config := con.GetActiveSessionConfig()
+
+	/* If the HTTP C2 Config name is not defined, then put in the default value
+	   This will have no effect on implants that do not use HTTP C2
+	   Also this should be overridden when the build info is pulled from the
+	   database, but if there is no build info and we have to create the build
+	   from scratch, we need to have something in here.
+	*/
+	if config.HTTPC2ConfigName == "" {
+		config.HTTPC2ConfigName = consts.DefaultC2Profile
+	}
+
 	ctrl := make(chan bool)
 	con.SpinUntil("Attempting to create a new sliver session as 'NT AUTHORITY\\SYSTEM'...", ctrl)
 

--- a/server/rpc/rpc-priv.go
+++ b/server/rpc/rpc-priv.go
@@ -109,6 +109,12 @@ func (rpc *Server) GetSystem(ctx context.Context, req *clientpb.GetSystemReq) (*
 	if err != nil {
 		req.Config.Format = clientpb.OutputFormat_SHELLCODE
 		req.Config.ObfuscateSymbols = false
+		req.Config.IsShellcode = true
+		req.Config.IsSharedLib = false
+		req.Config.TemplateName = "sliver"
+		if len(req.Config.Exports) == 0 {
+			req.Config.Exports = []string{"StartW"}
+		}
 		build, err := generate.GenerateConfig(name, req.Config)
 		if err != nil {
 			return nil, rpcError(err)


### PR DESCRIPTION
`getsystem` command is failing with multiple RPC errors due to missing implant configuration fields during shellcode generation. Problems are with missing HTTPC2ConfigName, empty DLL export lists, and unset shellcode flags.

Current 1.6.2 precompiled binaries running getsystem:

`[!] rpc error: code = NotFound desc = record not found`


#### Changes

Set `HTTPC2ConfigName` to `"default"` if unset, preventing `record not found` errors when loading C2 configs.

Ensure `Exports` includes `"StartW"` to avoid template panics on empty slices.

Explicitly set `IsShellcode`, `IsSharedLib`, and `TemplateName` to required values for shellcode builds.


#### Testing

Verified `getsystem` works, returning a system session.

Confirmed all changes pass `go-tests.sh`.
