### PR TITLE
Fix: server panic on single-word lists and off-by-one in codename generation

### DIFF
--- a/server/codenames/codenames.go
+++ b/server/codenames/codenames.go
@@ -73,7 +73,7 @@ func getRandomWord(txtFilePath string) (string, error) {
 	if wordsLen == 0 {
 		return "", fmt.Errorf("no words found in %s", txtFilePath)
 	}
-	word := words[util.Intn(wordsLen-1)]
+	word := words[util.Intn(wordsLen)]
 	return strings.TrimSpace(word), nil
 }
 


### PR DESCRIPTION
### Description
This PR fixes two related bugs in `sliver/server/codenames/codenames.go`:

1. **Server Panic**: When a wordlist (`adjectives.txt` or `nouns.txt`) contains only one word, the server would panic because `util.Intn(wordsLen-1)` resulted in `util.Intn(0)`, which is invalid.
2. **Missing Words (Off-by-one)**: The use of `wordsLen-1` prevented the last word in any wordlist from ever being selected, causing unnecessary name collisions and limiting the variety of codenames.

### Changes
- Changed `util.Intn(wordsLen-1)` to `util.Intn(wordsLen)` to correctly handle the full range of the wordlist slices.

### Related Issues
- Fixes #2128
- Fixes #2134 