### PR TITLE
fix(wininet): Fix handle leak in WinINet driver

### DIFF
--- a/implant/sliver/transports/httpclient/drivers/win/wininet/client_windows.go
+++ b/implant/sliver/transports/httpclient/drivers/win/wininet/client_windows.go
@@ -58,6 +58,7 @@ func (c *Client) Do(request *http.Request) (*http.Response, error) {
 	var buf []byte
 	var err error
 	var reqHandle uintptr
+	var connHandle uintptr
 	var resp *Response
 
 	var rawBody []byte
@@ -81,9 +82,17 @@ func (c *Client) Do(request *http.Request) (*http.Response, error) {
 		Body:    rawBody,
 	}
 
-	if reqHandle, err = buildRequest(c.handle, req); err != nil {
+	if connHandle, reqHandle, err = buildRequest(c.handle, req); err != nil {
+		if reqHandle != 0 {
+			InternetCloseHandle(reqHandle)
+		}
+		if connHandle != 0 {
+			InternetCloseHandle(connHandle)
+		}
 		return nil, err
 	}
+	defer InternetCloseHandle(reqHandle)
+	defer InternetCloseHandle(connHandle)
 
 	if c.Timeout > 0 {
 		buf = make([]byte, 4)
@@ -231,4 +240,12 @@ func (jar *Jar) SetCookies(u *url.URL, cookies []*Cookie) {
 // restrictions such as in RFC 6265 (which we do not).
 func (jar *Jar) Cookies(u *url.URL) []*Cookie {
 	return jar.cookies
+}
+
+// Close will close the client handle
+func (c *Client) Close() {
+	if c.handle != 0 {
+		InternetCloseHandle(c.handle)
+		c.handle = 0
+	}
 }

--- a/implant/sliver/transports/httpclient/drivers/win/wininet/utils_windows.go
+++ b/implant/sliver/transports/httpclient/drivers/win/wininet/utils_windows.go
@@ -17,7 +17,7 @@ func convertFail(str string, err error) error {
 	)
 }
 
-func buildRequest(sessionHndl uintptr, r *Request) (uintptr, error) {
+func buildRequest(sessionHndl uintptr, r *Request) (uintptr, uintptr, error) {
 	var connHndl uintptr
 	var err error
 	var flags uintptr
@@ -29,7 +29,7 @@ func buildRequest(sessionHndl uintptr, r *Request) (uintptr, error) {
 
 	// Parse URL
 	if uri, err = url.Parse(r.URL); err != nil {
-		return 0, fmt.Errorf("failed to parse url %s: %w", r.URL, err)
+		return 0, 0, fmt.Errorf("failed to parse url %s: %w", r.URL, err)
 	}
 
 	passwd, _ = uri.User.Password()
@@ -37,7 +37,7 @@ func buildRequest(sessionHndl uintptr, r *Request) (uintptr, error) {
 	if uri.Port() != "" {
 		if port, err = strconv.ParseInt(uri.Port(), 10, 64); err != nil {
 			err = fmt.Errorf("port %s invalid: %w", uri.Port(), err)
-			return 0, err
+			return 0, 0, err
 		}
 	}
 
@@ -58,7 +58,7 @@ func buildRequest(sessionHndl uintptr, r *Request) (uintptr, error) {
 		0,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("failed to create connection: %w", err)
+		return 0, 0, fmt.Errorf("failed to create connection: %w", err)
 	}
 
 	// Send query string too
@@ -82,10 +82,10 @@ func buildRequest(sessionHndl uintptr, r *Request) (uintptr, error) {
 		0,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("failed to open request: %w", err)
+		return connHndl, 0, fmt.Errorf("failed to open request: %w", err)
 	}
 
-	return reqHndl, nil
+	return connHndl, reqHndl, nil
 }
 
 var cookies []*Cookie

--- a/implant/sliver/transports/httpclient/drivers/win/wininet/wininet_windows.go
+++ b/implant/sliver/transports/httpclient/drivers/win/wininet/wininet_windows.go
@@ -213,6 +213,20 @@ func HTTPSendRequestW(
 	return nil
 }
 
+// InternetCloseHandle is from wininet.h
+func InternetCloseHandle(hndl uintptr) error {
+	var err error
+	var proc string = "InternetCloseHandle"
+	var success uintptr
+
+	success, _, err = wininet.NewProc(proc).Call(hndl)
+	if success == 0 {
+		return fmt.Errorf("%s: %w", proc, err)
+	}
+
+	return nil
+}
+
 // InternetConnectW is from wininet.h
 func InternetConnectW(
 	sessionHndl uintptr,
@@ -437,7 +451,7 @@ func InternetErrorDlg(
 	)
 	// we expect 12032 if user hits okay, otherwise we return the response code as an error
 	if uint32(success) != ERROR_INTERNET_FORCE_RETRY {
-		return success, fmt.Errorf("%s: %s", proc, success)
+		return success, fmt.Errorf("%s: %v", proc, success)
 	}
 
 	*lppvData = buf


### PR DESCRIPTION
Fixes #1892

The WinINet driver was not calling InternetCloseHandle on connection and request handles after each request, causing a handle leak.