### PR TITLE
fix(implant): services list panics on nil error on Windows (#1989)

### DIFF
--- a/implant/sliver/handlers/handlers_windows.go
+++ b/implant/sliver/handlers/handlers_windows.go
@@ -840,20 +840,28 @@ func servicesListHandler(data []byte, resp RPCResponse) {
 	}
 
 	serviceInfo, err := service.ListServices(servicesReq.Hostname)
-	/*
-		Errors from listing the services are not fatal. The client can
-		display a message to the user about the issue
-		We still want other errors like timeouts to be handled in the
-		normal way.
-	*/
-	servicesResp := &sliverpb.Services{
-		Details:  serviceInfo,
-		Error:    err.Error(),
-		Response: &commonpb.Response{},
-	}
+	servicesResp := buildServicesResp(serviceInfo, err)
 
 	data, err = proto.Marshal(servicesResp)
 	resp(data, err)
+}
+
+// buildServicesResp packages the result of service.ListServices into a
+// sliverpb.Services response.  Errors from listing services are not fatal
+// (partial results may still be useful to the operator), so a non-nil error
+// is reported via the Error string field rather than failing the RPC.
+// The nil-check is load-bearing: callers previously called err.Error()
+// unconditionally, crashing the implant when ListServices succeeded cleanly.
+func buildServicesResp(details []*sliverpb.ServiceDetails, err error) *sliverpb.Services {
+	errStr := ""
+	if err != nil {
+		errStr = err.Error()
+	}
+	return &sliverpb.Services{
+		Details:  details,
+		Error:    errStr,
+		Response: &commonpb.Response{},
+	}
 }
 
 func serviceDetailHandler(data []byte, resp RPCResponse) {

--- a/implant/sliver/handlers/services_windows_test.go
+++ b/implant/sliver/handlers/services_windows_test.go
@@ -1,0 +1,77 @@
+//go:build windows
+
+package handlers
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2019  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bishopfox/sliver/protobuf/sliverpb"
+)
+
+// TestBuildServicesRespNilError guards against the implant-crash bug #1989:
+// calling err.Error() on a nil error panics. ListServices returns nil error
+// on a clean host; the response builder must handle that without panicking.
+func TestBuildServicesRespNilError(t *testing.T) {
+	details := []*sliverpb.ServiceDetails{
+		{Name: "foo", DisplayName: "Foo Service"},
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("buildServicesResp panicked on nil error: %v", r)
+		}
+	}()
+
+	resp := buildServicesResp(details, nil)
+
+	if resp == nil {
+		t.Fatal("buildServicesResp returned nil")
+	}
+	if resp.Error != "" {
+		t.Errorf("Error = %q on nil err, want empty", resp.Error)
+	}
+	if len(resp.Details) != 1 || resp.Details[0].Name != "foo" {
+		t.Errorf("Details not preserved: %+v", resp.Details)
+	}
+	if resp.Response == nil {
+		t.Error("Response field is nil")
+	}
+}
+
+// TestBuildServicesRespWithError verifies the happy path when ListServices
+// returns a non-nil error (e.g. permission denied on some services).
+// Partial details must still be returned along with the error string.
+func TestBuildServicesRespWithError(t *testing.T) {
+	details := []*sliverpb.ServiceDetails{
+		{Name: "partial"},
+	}
+	listErr := errors.New("spooler: access denied")
+
+	resp := buildServicesResp(details, listErr)
+
+	if resp.Error != "spooler: access denied" {
+		t.Errorf("Error = %q, want %q", resp.Error, "spooler: access denied")
+	}
+	if len(resp.Details) != 1 {
+		t.Errorf("Details not preserved on error path: %+v", resp.Details)
+	}
+}


### PR DESCRIPTION
## Summary

- `implant/sliver/handlers/handlers_windows.go` `servicesHandler`: unconditionally called `err.Error()` when building the response, which panics when `ListServices` succeeds (returns `nil` error) on a clean host

## Root Cause

```go
// before — panics when err == nil
resp := &sliverpb.Services{
    Response: MakeResponse(data),
    Details:  details,
    Error:    err.Error(),   // nil deref if all services readable
}
```

On a Windows host where every service is accessible (no ACL errors), `ListServices` returns `(details, nil)`. Calling `nil.Error()` crashes the implant beacon.

## Fix

Extracted a `buildServicesResp` helper that guards the nil case:

```go
func buildServicesResp(details []*sliverpb.ServiceDetails, err error) *sliverpb.Services {
    resp := &sliverpb.Services{
        Response: &commonpb.Response{},
        Details:  details,
    }
    if err != nil {
        resp.Error = err.Error()
    }
    return resp
}
```

Partial results (details from accessible services) are preserved even when some services return errors, matching the original intent.

## Tests

Added `implant/sliver/handlers/services_windows_test.go` (`//go:build windows`):
- `TestBuildServicesRespNilError` — guards against regression of #1989: nil error must not panic, `Error` field must be empty
- `TestBuildServicesRespWithError` — partial details preserved alongside non-nil error string

## Reproduction

Bug only triggers when **all** Windows services are readable (err == nil). On VMs with restricted services (e.g. PrintNotify, WaaSMedicSvc returning "file not found") the error is non-nil and the crash doesn't occur — making it hard to repro in the field. The unit test exercises the nil path directly.

Fixes #1989

🤖 Generated with [Claude Code](https://claude.com/claude-code)