### PR TITLE
feat(mcp): add execute tool for remote command execution

### DIFF
--- a/client/mcp/execute.go
+++ b/client/mcp/execute.go
@@ -1,0 +1,106 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+	"github.com/bishopfox/sliver/protobuf/sliverpb"
+)
+
+const (
+	executeToolName = "execute"
+)
+
+// executeArgs defines the parameters for command execution
+type executeArgs struct {
+	SessionID      string   `json:"session_id,omitempty"`
+	BeaconID       string   `json:"beacon_id,omitempty"`
+	Path           string   `json:"path"`
+	Args           []string `json:"args,omitempty"`
+	Output         bool     `json:"output,omitempty"`
+	Wait           bool     `json:"wait,omitempty"`
+	TimeoutSeconds int64    `json:"timeout_seconds,omitempty"`
+}
+
+// executeResult defines the execution result
+type executeResult struct {
+	Stdout string `json:"stdout,omitempty"`
+	Stderr string `json:"stderr,omitempty"`
+	Status uint32 `json:"status"`
+	Pid    uint32 `json:"pid,omitempty"`
+}
+
+func (s *SliverMCPServer) executeHandler(ctx context.Context, request mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	var args executeArgs
+	if err := request.BindArguments(&args); err != nil {
+		return mcpapi.NewToolResultError(fmt.Sprintf("invalid arguments: %v", err)), nil
+	}
+
+	if args.Path == "" {
+		return mcpapi.NewToolResultError("path is required"), nil
+	}
+
+	// Default to capturing output
+	if !args.Output {
+		args.Output = true
+	}
+
+	return s.handleExecute(ctx, args)
+}
+
+func (s *SliverMCPServer) handleExecute(ctx context.Context, args executeArgs) (*mcpapi.CallToolResult, error) {
+	if s.Rpc == nil {
+		return mcpapi.NewToolResultError("rpc client not configured"), nil
+	}
+
+	s.logToolCall(executeToolName, args.SessionID, args.BeaconID, fmt.Sprintf("path=%q args=%v", args.Path, args.Args))
+
+	args.TimeoutSeconds = applyDefaultTimeout(args.Wait, args.TimeoutSeconds)
+	ctx, cancel := withTimeout(ctx, args.TimeoutSeconds)
+	if cancel != nil {
+		defer cancel()
+	}
+
+	req, isBeacon, err := buildRequest(args.SessionID, args.BeaconID, args.TimeoutSeconds)
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+
+	exec, err := s.Rpc.Execute(ctx, &sliverpb.ExecuteReq{
+		Request: req,
+		Path:    args.Path,
+		Args:    args.Args,
+		Output:  args.Output,
+	})
+	if err != nil {
+		return mcpapi.NewToolResultErrorFromErr("failed to execute command", err), nil
+	}
+
+	if exec.Response != nil && exec.Response.Err != "" {
+		return mcpapi.NewToolResultError(exec.Response.Err), nil
+	}
+
+	if isBeacon && exec.Response != nil && exec.Response.Async {
+		if !args.Wait {
+			return newAsyncResult("execute", exec.Response.TaskID, exec.Response.BeaconID), nil
+		}
+		resolved := &sliverpb.Execute{}
+		if err := s.waitForBeaconTaskResponse(ctx, exec.Response.TaskID, resolved); err != nil {
+			return mcpapi.NewToolResultErrorFromErr("failed to await execute task", err), nil
+		}
+		exec = resolved
+		if exec.Response != nil && exec.Response.Err != "" {
+			return mcpapi.NewToolResultError(exec.Response.Err), nil
+		}
+	}
+
+	result := executeResult{
+		Stdout: string(exec.Stdout),
+		Stderr: string(exec.Stderr),
+		Status: exec.Status,
+		Pid:    exec.Pid,
+	}
+
+	return mcpapi.NewToolResultStructuredOnly(result), nil
+}

--- a/client/mcp/server.go
+++ b/client/mcp/server.go
@@ -152,6 +152,15 @@ func newServer(cfg Config, rpc rpcpb.SliverRPCClient, logger *log.Logger) *Slive
 		mcpapi.WithReadOnlyHintAnnotation(false),
 		mcpapi.WithDestructiveHintAnnotation(true),
 	)
+	// Execute tool - run commands on remote target
+	executeTool := mcpapi.NewTool(
+		executeToolName,
+		mcpapi.WithDescription("Execute a command on a remote session or beacon. Returns stdout, stderr, and exit status."),
+		mcpapi.WithInputSchema[executeArgs](),
+		mcpapi.WithReadOnlyHintAnnotation(false),
+		mcpapi.WithDestructiveHintAnnotation(true),
+	)
+
 	srv := &SliverMCPServer{
 		Rpc:    rpc,
 		server: base,
@@ -168,6 +177,7 @@ func newServer(cfg Config, rpc rpcpb.SliverRPCClient, logger *log.Logger) *Slive
 	srv.server.AddTool(mkdirTool, srv.mkdirHandler)
 	srv.server.AddTool(chmodTool, srv.chmodHandler)
 	srv.server.AddTool(chownTool, srv.chownHandler)
+	srv.server.AddTool(executeTool, srv.executeHandler)
 	return srv
 }
 


### PR DESCRIPTION
## Summary

Add an `execute` MCP tool that allows running commands on remote sessions and beacons via the MCP interface.

## Features

- Execute arbitrary commands on session or beacon targets
- Full async beacon task handling with optional `wait` parameter
- Returns structured response with stdout, stderr, exit status, and PID
- Output capture enabled by default
- Follows existing MCP tool conventions (`buildRequest`, `logToolCall`, `newAsyncResult`, etc.)

## Changes

- `client/mcp/execute.go` — new file implementing the execute tool handler
- `client/mcp/server.go` — register the execute tool in `newServer()`

## Usage

The tool accepts:
| Parameter | Description |
|-----------|-------------|
| `session_id` | Target session ID (mutually exclusive with beacon_id) |
| `beacon_id` | Target beacon ID (mutually exclusive with session_id) |
| `path` | Command/binary path to execute (required) |
| `args` | Command arguments |
| `output` | Capture output (defaults to true) |
| `wait` | Wait for beacon task completion |
| `timeout_seconds` | Execution timeout |
