### PR TITLE
fix(implant): run LocalTask shellcode in forked child (#2237)

### DIFF
--- a/implant/sliver/taskrunner/task_darwin.go
+++ b/implant/sliver/taskrunner/task_darwin.go
@@ -34,21 +34,60 @@ import (
 	"unsafe"
 )
 
-// LocalTask - Run a shellcode in the current process
-// Will hang the process until shellcode completion
-// TODO: actually test this code
-// Adapted/stolen from: https://github.com/lesnuages/hershell/blob/master/shell/shell_default.go#L48
+//go:linkname localTaskBeforeFork syscall.runtime_BeforeFork
+func localTaskBeforeFork()
+
+//go:linkname localTaskAfterFork syscall.runtime_AfterFork
+func localTaskAfterFork()
+
+//go:linkname localTaskAfterForkInChild syscall.runtime_AfterForkInChild
+func localTaskAfterForkInChild()
+
+// LocalTask - Run shellcode in a forked child; blocks until the child exits.
+// Forking isolates the beacon from payloads that exit/execve (issue #2237).
 func LocalTask(data []byte, rwxPages bool) error {
 	dataAddr := uintptr(unsafe.Pointer(&data[0]))
 	page := getPage(dataAddr)
-	syscall.Mprotect(page, syscall.PROT_READ|syscall.PROT_EXEC)
+	pageAddr := uintptr(unsafe.Pointer(&page[0]))
+	pageLen := uintptr(len(page))
 	dataPtr := unsafe.Pointer(&data)
+	// funcPtr trick from hershell (https://github.com/lesnuages/hershell)
 	funcPtr := *(*func())(unsafe.Pointer(&dataPtr))
+
 	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	go func(fPtr func()) {
-		fPtr()
-	}(funcPtr)
+	localTaskBeforeFork()
+	// Raw SYS_FORK on Darwin: r0 holds child's pid in BOTH processes; r1==1
+	// flags the child (libSystem's fork() wrapper hides this).
+	r0, isChild, errno := syscall.RawSyscall(syscall.SYS_FORK, 0, 0, 0)
+	if errno != 0 {
+		localTaskAfterFork()
+		runtime.UnlockOSThread()
+		return errno
+	}
+	if isChild == 1 {
+		localTaskAfterForkInChild()
+		for fd := uintptr(3); fd < 1024; fd++ {
+			syscall.RawSyscall(syscall.SYS_CLOSE, fd, 0, 0)
+		}
+		syscall.RawSyscall(syscall.SYS_MPROTECT, pageAddr, pageLen, uintptr(syscall.PROT_READ|syscall.PROT_EXEC))
+		funcPtr()
+		for {
+			syscall.RawSyscall(syscall.SYS_EXIT, 0, 0, 0)
+		}
+	}
+	localTaskAfterFork()
+	var ws syscall.WaitStatus
+	_, err := syscall.Wait4(int(r0), &ws, 0, nil)
+	runtime.UnlockOSThread()
+	if err != nil {
+		return err
+	}
+	if ws.Signaled() {
+		return fmt.Errorf("shellcode child killed by signal %v", ws.Signal())
+	}
+	if ws.ExitStatus() != 0 {
+		return fmt.Errorf("shellcode child exited %d", ws.ExitStatus())
+	}
 	return nil
 }
 

--- a/implant/sliver/taskrunner/task_darwin_test.go
+++ b/implant/sliver/taskrunner/task_darwin_test.go
@@ -1,0 +1,127 @@
+//go:build darwin
+
+package taskrunner
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2019  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+const localTaskHelperEnv = "SLIVER_LOCALTASK_HELPER"
+const localTaskSentinel = "PARENT_ALIVE_AFTER_LOCALTASK"
+
+// darwin/amd64 mov eax,0x2000001 ; xor edi,edi ; syscall  — exit(0)
+var exitShellcodeDarwinAmd64 = []byte{0xb8, 0x01, 0x00, 0x00, 0x02, 0x31, 0xff, 0x0f, 0x05}
+
+// darwin/amd64 mov eax,0x2000001 ; mov edi,42 ; syscall  — exit(42)
+var exit42ShellcodeDarwinAmd64 = []byte{0xb8, 0x01, 0x00, 0x00, 0x02, 0xbf, 0x2a, 0x00, 0x00, 0x00, 0x0f, 0x05}
+
+// darwin/arm64 movz x0,#0 ; movz x16,#1 ; svc #0x80  — exit(0)
+// Stored as [N]uint32 so the backing storage is 4-byte aligned (ARM64 SIGBUS
+// otherwise).
+var exitShellcodeDarwinArm64Words = [3]uint32{0xd2800000, 0xd2800030, 0xd4001001}
+
+// darwin/arm64 movz x0,#42 ; movz x16,#1 ; svc #0x80  — exit(42)
+var exit42ShellcodeDarwinArm64Words = [3]uint32{0xd2800540, 0xd2800030, 0xd4001001}
+
+func asBytes[T any](words *T) []byte {
+	return unsafe.Slice((*byte)(unsafe.Pointer(words)), unsafe.Sizeof(*words))
+}
+
+func exitShellcode() []byte {
+	switch runtime.GOARCH {
+	case "amd64":
+		return exitShellcodeDarwinAmd64
+	case "arm64":
+		return asBytes(&exitShellcodeDarwinArm64Words)
+	}
+	return nil
+}
+
+func exit42Shellcode() []byte {
+	switch runtime.GOARCH {
+	case "amd64":
+		return exit42ShellcodeDarwinAmd64
+	case "arm64":
+		return asBytes(&exit42ShellcodeDarwinArm64Words)
+	}
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	switch os.Getenv(localTaskHelperEnv) {
+	case "exit0":
+		_ = LocalTask(exitShellcode(), false)
+		time.Sleep(500 * time.Millisecond)
+		fmt.Println(localTaskSentinel)
+		os.Exit(0)
+	case "exit42":
+		err := LocalTask(exit42Shellcode(), false)
+		if err != nil {
+			fmt.Printf("LOCALTASK_ERR=%s\n", err.Error())
+		} else {
+			fmt.Println("LOCALTASK_ERR=<nil>")
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func runHelper(t *testing.T, mode string) []byte {
+	t.Helper()
+	if exitShellcode() == nil {
+		t.Skipf("no exit shellcode for GOARCH=%s", runtime.GOARCH)
+	}
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = append(os.Environ(), localTaskHelperEnv+"="+mode)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helper subprocess (%s) exited abnormally: %v\noutput: %s", mode, err, out)
+	}
+	return out
+}
+
+func TestLocalTask_ParentSurvives(t *testing.T) {
+	out := runHelper(t, "exit0")
+	if !bytes.Contains(out, []byte(localTaskSentinel)) {
+		t.Fatalf("expected sentinel %q in helper output:\n%s", localTaskSentinel, out)
+	}
+}
+
+// Accepts signal-kill as well as clean non-zero exit: macOS Apple Silicon
+// W^X faults mprotected-page execution with SIGBUS regardless of the
+// shellcode bytes, which still exercises LocalTask's error path.
+func TestLocalTask_ReportsChildFailure(t *testing.T) {
+	out := runHelper(t, "exit42")
+	if bytes.Contains(out, []byte("LOCALTASK_ERR=shellcode child exited 42")) {
+		return
+	}
+	if bytes.Contains(out, []byte("LOCALTASK_ERR=shellcode child killed by signal")) {
+		return
+	}
+	t.Fatalf("expected LOCALTASK_ERR for exit-42 or signal kill:\n%s", out)
+}

--- a/implant/sliver/taskrunner/task_linux.go
+++ b/implant/sliver/taskrunner/task_linux.go
@@ -34,19 +34,59 @@ import (
 	//{{end}}
 )
 
-// LocalTask - Run a shellcode in the current process
-// Will hang the process until shellcode completion
+//go:linkname localTaskBeforeFork syscall.runtime_BeforeFork
+func localTaskBeforeFork()
+
+//go:linkname localTaskAfterFork syscall.runtime_AfterFork
+func localTaskAfterFork()
+
+//go:linkname localTaskAfterForkInChild syscall.runtime_AfterForkInChild
+func localTaskAfterForkInChild()
+
+// LocalTask - Run shellcode in a forked child; blocks until the child exits.
+// Forking isolates the beacon from payloads that exit/execve (issue #2237).
 func LocalTask(data []byte, rwxPages bool) error {
 	dataAddr := uintptr(unsafe.Pointer(&data[0]))
 	page := getPage(dataAddr)
-	syscall.Mprotect(page, syscall.PROT_READ|syscall.PROT_EXEC)
+	pageAddr := uintptr(unsafe.Pointer(&page[0]))
+	pageLen := uintptr(len(page))
 	dataPtr := unsafe.Pointer(&data)
+	// funcPtr trick from hershell (https://github.com/lesnuages/hershell)
 	funcPtr := *(*func())(unsafe.Pointer(&dataPtr))
+
 	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	go func(fPtr func()) {
-		fPtr()
-	}(funcPtr)
+	localTaskBeforeFork()
+	// SYS_CLONE(SIGCHLD) = fork(). linux/arm64 has no SYS_FORK.
+	pid, _, errno := syscall.RawSyscall6(syscall.SYS_CLONE, uintptr(syscall.SIGCHLD), 0, 0, 0, 0, 0)
+	if errno != 0 {
+		localTaskAfterFork()
+		runtime.UnlockOSThread()
+		return errno
+	}
+	if pid == 0 {
+		localTaskAfterForkInChild()
+		for fd := uintptr(3); fd < 1024; fd++ {
+			syscall.RawSyscall(syscall.SYS_CLOSE, fd, 0, 0)
+		}
+		syscall.RawSyscall(syscall.SYS_MPROTECT, pageAddr, pageLen, uintptr(syscall.PROT_READ|syscall.PROT_EXEC))
+		funcPtr()
+		for {
+			syscall.RawSyscall(syscall.SYS_EXIT_GROUP, 0, 0, 0)
+		}
+	}
+	localTaskAfterFork()
+	var ws syscall.WaitStatus
+	_, err := syscall.Wait4(int(pid), &ws, 0, nil)
+	runtime.UnlockOSThread()
+	if err != nil {
+		return err
+	}
+	if ws.Signaled() {
+		return fmt.Errorf("shellcode child killed by signal %v", ws.Signal())
+	}
+	if ws.ExitStatus() != 0 {
+		return fmt.Errorf("shellcode child exited %d", ws.ExitStatus())
+	}
 	return nil
 }
 

--- a/implant/sliver/taskrunner/task_linux_test.go
+++ b/implant/sliver/taskrunner/task_linux_test.go
@@ -1,0 +1,87 @@
+//go:build linux
+
+package taskrunner
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2019  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+)
+
+const localTaskHelperEnv = "SLIVER_LOCALTASK_HELPER"
+const localTaskSentinel = "PARENT_ALIVE_AFTER_LOCALTASK"
+
+// linux/amd64: xor eax,eax ; xor edi,edi ; mov al,0x3c ; syscall  — exit(0)
+var exitShellcodeAmd64 = []byte{0x31, 0xc0, 0x31, 0xff, 0xb0, 0x3c, 0x0f, 0x05}
+
+// linux/amd64: xor eax,eax ; mov al,0x3c ; mov edi,42 ; syscall  — exit(42)
+var exit42ShellcodeAmd64 = []byte{0x31, 0xc0, 0xb0, 0x3c, 0xbf, 0x2a, 0x00, 0x00, 0x00, 0x0f, 0x05}
+
+func TestMain(m *testing.M) {
+	switch os.Getenv(localTaskHelperEnv) {
+	case "exit0":
+		_ = LocalTask(exitShellcodeAmd64, false)
+		time.Sleep(500 * time.Millisecond)
+		fmt.Println(localTaskSentinel)
+		os.Exit(0)
+	case "exit42":
+		err := LocalTask(exit42ShellcodeAmd64, false)
+		if err != nil {
+			fmt.Printf("LOCALTASK_ERR=%s\n", err.Error())
+		} else {
+			fmt.Println("LOCALTASK_ERR=<nil>")
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func runHelper(t *testing.T, mode string) []byte {
+	t.Helper()
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("exit shellcode is amd64-specific; GOARCH=%s", runtime.GOARCH)
+	}
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = append(os.Environ(), localTaskHelperEnv+"="+mode)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helper subprocess (%s) exited abnormally: %v\noutput: %s", mode, err, out)
+	}
+	return out
+}
+
+func TestLocalTask_ParentSurvives(t *testing.T) {
+	out := runHelper(t, "exit0")
+	if !bytes.Contains(out, []byte(localTaskSentinel)) {
+		t.Fatalf("expected sentinel %q in helper output:\n%s", localTaskSentinel, out)
+	}
+}
+
+func TestLocalTask_ReportsChildFailure(t *testing.T) {
+	out := runHelper(t, "exit42")
+	if !bytes.Contains(out, []byte("LOCALTASK_ERR=shellcode child exited 42")) {
+		t.Fatalf("expected exit-42 error in helper output:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #2237. `LocalTask` ran shellcode in a goroutine, so payloads that exit/execve killed the beacon. Fork a child instead and let the parent wait on it.

- linux: `SYS_CLONE(SIGCHLD)` since arm64 has no `SYS_FORK`
- darwin: `SYS_FORK` with an `r1==1` ischild check (libSystem's fork wrapper normally hides this)
- wrapped with `runtime_BeforeFork` / `AfterFork` / `AfterForkInChild` via `//go:linkname` so `stackguard0` gets poisoned and inherited signal handlers get cleared
- child mprotects its own page, closes inherited fds 3..1024, falls back to `SYS_EXIT_GROUP` (linux) / `SYS_EXIT` (darwin)

## Verification
- `go test ./implant/sliver/taskrunner/...` on linux/amd64 (docker) and darwin/arm64 (m3 pro mac). `-race` and `-count=20` clean on both
- cross builds green for linux amd64/arm64, darwin amd64/arm64, windows amd64
- reproduced the pre-patch crash, passes after