### PR TITLE
fix(implant): services list panics on nil error on Windows (#1989)

### DIFF
--- a/implant/sliver/handlers/handlers_windows.go
+++ b/implant/sliver/handlers/handlers_windows.go
@@ -840,20 +840,28 @@ func servicesListHandler(data []byte, resp RPCResponse) {
 	}
 
 	serviceInfo, err := service.ListServices(servicesReq.Hostname)
-	/*
-		Errors from listing the services are not fatal. The client can
-		display a message to the user about the issue
-		We still want other errors like timeouts to be handled in the
-		normal way.
-	*/
-	servicesResp := &sliverpb.Services{
-		Details:  serviceInfo,
-		Error:    err.Error(),
-		Response: &commonpb.Response{},
-	}
+	servicesResp := buildServicesResp(serviceInfo, err)
 
 	data, err = proto.Marshal(servicesResp)
 	resp(data, err)
+}
+
+// buildServicesResp packages the result of service.ListServices into a
+// sliverpb.Services response.  Errors from listing services are not fatal
+// (partial results may still be useful to the operator), so a non-nil error
+// is reported via the Error string field rather than failing the RPC.
+// The nil-check is load-bearing: callers previously called err.Error()
+// unconditionally, crashing the implant when ListServices succeeded cleanly.
+func buildServicesResp(details []*sliverpb.ServiceDetails, err error) *sliverpb.Services {
+	errStr := ""
+	if err != nil {
+		errStr = err.Error()
+	}
+	return &sliverpb.Services{
+		Details:  details,
+		Error:    errStr,
+		Response: &commonpb.Response{},
+	}
 }
 
 func serviceDetailHandler(data []byte, resp RPCResponse) {


### PR DESCRIPTION
## Bug

Running `services` against a Windows beacon can kill the beacon with a nil pointer deref. The implant panics and the session dies.

## Cause

`servicesListHandler` in `implant/sliver/handlers/handlers_windows.go` calls `err.Error()` with no nil check:

```go
serviceInfo, err := service.ListServices(servicesReq.Hostname)
servicesResp := &sliverpb.Services{
    Details:  serviceInfo,
    Error:    err.Error(),   // nil deref when err == nil
    Response: &commonpb.Response{},
}
```

`ListServices` returns `(list, nil)` when every service reads without error. Calling `.Error()` on nil → `0xc0000005`, process exits.

## Fix

Add the nil guard. One helper, one check:

```go
func buildServicesResp(details []*sliverpb.ServiceDetails, err error) *sliverpb.Services {
    errStr := ""
    if err != nil {
        errStr = err.Error()
    }
    return &sliverpb.Services{
        Details:  details,
        Error:    errStr,
        Response: &commonpb.Response{},
    }
}
```

## Why it doesn't repro easily

A beacon running as a normal user hits access-denied on a bunch of services during `openService` / `Config()` / `Query()`. Those failures get collected into `serviceErrors` and `ListServices` returns a non-nil error — so the buggy `err.Error()` call is safe. That's why most operators never see this crash.

The bug only fires when every service reads cleanly (no errors at all). On modern Win10/11 that's hard to hit even as SYSTEM because services like `WaaSMedicSvc` are PPL-protected and will fail for anyone. But it's not impossible — older Windows versions, stripped-down VMs, or just the right host config hits it and the beacon dies.

## Reproducing it deliberately

To force the code path, add one line to `ListServices` (`implant/sliver/service/service_windows.go`, near line 195):

```go
operationError = nil // REPRO: force nil error to exercise the bug path
```

Then build sliver-server, generate a Windows beacon, run it on any Win VM, and call `services` — the unpatched beacon panics, the patched beacon returns results normally.

Fixes #1989