### PR TITLE
Fix unbounded PNG decoding

### DIFF
--- a/server/c2/http_decode_test.go
+++ b/server/c2/http_decode_test.go
@@ -1,0 +1,42 @@
+package c2
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2026  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"bytes"
+	"errors"
+	"image"
+	"image/png"
+	"testing"
+
+	sliverEncoders "github.com/bishopfox/sliver/util/encoders"
+)
+
+func TestDecodeReqBodyWithMaxLenRejectsOversizedPNG(t *testing.T) {
+	img := image.NewNRGBA(image.Rect(0, 0, 1700, 1700))
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, img); err != nil {
+		t.Fatalf("png encode failed: %v", err)
+	}
+
+	_, err := decodeReqBodyWithMaxLen(sliverEncoders.PNGEncoder{}, encoded.Bytes(), DefaultMaxUnauthBodyLength)
+	if !errors.Is(err, sliverEncoders.ErrPNGTooLarge) {
+		t.Fatalf("expected ErrPNGTooLarge, got %v", err)
+	}
+}

--- a/util/encoders/images.go
+++ b/util/encoders/images.go
@@ -20,6 +20,8 @@ package encoders
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"image"
 	"image/color"
 	"image/png"
@@ -36,10 +38,21 @@ const (
 
 	// we can shove three bytes into each pixel: R, G, and B.
 	bytesPerPixel = 3
+
+	// DefaultMaxPNGDecodeLen is the maximum amount of pixel data Decode will
+	// process. Callers handling untrusted data should use DecodeWithMaxLen with
+	// a limit appropriate for the request they are processing.
+	DefaultMaxPNGDecodeLen = 2 * 1024 * 1024 * 1024 // 2GB
 )
+
+// ErrPNGTooLarge is returned when a PNG's dimensions or decoded payload exceed
+// the decode limit.
+var ErrPNGTooLarge = errors.New("png decoded payload exceeds maximum size")
 
 // PNGEncoder - PNG image object
 type PNGEncoder struct{}
+
+var _ LimitedDecoder = PNGEncoder{}
 
 // Encode outputs a valid PNG file
 func (p PNGEncoder) Encode(data []byte) ([]byte, error) {
@@ -54,12 +67,50 @@ func (p PNGEncoder) Encode(data []byte) ([]byte, error) {
 
 // Decode reads a encoded PNG to get the original binary data
 func (p PNGEncoder) Decode(data []byte) ([]byte, error) {
-	buf := bytes.NewBuffer(data)
-	img, err := png.Decode(buf)
+	return p.DecodeWithMaxLen(data, DefaultMaxPNGDecodeLen)
+}
+
+// DecodeWithMaxLen reads an encoded PNG while limiting both the returned
+// payload and the three-byte-per-pixel representation used during decoding.
+// Since padding and escape sequences are removed after extracting the pixels,
+// this may conservatively reject an image whose final payload would fit.
+func (p PNGEncoder) DecodeWithMaxLen(data []byte, maxLen int64) ([]byte, error) {
+	if maxLen < 0 {
+		return nil, fmt.Errorf("invalid max decode length: %d", maxLen)
+	}
+
+	config, err := png.DecodeConfig(bytes.NewReader(data))
 	if err != nil {
 		return nil, err
 	}
-	return bytesFromImage(img), nil
+	if err := validatePNGDimensions(config.Width, config.Height, maxLen); err != nil {
+		return nil, err
+	}
+
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	decoded := bytesFromImage(img)
+	if int64(len(decoded)) > maxLen {
+		return nil, fmt.Errorf("%w: decoded payload is %d bytes, limit is %d", ErrPNGTooLarge, len(decoded), maxLen)
+	}
+	return decoded, nil
+}
+
+func validatePNGDimensions(width int, height int, maxLen int64) error {
+	if width <= 0 || height <= 0 {
+		return fmt.Errorf("invalid PNG dimensions: %dx%d", width, height)
+	}
+
+	// bytesFromImage materializes three bytes for every pixel before removing
+	// padding and escape sequences. Bound that intermediate representation
+	// before png.Decode allocates storage based on attacker-controlled dimensions.
+	maxPixels := maxLen / int64(bytesPerPixel)
+	if int64(width) > maxPixels/int64(height) {
+		return fmt.Errorf("%w: %dx%d image exceeds %d bytes", ErrPNGTooLarge, width, height, maxLen)
+	}
+	return nil
 }
 
 // imageFromBytes returns a valid image with data encoded in each pixel

--- a/util/encoders/images_test.go
+++ b/util/encoders/images_test.go
@@ -20,6 +20,9 @@ package encoders
 
 import (
 	"bytes"
+	"encoding/binary"
+	"errors"
+	"hash/crc32"
 	"testing"
 )
 
@@ -60,5 +63,79 @@ func TestPNGRandomDataRandomSize(t *testing.T) {
 		if !bytes.Equal(sample, decodeOutput) {
 			t.Errorf("png Decode(img) => %q, expected %q", decodeOutput, sample)
 		}
+	}
+}
+
+func TestPNGDecodeWithMaxLen(t *testing.T) {
+	const maxLen = 4 * bytesPerPixel
+	payload := []byte{0x00, 0x01, 0x02, 0x03, 0x04}
+	pngEncoder := new(PNGEncoder)
+	encoded, err := pngEncoder.Encode(payload)
+	if err != nil {
+		t.Fatalf("png encode failed: %v", err)
+	}
+
+	decoded, err := pngEncoder.DecodeWithMaxLen(encoded, maxLen)
+	if err != nil {
+		t.Fatalf("png decode failed: %v", err)
+	}
+	if !bytes.Equal(payload, decoded) {
+		t.Fatalf("decoded payload does not match original: %q != %q", decoded, payload)
+	}
+}
+
+func TestPNGDecodeWithMaxLenRejectsOversizedPixelData(t *testing.T) {
+	payload := bytes.Repeat([]byte("A"), 8192)
+	pngEncoder := new(PNGEncoder)
+	encoded, err := pngEncoder.Encode(payload)
+	if err != nil {
+		t.Fatalf("png encode failed: %v", err)
+	}
+
+	_, err = pngEncoder.DecodeWithMaxLen(encoded, int64(len(payload)-1))
+	if !errors.Is(err, ErrPNGTooLarge) {
+		t.Fatalf("expected ErrPNGTooLarge, got %v", err)
+	}
+}
+
+func TestPNGDecodeWithMaxLenRejectsOversizedDimensionsBeforeDecode(t *testing.T) {
+	const maxLen = 8 * 1024 * 1024
+	pngEncoder := new(PNGEncoder)
+	encoded, err := pngEncoder.Encode([]byte("abc"))
+	if err != nil {
+		t.Fatalf("png encode failed: %v", err)
+	}
+
+	// A PNG starts with an eight-byte signature followed by its IHDR chunk.
+	// Rewrite only the CRC-valid header and omit IDAT so this test remains safe
+	// even if the preflight check regresses and png.Decode is called directly.
+	const ihdrEnd = 33
+	if len(encoded) < ihdrEnd || string(encoded[12:16]) != "IHDR" {
+		t.Fatal("encoded PNG does not contain the expected IHDR chunk")
+	}
+	encoded = encoded[:ihdrEnd]
+	binary.BigEndian.PutUint32(encoded[16:20], 4096)
+	binary.BigEndian.PutUint32(encoded[20:24], 4096)
+	binary.BigEndian.PutUint32(encoded[29:33], crc32.ChecksumIEEE(encoded[12:29]))
+
+	_, err = pngEncoder.DecodeWithMaxLen(encoded, maxLen)
+	if !errors.Is(err, ErrPNGTooLarge) {
+		t.Fatalf("expected ErrPNGTooLarge, got %v", err)
+	}
+}
+
+func TestValidatePNGDimensionsRejectsReportedBomb(t *testing.T) {
+	err := validatePNGDimensions(32767, 32767, 8*1024*1024)
+	if !errors.Is(err, ErrPNGTooLarge) {
+		t.Fatalf("expected ErrPNGTooLarge, got %v", err)
+	}
+}
+
+func TestValidatePNGDimensionsPixelDataBoundary(t *testing.T) {
+	if err := validatePNGDimensions(1, 1, bytesPerPixel); err != nil {
+		t.Fatalf("expected one pixel to fit: %v", err)
+	}
+	if err := validatePNGDimensions(1, 1, bytesPerPixel-1); !errors.Is(err, ErrPNGTooLarge) {
+		t.Fatalf("expected ErrPNGTooLarge, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- preflight PNG dimensions before allocating decoded pixel storage
- make `PNGEncoder` implement `LimitedDecoder` so HTTP C2 request limits apply to PNG traffic encoders
- add encoder-level and HTTP C2 regression tests for oversized PNG dimensions

## Root cause

The anonymous HTTP C2 path bounded the compressed request body, but PNG decoding called `png.Decode` before checking the decoded size. An attacker-controlled IHDR could therefore trigger a very large allocation from a small request.

## Impact

Oversized PNG traffic-encoder payloads are rejected from their header dimensions before pixel allocation, while valid payloads continue through the existing decoder path.

## Validation

- `make`
- `./go-tests.sh --unit-only`
- `./go-tests.sh --skip-generate` (unit packages plus C2 yamux and DNS end-to-end tests)
- `git diff --check`

The unrestricted generator matrix was also attempted. Its existing embedded Go 1.26.2 Windows/ARM64 debug build fails with `syscall.Syscall15: nosplit stack over 792 byte limit`; this reproduces independently of the PNG changes.