### PR TITLE
Fix for getsystem in beacon mode

### DIFF
--- a/client/command/privilege/commands.go
+++ b/client/command/privilege/commands.go
@@ -74,7 +74,7 @@ func Commands(con *console.SliverClient) []*cobra.Command {
 			GetSystemCmd(cmd, con, args)
 		},
 		GroupID:     consts.PrivilegesHelpGroup,
-		Annotations: flags.RestrictTargets(consts.WindowsCmdsFilter),
+		Annotations: flags.RestrictTargets(consts.WindowsCmdsFilter, consts.SessionCmdsFilter),
 	}
 	flags.Bind("", false, getSystemCmd, func(f *pflag.FlagSet) {
 		f.StringP("process", "p", "spoolsv.exe", "SYSTEM process to inject into")

--- a/client/command/privilege/getsystem.go
+++ b/client/command/privilege/getsystem.go
@@ -37,6 +37,10 @@ func GetSystemCmd(cmd *cobra.Command, con *console.SliverClient, args []string) 
 	if session == nil && beacon == nil {
 		return
 	}
+	if session == nil {
+		con.PrintErrorf("Command is only supported for sessions.\n")
+		return
+	}
 	targetOS := getOS(session, beacon)
 	if targetOS != "windows" {
 		con.PrintErrorf("Command only supported on Windows.\n")
@@ -45,6 +49,10 @@ func GetSystemCmd(cmd *cobra.Command, con *console.SliverClient, args []string) 
 
 	process, _ := cmd.Flags().GetString("process")
 	config := con.GetActiveSessionConfig()
+	if config == nil {
+		con.PrintErrorf("Failed to derive active session config.\n")
+		return
+	}
 
 	/* If the HTTP C2 Config name is not defined, then put in the default value
 	   This will have no effect on implants that do not use HTTP C2


### PR DESCRIPTION
Issue #2206 `getsystem` can run in beacon context, but it assumes a session config and dereferences it unconditionally.