### PR TITLE
chore(doc): replace red-team with bf-red-team in CODEOWNERS (CLD-10806)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BishopFox/red-team
+* @BishopFox/bf-red-team


### PR DESCRIPTION
## Summary
* Replace legacy `@BishopFox/red-team` with `@BishopFox/bf-red-team` in CODEOWNERS
* Part of CODEOWNERS Standardization epic CLD-10782
* Scan results: CLD-10787

## Jira
CLD-10806