### PR TITLE
Use lport from server config in daemon mode  / fix #2129

### DIFF
--- a/server/cli/operator.go
+++ b/server/cli/operator.go
@@ -64,6 +64,14 @@ var operatorCmd = &cobra.Command{
 			return
 		}
 
+		if !cmd.Flags().Changed(lportFlagStr) {
+			serverConfig := configs.GetServerConfig()
+
+			if serverConfig.DaemonMode {
+				lport = uint16(serverConfig.DaemonConfig.Port)
+			}
+		}
+
 		save, err := cmd.Flags().GetString(saveFlagStr)
 		if err != nil {
 			fmt.Printf("Failed to parse --%s flag %s", saveFlagStr, err)


### PR DESCRIPTION
When DaemonMode is enabled in the server config and --lport isn’t provided, the operator config is set up to using DaemonConfig.Port for the listen port

Fixes #2129