### PR TITLE
Duplicate HTML Fix

### DIFF
--- a/server/c2/http.go
+++ b/server/c2/http.go
@@ -776,6 +776,8 @@ func (s *SliverHTTPC2) stagerHandler(resp http.ResponseWriter, req *http.Request
 	nonces, err := getNoncesFromURL(req.URL, 0)
 	if err != nil {
 		s.defaultHandler(resp, req)
+		// Added return statement to prevent duplicate HTML when serving websites
+		return
 	}
 
 	for _, nonce := range nonces {


### PR DESCRIPTION
stageHandler function was missing a return statement at line 780, causing the server to serve duplicate HTML blocks when using the websites feature, causing things to render twice, and breaking embedded scripts like WAS stagers.
