### PR TITLE
fix(dns): step back on varint-boundary overshoot in SplitBuffer

### DIFF
--- a/implant/sliver/transports/dnsclient/dnsclient.go
+++ b/implant/sliver/transports/dnsclient/dnsclient.go
@@ -751,6 +751,20 @@ func (s *SliverDNSClient) SplitBuffer(msg *dnspb.DNSMessage, encoder encoders.En
 			// {{end}}
 		}
 		lastLen = len(msg.Data) // Save the amount of data that fit for the next loop
+
+		// Step back if a protobuf varint boundary caused encoded to overshoot.
+		// Adding 1 byte across a varint boundary (e.g. Data length 127→128) grows
+		// the proto by 2 bytes, which can jump base32 by +3 or +4, exceeding the
+		// subdataSpace-1 guard above.
+		for s.subdataSpace < len(encoded) && stop > start {
+			stop--
+			msg.Data = data[start:stop]
+			pbMsg, _ := proto.Marshal(msg)
+			encodedValue, _ := encoder.Encode(pbMsg)
+			encoded = string(encodedValue)
+		}
+		lastLen = len(msg.Data)
+
 		// {{if .Config.Debug}}
 		encodedSubdata = append(encodedSubdata, encoded)
 		// {{end}}

--- a/implant/sliver/transports/dnsclient/dnsclient_test.go
+++ b/implant/sliver/transports/dnsclient/dnsclient_test.go
@@ -137,6 +137,22 @@ func TestSplitBufferBase32(t *testing.T) {
 	}
 }
 
+func TestSplitBufferParityRegression(t *testing.T) {
+	// Sweep parent domain lengths across 8 chars to cover the full base32 group
+	// period. The varint-boundary bug surfaces when msg.Data length crosses 128
+	// bytes: the proto varint grows from 1 to 2 bytes, causing a +3/+4 base32
+	// jump that exceeds the subdataSpace-1 guard in SplitBuffer.
+	base := "example.com"
+	for pad := 0; pad < 8; pad++ {
+		parent := fmt.Sprintf(".%s%s.", strings.Repeat("x", pad), base)
+		client := NewDNSClient(parent, opts)
+		testData := randomData(256) // crosses the 128-byte Data varint boundary
+		t.Run(fmt.Sprintf("parentLen%d", len(parent)), func(t *testing.T) {
+			clientSplitBuffer(t, client, encoders.Base32{}, testData)
+		})
+	}
+}
+
 func TestSplitBufferDomainConstraints(t *testing.T) {
 	client := NewDNSClient(parent1, opts)
 	testData := randomData(8192)


### PR DESCRIPTION
Fixes #2279

## What

Adds a step-back loop in `SplitBuffer` (`implant/sliver/transports/dnsclient/dnsclient.go`) that corrects encoded-length overshoots caused by protobuf varint boundary growth, and adds a regression test that sweeps parent domain lengths to cover all parities.

## Why

The existing guard `subdataSpace - 1` assumes the worst-case base32 jump from adding one raw byte is +2 chars (crossing a 5-byte group boundary). This holds for pure base32, but not when the underlying protobuf grows by 2 bytes at a varint boundary (e.g. `msg.Data` length crossing 128). At that point the base32 encoding jumps +3 or +4, causing `joinSubdataToParent` to return `errMsgTooLong` — logged as `[dns] join subdata failed` in debug mode and aborting the DNS session init.

The failure alternates with parent domain length (even passes, odd fails, or vice versa) because `subdataSpace` shifts by 1 per domain character, which alternately puts the encoded length inside or outside the overshoot window.

## Changes

- **`implant/sliver/transports/dnsclient/dnsclient.go`** — after the inner loop that fills a chunk, step back one byte at a time if the encoded length exceeds `subdataSpace`. In practice this fires at most 1–2 times per chunk (at a varint boundary), so there is no meaningful performance impact.
- **`implant/sliver/transports/dnsclient/dnsclient_test.go`** — `TestSplitBufferParityRegression` sweeps 8 consecutive parent domain lengths (covering the full base32 group period) with a 256-byte payload that crosses the 128-byte varint boundary, verifying round-trip correctness at every parity.

## Testing

```
# Implant-side (encoding)
go test -v -run TestSplitBuffer ./implant/sliver/transports/dnsclient/

# Server-side (decoding / round-trip)
go test -v -tags go_sqlite,server -run "TestDNSSessionInitRoundTrip|TestDNSWriteEnvelopeRoundTrip|TestDNSReadEnvelopeRoundTrip|TestDecodeSubdata|TestAccumulateInitData" ./server/c2/
```

All pass. The regression test `TestSplitBufferParityRegression` fails on the unpatched code and passes with this fix.