### PR TITLE
fix(console): backspace deletes char not word in emacs keymap (#2209)

### DIFF
--- a/vendor/github.com/reeflective/readline/internal/keymap/emacs.go
+++ b/vendor/github.com/reeflective/readline/internal/keymap/emacs.go
@@ -7,7 +7,6 @@ var unescape = inputrc.Unescape
 // emacsKeys are the default keymaps in Emacs mode.
 var emacsKeys = map[string]inputrc.Bind{
 	unescape(`\C-D`):     {Action: "end-of-file"},
-	unescape(`\C-h`):     {Action: "backward-kill-word"},
 	unescape(`\C-N`):     {Action: "down-line-or-history"},
 	unescape(`\C-P`):     {Action: "up-line-or-history"},
 	unescape(`\C-x\C-b`): {Action: "vi-match"},


### PR DESCRIPTION
## Bug

In the sliver console, pressing Backspace deletes the whole previous word. Type `beaconss`, hit Backspace, everything disappears instead of just the last `s`. Reported on Kali, but it hits any Linux terminal that sends `\C-h` (0x08) on Backspace.

## Cause

`vendor/github.com/reeflective/readline/internal/keymap/emacs.go` has a table `emacsKeys` with a bad entry:

```go
unescape(`\C-h`): {Action: "backward-kill-word"},
```

That line shadows the correct `DefaultBinds()` entry (`\C-h` → `backward-delete-char`). GNU readline convention: `\C-h` is single-char delete, `\M-\C-h` is word-kill. The override got it backwards.

## Fix

Delete the one bad line. `DefaultBinds()` already has the right binding, and `\M-\C-h` (Meta-Backspace) still does word-kill.

```diff
 var emacsKeys = map[string]inputrc.Bind{
 	unescape(`\C-D`):     {Action: "end-of-file"},
-	unescape(`\C-h`):     {Action: "backward-kill-word"},
 	unescape(`\C-N`):     {Action: "down-line-or-history"},
```

## Tested

Built on a Kali arm64 VM (6.18). Master deletes the whole word; patched binary deletes one char. Meta-Backspace still kills the word like it should.

Change lives in `vendor/` per the "vendor changes in a distinct commit" rule.

Fixes #2209