### PR TITLE
Use req.Name for name validation in RPC

### DIFF
--- a/server/rpc/rpc-generate.go
+++ b/server/rpc/rpc-generate.go
@@ -1084,7 +1084,7 @@ func (rpc *Server) GenerateStage(ctx context.Context, req *clientpb.GenerateStag
 		if err != nil {
 			return nil, rpcError(err)
 		}
-	} else if err := util.AllowedName(name); err != nil {
+	} else if err := util.AllowedName(req.Name); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	} else {
 		name = req.Name


### PR DESCRIPTION
Small fix for `profiles stage` command. 

**Current behavior:**

```
[server] sliver > profiles stage --name "win-stage" win
[!] rpc error: code = InvalidArgument desc = name cannot be blank
```

**Expected behavior (after fix):**

```
[server] sliver > profiles stage --name "win-stage" win
[*] Implant saved to /opt/sliver/bin/win-stage.bin
```