### PR TITLE
core/events: don't panic on send to closed subscriber

### DIFF
--- a/server/core/events.go
+++ b/server/core/events.go
@@ -69,9 +69,21 @@ func (broker *eventBroker) Start() {
 			}
 		case event := <-broker.publish:
 			for sub := range subscribers {
-				sub <- event
+				safeBrokerSend(sub, event)
 			}
 		}
+	}
+}
+
+// safeBrokerSend sends an event to a subscriber, recovering from a closed-channel
+// panic if the subscriber dropped its end without unsubscribing first (#2252).
+func safeBrokerSend(sub chan Event, event Event) {
+	defer func() { _ = recover() }()
+	select {
+	case sub <- event:
+	default:
+		// Subscriber's buffer is full or it's gone; drop the event rather
+		// than block the broker.
 	}
 }
 


### PR DESCRIPTION
Closes #2252. Subscribers that drop their channel without calling `Unsubscribe` (e.g., sliver-py disconnect) make the broker panic with `send on closed channel`. Recover and use a non-blocking send so a single misbehaving subscriber can't take down the server.