### PR TITLE
Restrict external builder RPCs to assigned build jobs

### DIFF
--- a/server/builder/builder.go
+++ b/server/builder/builder.go
@@ -132,7 +132,8 @@ func (b *Builder) handleBuildEvent(event *clientpb.Event) {
 	implantBuildID := parts[1]
 	builderLog.Infof("Build event for implant build id: %s", implantBuildID)
 	extConfig, err := b.rpc.GenerateExternalGetBuildConfig(context.Background(), &clientpb.ImplantBuild{
-		ID: implantBuildID,
+		ID:   implantBuildID,
+		Name: b.externalBuilder.Name,
 	})
 	if err != nil {
 		builderLog.Errorf("Failed to get build config: %s", err)
@@ -245,7 +246,7 @@ func (b *Builder) handleBuildEvent(event *clientpb.Event) {
 
 	builderLog.Infof("Uploading '%s' to server ...", extConfig.Build.Name)
 	_, err = b.rpc.GenerateExternalSaveBuild(context.Background(), &clientpb.ExternalImplantBinary{
-		Name:           extConfig.Build.Name,
+		Name:           b.externalBuilder.Name,
 		ImplantBuildID: extConfig.Build.ID,
 		File: &commonpb.File{
 			Name: fileName,

--- a/server/core/externalbuilds.go
+++ b/server/core/externalbuilds.go
@@ -1,0 +1,56 @@
+package core
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2026  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import "sync"
+
+var (
+	// implantBuildID -> *ExternalBuildAssignment
+	externalBuildAssignments = &sync.Map{}
+)
+
+// ExternalBuildAssignment tracks which remote builder is allowed to access a build.
+type ExternalBuildAssignment struct {
+	BuildID      string
+	BuilderName  string
+	OperatorName string
+}
+
+// TrackExternalBuildAssignment stores the builder/operator assignment for a build.
+func TrackExternalBuildAssignment(buildID string, builderName string, operatorName string) {
+	externalBuildAssignments.Store(buildID, &ExternalBuildAssignment{
+		BuildID:      buildID,
+		BuilderName:  builderName,
+		OperatorName: operatorName,
+	})
+}
+
+// GetExternalBuildAssignment returns the assignment for a build, if present.
+func GetExternalBuildAssignment(buildID string) *ExternalBuildAssignment {
+	assignment, ok := externalBuildAssignments.Load(buildID)
+	if !ok {
+		return nil
+	}
+	return assignment.(*ExternalBuildAssignment)
+}
+
+// RemoveExternalBuildAssignment clears any assignment for a build.
+func RemoveExternalBuildAssignment(buildID string) {
+	externalBuildAssignments.Delete(buildID)
+}

--- a/server/core/externalbuilds_test.go
+++ b/server/core/externalbuilds_test.go
@@ -1,0 +1,27 @@
+package core
+
+import "testing"
+
+func TestTrackAndRemoveExternalBuildAssignment(t *testing.T) {
+	buildID := "build-test-id"
+	TrackExternalBuildAssignment(buildID, "builder-a", "operator-a")
+	t.Cleanup(func() {
+		RemoveExternalBuildAssignment(buildID)
+	})
+
+	assignment := GetExternalBuildAssignment(buildID)
+	if assignment == nil {
+		t.Fatalf("expected assignment for build %s", buildID)
+	}
+	if assignment.BuilderName != "builder-a" {
+		t.Fatalf("expected builder-a, got %s", assignment.BuilderName)
+	}
+	if assignment.OperatorName != "operator-a" {
+		t.Fatalf("expected operator-a, got %s", assignment.OperatorName)
+	}
+
+	RemoveExternalBuildAssignment(buildID)
+	if GetExternalBuildAssignment(buildID) != nil {
+		t.Fatalf("expected assignment removal for build %s", buildID)
+	}
+}

--- a/server/rpc/rpc-generate_external_authz_test.go
+++ b/server/rpc/rpc-generate_external_authz_test.go
@@ -1,0 +1,147 @@
+package rpc
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"testing"
+
+	"github.com/bishopfox/sliver/protobuf/clientpb"
+	"github.com/bishopfox/sliver/server/core"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+func TestAuthorizeBuilderForExternalBuildAllowsAssignedBuilder(t *testing.T) {
+	const (
+		buildID      = "build-authz-allow"
+		builderName  = "builder-authz-allow"
+		operatorName = "operator-authz-allow"
+	)
+	err := core.AddBuilder(&clientpb.Builder{Name: builderName, OperatorName: operatorName})
+	if err != nil {
+		t.Fatalf("add builder: %v", err)
+	}
+	t.Cleanup(func() {
+		core.RemoveBuilder(builderName)
+		core.RemoveExternalBuildAssignment(buildID)
+	})
+	core.TrackExternalBuildAssignment(buildID, builderName, operatorName)
+
+	rpc := &Server{}
+	err = rpc.authorizeBuilderForExternalBuild(contextWithCommonName(operatorName), builderName, buildID)
+	if err != nil {
+		t.Fatalf("authorizeBuilderForExternalBuild() unexpected error: %v", err)
+	}
+}
+
+func TestAuthorizeBuilderForExternalBuildRejectsForeignBuilder(t *testing.T) {
+	const (
+		buildID      = "build-authz-foreign"
+		ownerBuilder = "builder-owner"
+		otherBuilder = "builder-other"
+		operatorName = "operator-shared"
+	)
+	if err := core.AddBuilder(&clientpb.Builder{Name: ownerBuilder, OperatorName: operatorName}); err != nil {
+		t.Fatalf("add owner builder: %v", err)
+	}
+	if err := core.AddBuilder(&clientpb.Builder{Name: otherBuilder, OperatorName: operatorName}); err != nil {
+		t.Fatalf("add other builder: %v", err)
+	}
+	t.Cleanup(func() {
+		core.RemoveBuilder(ownerBuilder)
+		core.RemoveBuilder(otherBuilder)
+		core.RemoveExternalBuildAssignment(buildID)
+	})
+	core.TrackExternalBuildAssignment(buildID, ownerBuilder, operatorName)
+
+	rpc := &Server{}
+	err := rpc.authorizeBuilderForExternalBuild(contextWithCommonName(operatorName), otherBuilder, buildID)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestAuthorizeBuilderForExternalBuildRejectsWrongOperator(t *testing.T) {
+	const (
+		buildID          = "build-authz-wrong-op"
+		builderName      = "builder-authz-wrong-op"
+		ownerOperator    = "operator-owner"
+		attackerOperator = "operator-attacker"
+	)
+	err := core.AddBuilder(&clientpb.Builder{Name: builderName, OperatorName: ownerOperator})
+	if err != nil {
+		t.Fatalf("add builder: %v", err)
+	}
+	t.Cleanup(func() {
+		core.RemoveBuilder(builderName)
+		core.RemoveExternalBuildAssignment(buildID)
+	})
+	core.TrackExternalBuildAssignment(buildID, builderName, ownerOperator)
+
+	rpc := &Server{}
+	err = rpc.authorizeBuilderForExternalBuild(contextWithCommonName(attackerOperator), builderName, buildID)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestAuthorizeBuilderOperatorForExternalBuildRejectsForeignOperator(t *testing.T) {
+	const (
+		buildID       = "build-op-authz"
+		builderName   = "builder-op-authz"
+		ownerOperator = "operator-a"
+		otherOperator = "operator-b"
+	)
+	core.TrackExternalBuildAssignment(buildID, builderName, ownerOperator)
+	t.Cleanup(func() {
+		core.RemoveExternalBuildAssignment(buildID)
+	})
+
+	rpc := &Server{}
+	err := rpc.authorizeBuilderOperatorForExternalBuild(contextWithCommonName(otherOperator), buildID)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestSplitExternalBuildEventData(t *testing.T) {
+	builderName, buildID, err := splitExternalBuildEventData([]byte("builder:name:abc123"))
+	if err != nil {
+		t.Fatalf("splitExternalBuildEventData() unexpected error: %v", err)
+	}
+	if builderName != "builder:name" {
+		t.Fatalf("expected builder:name, got %s", builderName)
+	}
+	if buildID != "abc123" {
+		t.Fatalf("expected abc123, got %s", buildID)
+	}
+}
+
+func TestSplitExternalBuildProgressData(t *testing.T) {
+	buildID, details, err := splitExternalBuildProgressData([]byte("abc123:done"))
+	if err != nil {
+		t.Fatalf("splitExternalBuildProgressData() unexpected error: %v", err)
+	}
+	if buildID != "abc123" {
+		t.Fatalf("expected abc123, got %s", buildID)
+	}
+	if details != "done" {
+		t.Fatalf("expected done, got %s", details)
+	}
+}
+
+func contextWithCommonName(commonName string) context.Context {
+	cert := &x509.Certificate{
+		Subject: pkix.Name{CommonName: commonName},
+	}
+	tlsInfo := credentials.TLSInfo{
+		State: tls.ConnectionState{
+			VerifiedChains: [][]*x509.Certificate{{cert}},
+		},
+	}
+	return peer.NewContext(context.Background(), &peer.Peer{AuthInfo: tlsInfo})
+}


### PR DESCRIPTION
## Summary
- add server-side tracking for external build assignment (`buildID -> builder/operator`)
- enforce assignment checks in `GenerateExternalGetBuildConfig` and `GenerateExternalSaveBuild`
- enforce operator ownership checks in `BuilderTrigger` for ack/fail/complete events
- filter `ExternalBuildEvent` delivery server-side in `BuilderRegister` so builders only receive their own build events
- update builder client flow to identify itself on fetch/save RPCs
- add unit tests for assignment tracking and external-builder authz helpers/parsers

## Security impact
This hardens external builder behavior by introducing object-level checks for build jobs instead of relying only on method-level builder permissions.
