### PR TITLE
Add Go c-archive output format

### DIFF
--- a/client/command/generate/commands.go
+++ b/client/command/generate/commands.go
@@ -367,7 +367,7 @@ func coreImplantFlags(name string, cmd *cobra.Command) {
 		f.StringP("limit-locale", "L", "", "limit execution to hosts that match this locale")
 		bindSpoofMetadataFlag(f)
 
-		f.StringP("format", "f", "exe", "Specifies the output formats, valid values are: 'exe', 'shared' (for dynamic libraries), 'service' (see: `psexec` for more info) and 'shellcode' (windows, darwin/arm64, linux/amd64, linux/arm64)")
+		f.StringP("format", "f", "exe", "Specifies the output formats, valid values are: 'exe', 'shared' (for dynamic libraries), 'archive' (for Go c-archives), 'service' (see: `psexec` for more info) and 'shellcode' (windows, darwin/arm64, linux/amd64, linux/arm64)")
 
 		// Shellcode generation options:
 		// - Windows: Donut

--- a/client/command/generate/generate.go
+++ b/client/command/generate/generate.go
@@ -254,6 +254,8 @@ func nameOfOutputFormat(value clientpb.OutputFormat) string {
 		return "Service"
 	case clientpb.OutputFormat_SHARED_LIB:
 		return "Shared Library"
+	case clientpb.OutputFormat_GO_ARCHIVE:
+		return "Go Archive"
 	case clientpb.OutputFormat_SHELLCODE:
 		return "Shellcode"
 	default:
@@ -389,6 +391,9 @@ func parseCompileFlags(cmd *cobra.Command, con *console.SliverClient) (string, *
 		configFormat = clientpb.OutputFormat_SHARED_LIB
 		isSharedLib = true
 		runAtLoad, _ = cmd.Flags().GetBool("run-at-load")
+	case "archive":
+		configFormat = clientpb.OutputFormat_GO_ARCHIVE
+		isSharedLib = true
 	case "shellcode":
 		configFormat = clientpb.OutputFormat_SHELLCODE
 		isShellcode = true

--- a/client/command/generate/helpers.go
+++ b/client/command/generate/helpers.go
@@ -197,7 +197,7 @@ func OSCompleter(con *console.SliverClient) carapace.Action {
 func FormatCompleter() carapace.Action {
 	return carapace.ActionCallback(func(_ carapace.Context) carapace.Action {
 		return carapace.ActionValues([]string{
-			"exe", "shared", "service", "shellcode",
+			"exe", "shared", "archive", "service", "shellcode",
 		}...).Tag("implant format")
 	})
 }

--- a/client/command/generate/output_format_test.go
+++ b/client/command/generate/output_format_test.go
@@ -1,0 +1,13 @@
+package generate
+
+import (
+	"testing"
+
+	"github.com/bishopfox/sliver/protobuf/clientpb"
+)
+
+func TestNameOfOutputFormatGoArchive(t *testing.T) {
+	if got := nameOfOutputFormat(clientpb.OutputFormat_GO_ARCHIVE); got != "Go Archive" {
+		t.Fatalf("nameOfOutputFormat(GO_ARCHIVE) = %q, want %q", got, "Go Archive")
+	}
+}

--- a/client/command/generate/profiles.go
+++ b/client/command/generate/profiles.go
@@ -263,6 +263,8 @@ func populateProfileProperties(config *clientpb.ImplantConfig) map[string]string
 		properties["format"] = "Executable"
 	case clientpb.OutputFormat_SHARED_LIB:
 		properties["format"] = "Shared Library"
+	case clientpb.OutputFormat_GO_ARCHIVE:
+		properties["format"] = "Go Archive"
 	case clientpb.OutputFormat_SERVICE:
 		properties["format"] = "Service"
 	case clientpb.OutputFormat_SHELLCODE:

--- a/client/forms/generate_profiles_new.go
+++ b/client/forms/generate_profiles_new.go
@@ -79,6 +79,7 @@ func GenerateProfilesNewForm() (*GenerateProfilesNewFormResult, error) {
 					options := []huh.Option[string]{
 						huh.NewOption("Executable", "exe"),
 						huh.NewOption("Shared library", "shared"),
+						huh.NewOption("Go archive", "archive"),
 					}
 					if result.OS == "windows" {
 						options = append(options,

--- a/client/forms/generate_profiles_new_beacon.go
+++ b/client/forms/generate_profiles_new_beacon.go
@@ -84,6 +84,7 @@ func GenerateProfilesNewBeaconForm() (*GenerateProfilesNewBeaconFormResult, erro
 					options := []huh.Option[string]{
 						huh.NewOption("Executable", "exe"),
 						huh.NewOption("Shared library", "shared"),
+						huh.NewOption("Go archive", "archive"),
 					}
 					if result.OS == "windows" {
 						options = append(options,

--- a/client/forms/generate_targets.go
+++ b/client/forms/generate_targets.go
@@ -22,6 +22,7 @@ type targetOptionBindings struct {
 var formatOptionOrder = []formatOption{
 	{format: clientpb.OutputFormat_EXECUTABLE, label: "Executable", value: "exe"},
 	{format: clientpb.OutputFormat_SHARED_LIB, label: "Shared library", value: "shared"},
+	{format: clientpb.OutputFormat_GO_ARCHIVE, label: "Go archive", value: "archive"},
 	{format: clientpb.OutputFormat_SERVICE, label: "Service", value: "service"},
 	{format: clientpb.OutputFormat_SHELLCODE, label: "Shellcode", value: "shellcode"},
 }
@@ -59,6 +60,7 @@ func commonFormatOptions(goos string) []huh.Option[string] {
 	options := []huh.Option[string]{
 		huh.NewOption("Executable", "exe"),
 		huh.NewOption("Shared library", "shared"),
+		huh.NewOption("Go archive", "archive"),
 	}
 	if goos == "windows" {
 		options = append(options,

--- a/protobuf/clientpb/client.pb.go
+++ b/protobuf/clientpb/client.pb.go
@@ -30,6 +30,7 @@ const (
 	OutputFormat_EXECUTABLE  OutputFormat = 2
 	OutputFormat_SERVICE     OutputFormat = 3
 	OutputFormat_THIRD_PARTY OutputFormat = 4
+	OutputFormat_GO_ARCHIVE  OutputFormat = 5
 )
 
 // Enum value maps for OutputFormat.
@@ -40,6 +41,7 @@ var (
 		2: "EXECUTABLE",
 		3: "SERVICE",
 		4: "THIRD_PARTY",
+		5: "GO_ARCHIVE",
 	}
 	OutputFormat_value = map[string]int32{
 		"SHARED_LIB":  0,
@@ -47,6 +49,7 @@ var (
 		"EXECUTABLE":  2,
 		"SERVICE":     3,
 		"THIRD_PARTY": 4,
+		"GO_ARCHIVE":  5,
 	}
 )
 
@@ -14023,7 +14026,7 @@ const file_clientpb_client_proto_rawDesc = "" +
 	"\fKeyAlgorithm\x18\x06 \x01(\tR\fKeyAlgorithm\x12\x0e\n" +
 	"\x02ID\x18\a \x01(\tR\x02ID\"R\n" +
 	"\x18CertificateAuthorityInfo\x126\n" +
-	"\x04info\x18\x01 \x03(\v2\".clientpb.CertificateAuthorityDataR\x04info*[\n" +
+	"\x04info\x18\x01 \x03(\v2\".clientpb.CertificateAuthorityDataR\x04info*k\n" +
 	"\fOutputFormat\x12\x0e\n" +
 	"\n" +
 	"SHARED_LIB\x10\x00\x12\r\n" +
@@ -14031,7 +14034,9 @@ const file_clientpb_client_proto_rawDesc = "" +
 	"\n" +
 	"EXECUTABLE\x10\x02\x12\v\n" +
 	"\aSERVICE\x10\x03\x12\x0f\n" +
-	"\vTHIRD_PARTY\x10\x04*-\n" +
+	"\vTHIRD_PARTY\x10\x04\x12\x0e\n" +
+	"\n" +
+	"GO_ARCHIVE\x10\x05*-\n" +
 	"\rStageProtocol\x12\a\n" +
 	"\x03TCP\x10\x00\x12\b\n" +
 	"\x04HTTP\x10\x01\x12\t\n" +

--- a/protobuf/clientpb/client.proto
+++ b/protobuf/clientpb/client.proto
@@ -130,6 +130,7 @@ enum OutputFormat {
   EXECUTABLE = 2;
   SERVICE = 3;
   THIRD_PARTY = 4;
+  GO_ARCHIVE = 5;
 }
 
 // ShellcodeConfig - options used when generating shellcode output.

--- a/server/builder/builder.go
+++ b/server/builder/builder.go
@@ -210,6 +210,10 @@ func (b *Builder) handleBuildEvent(event *clientpb.Event) {
 		b.mutex.Lock()
 		fPath, err = generate.SliverSharedLibrary(extConfig.Build.Name, extConfig.Build, extConfig.Config, httpC2Config.ImplantConfig)
 		b.mutex.Unlock()
+	case clientpb.OutputFormat_GO_ARCHIVE:
+		b.mutex.Lock()
+		fPath, err = generate.SliverArchive(extConfig.Build.Name, extConfig.Build, extConfig.Config, httpC2Config.ImplantConfig)
+		b.mutex.Unlock()
 	case clientpb.OutputFormat_SHELLCODE:
 		b.mutex.Lock()
 		fPath, err = generate.SliverShellcode(extConfig.Build.Name, extConfig.Build, extConfig.Config, httpC2Config.ImplantConfig)

--- a/server/cli/builder.go
+++ b/server/cli/builder.go
@@ -296,6 +296,9 @@ func parseForceEnableTargets(cmd *cobra.Command, externalBuilder *clientpb.Build
 		case "shared-lib", "sharedlib", "dll", "so", "dylib":
 			target.Format = clientpb.OutputFormat_SHARED_LIB
 
+		case "archive", "go-archive", "c-archive":
+			target.Format = clientpb.OutputFormat_GO_ARCHIVE
+
 		case "service", "svc":
 			target.Format = clientpb.OutputFormat_SERVICE
 
@@ -339,6 +342,9 @@ func parseForceDisableTargets(cmd *cobra.Command, externalBuilder *clientpb.Buil
 
 		case "shared-lib", "sharedlib", "dll", "so", "dylib":
 			format = clientpb.OutputFormat_SHARED_LIB
+
+		case "archive", "go-archive", "c-archive":
+			format = clientpb.OutputFormat_GO_ARCHIVE
 
 		case "service", "svc":
 			format = clientpb.OutputFormat_SERVICE

--- a/server/generate/archive_test.go
+++ b/server/generate/archive_test.go
@@ -1,0 +1,60 @@
+package generate
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestZipFilesIncludesArchiveHeaders(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"implant.a": "archive",
+		"implant.h": "cgo header",
+		"main.h":    "sliver header",
+	}
+	var paths []string
+	for name, contents := range files {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		paths = append(paths, path)
+	}
+
+	zipPath := filepath.Join(dir, "implant.zip")
+	if err := zipFiles(zipPath, paths...); err != nil {
+		t.Fatalf("zipFiles() error: %v", err)
+	}
+
+	reader, err := zip.OpenReader(zipPath)
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	defer reader.Close()
+
+	got := map[string]string{}
+	for _, file := range reader.File {
+		rc, err := file.Open()
+		if err != nil {
+			t.Fatalf("open zipped file %s: %v", file.Name, err)
+		}
+		data, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatalf("read zipped file %s: %v", file.Name, err)
+		}
+		got[file.Name] = string(data)
+	}
+
+	if len(got) != len(files) {
+		t.Fatalf("zip contained %d files, want %d", len(got), len(files))
+	}
+	for name, contents := range files {
+		if got[name] != contents {
+			t.Fatalf("zipped %s = %q, want %q", name, got[name], contents)
+		}
+	}
+}

--- a/server/generate/binaries.go
+++ b/server/generate/binaries.go
@@ -19,6 +19,7 @@ package generate
 */
 
 import (
+	"archive/zip"
 	"bytes"
 	"crypto/sha256"
 	"debug/elf"
@@ -648,6 +649,112 @@ func SliverSharedLibrary(name string, build *clientpb.ImplantBuild, config *clie
 	return dest, err
 }
 
+func zipFiles(dest string, files ...string) error {
+	outFile, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+
+	zipWriter := zip.NewWriter(outFile)
+	defer zipWriter.Close()
+
+	for _, filePath := range files {
+		inFile, err := os.Open(filePath)
+		if err != nil {
+			return err
+		}
+
+		fileWriter, err := zipWriter.Create(filepath.Base(filePath))
+		if err != nil {
+			inFile.Close()
+			return err
+		}
+		_, err = io.Copy(fileWriter, inFile)
+		inFile.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// SliverArchive - Generates a sliver c-archive bundle (.a and .h)
+func SliverArchive(name string, build *clientpb.ImplantBuild, config *clientpb.ImplantConfig, pbC2Implant *clientpb.HTTPC2ImplantConfig) (string, error) {
+	appDir := assets.GetRootAppDir()
+
+	var cc string
+	var cxx string
+	if runtime.GOOS != config.GOOS || runtime.GOARCH != config.GOARCH {
+		buildLog.Debugf("Cross-compiling from %s/%s to %s/%s", runtime.GOOS, runtime.GOARCH, config.GOOS, config.GOARCH)
+		cc, cxx = findCrossCompilers(config.GOOS, config.GOARCH)
+	}
+
+	buildLog.Infof(" CC: %s", cc)
+	buildLog.Infof("CXX: %s", cxx)
+
+	goConfig := &gogo.GoConfig{
+		CGO: "1",
+		CC:  cc,
+		CXX: cxx,
+
+		GOOS:       config.GOOS,
+		GOARCH:     config.GOARCH,
+		GOCACHE:    gogo.GetGoCache(appDir),
+		GOMODCACHE: gogo.GetGoModCache(appDir),
+		GOROOT:     gogo.GetGoRootDir(appDir),
+		GOPROXY:    getGoProxy(),
+		HTTPPROXY:  getGoHttpProxy(),
+		HTTPSPROXY: getGoHttpsProxy(),
+
+		Obfuscation: config.ObfuscateSymbols,
+		GOGARBLE:    goGarble(config),
+	}
+	sanitizeZigForBuild(goConfig, "c-archive")
+	buildLog.Infof(" CC: %s", goConfig.CC)
+	buildLog.Infof("CXX: %s", goConfig.CXX)
+
+	config.IsSharedLib = true
+	pkgPath, err := renderSliverGoCode(name, build, config, goConfig, pbC2Implant)
+	if err != nil {
+		return "", err
+	}
+
+	dest := filepath.Join(goConfig.ProjectDir, "bin", filepath.Base(name))
+	dest += ".a"
+	headerDest := strings.TrimSuffix(dest, filepath.Ext(dest)) + ".h"
+	zipDest := strings.TrimSuffix(dest, filepath.Ext(dest)) + ".zip"
+	mainHeaderDest := filepath.Join(pkgPath, "main.h")
+
+	tags := []string{}
+	if config.NetGoEnabled {
+		tags = append(tags, "netgo")
+	}
+	ldflags := []string{""} // Garble will automatically add "-s -w -buildid="
+
+	// Keep those for potential later use
+	gcFlags := ""
+	asmFlags := ""
+	_, err = gogo.GoBuild(*goConfig, pkgPath, dest, "c-archive", tags, ldflags, gcFlags, asmFlags)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(headerDest); err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(mainHeaderDest); err != nil {
+		return "", err
+	}
+
+	err = zipFiles(zipDest, dest, headerDest, mainHeaderDest)
+	if err != nil {
+		return "", err
+	}
+
+	return zipDest, err
+}
+
 // SliverExecutable - Generates a sliver executable binary
 func SliverExecutable(name string, build *clientpb.ImplantBuild, config *clientpb.ImplantConfig, pbC2Implant *clientpb.HTTPC2ImplantConfig) (string, error) {
 	appDir := assets.GetRootAppDir()
@@ -1206,7 +1313,7 @@ func GetCompilerTargets() []*clientpb.CompilerTarget {
 		})
 	}
 
-	// SHARED_LIB - Determine if we can probably build a dll/dylib/so
+	// SHARED_LIB/GO_ARCHIVE - Determine if we can probably build cgo artifacts
 	for longPlatform := range SupportedCompilerTargets {
 		platform := strings.SplitN(longPlatform, "/", 2)
 
@@ -1216,6 +1323,11 @@ func GetCompilerTargets() []*clientpb.CompilerTarget {
 				GOOS:   platform[0],
 				GOARCH: platform[1],
 				Format: clientpb.OutputFormat_SHARED_LIB,
+			})
+			targets = append(targets, &clientpb.CompilerTarget{
+				GOOS:   platform[0],
+				GOARCH: platform[1],
+				Format: clientpb.OutputFormat_GO_ARCHIVE,
 			})
 			continue
 		}
@@ -1231,6 +1343,11 @@ func GetCompilerTargets() []*clientpb.CompilerTarget {
 					GOOS:   platform[0],
 					GOARCH: platform[1],
 					Format: clientpb.OutputFormat_SHARED_LIB,
+				})
+				targets = append(targets, &clientpb.CompilerTarget{
+					GOOS:   platform[0],
+					GOARCH: platform[1],
+					Format: clientpb.OutputFormat_GO_ARCHIVE,
 				})
 			}
 		}

--- a/server/generate/external.go
+++ b/server/generate/external.go
@@ -34,7 +34,9 @@ func SliverExternal(name string, config *clientpb.ImplantConfig) (*clientpb.Exte
 	config.IncludeTCP = config.IncludeTCP || models.IsC2Enabled([]string{"tcppivot"}, config.C2)
 
 	// set file extension for external builds
-	if config.IsSharedLib {
+	if config.Format == clientpb.OutputFormat_GO_ARCHIVE {
+		config.Extension = ".zip"
+	} else if config.IsSharedLib {
 		switch config.GOOS {
 		case WINDOWS:
 			config.Extension = ".dll"

--- a/server/rpc/rpc-generate.go
+++ b/server/rpc/rpc-generate.go
@@ -115,6 +115,8 @@ func (rpc *Server) Generate(ctx context.Context, req *clientpb.GenerateReq) (*cl
 		fPath, err = generate.SliverExecutable(name, build, config, httpC2Config.ImplantConfig)
 	case clientpb.OutputFormat_SHARED_LIB:
 		fPath, err = generate.SliverSharedLibrary(name, build, config, httpC2Config.ImplantConfig)
+	case clientpb.OutputFormat_GO_ARCHIVE:
+		fPath, err = generate.SliverArchive(name, build, config, httpC2Config.ImplantConfig)
 	case clientpb.OutputFormat_SHELLCODE:
 		fPath, err = generate.SliverShellcode(name, build, config, httpC2Config.ImplantConfig)
 	default:
@@ -1114,6 +1116,8 @@ func (rpc *Server) GenerateStage(ctx context.Context, req *clientpb.GenerateStag
 		fPath, err = generate.SliverExecutable(name, build, profile.Config, httpC2Config.ImplantConfig)
 	case clientpb.OutputFormat_SHARED_LIB:
 		fPath, err = generate.SliverSharedLibrary(name, build, profile.Config, httpC2Config.ImplantConfig)
+	case clientpb.OutputFormat_GO_ARCHIVE:
+		fPath, err = generate.SliverArchive(name, build, profile.Config, httpC2Config.ImplantConfig)
 	case clientpb.OutputFormat_SHELLCODE:
 		fPath, err = generate.SliverShellcode(name, build, profile.Config, httpC2Config.ImplantConfig)
 	default:


### PR DESCRIPTION
## Summary

Closes #2289

Adds `archive` as a generation output format for Go c-archives. The new format builds Sliver as a Go `c-archive` and packages the generated `.a`, generated cgo export header, and rendered `main.h` into a `.zip`.

This format requires CGO because Go c-archive output depends on `-buildmode=c-archive`; the implementation mirrors the existing shared-library compiler setup where possible.

## Motivation

Sliver already supports Go shared library output for compatible targets. This adds a closely related archive output for users who need to link the generated implant archive into their own native wrapper or loader workflow.

## Implementation

- Adds `GO_ARCHIVE` to the client protobuf output format enum.
- Wires `archive` through the CLI, generate forms, profiles, RPC generation path, server builder, and external builder metadata.
- Adds `SliverArchive` beside the existing shared-library generation path.
- Reuses the existing shared-library export rendering by setting `config.IsSharedLib = true`.
- Builds with Go `-buildmode=c-archive`.
- Packages the generated `.a`, generated `.h`, and rendered `main.h` into a `.zip`.

## Tests

- Added unit coverage for the new output format display name.
- Added unit coverage for archive ZIP packaging to verify `.a`, generated `.h`, and `main.h` are included.

<img width="1743" height="317" alt="NewUnitTests" src="https://github.com/user-attachments/assets/2748b07c-cf9d-4f1b-9683-c00185c3e40a" />

- Ran focused package tests for client generate and server generate archive behavior.
- Ran compile-only checks for touched server packages.

## Manual Validation

Generated a Windows AMD64 archive with:

```sh
generate --format archive --mtls localhost
```

As expected, a ZIP archive is emitted containing the archive and header files:

<img width="690" height="397" alt="OutputProof" src="https://github.com/user-attachments/assets/3094b423-d80f-459e-ad1e-bfa939642823" />

Created a minimal wrapper for native linking validation:

```C
#include "ARCHITECTURAL_YOKE.h"
#include <windows.h>

DWORD WINAPI WorkerThread(LPVOID lpParam)
{
    StartW();
    return 0;
}

BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved)
{
    if (fdwReason == DLL_PROCESS_ATTACH) {
        DisableThreadLibraryCalls(hinstDLL);

        HANDLE hThread = CreateThread(NULL, 0, WorkerThread, NULL, 0, NULL);
        if (hThread != NULL) {
            CloseHandle(hThread);
        }
    }
    return TRUE;
}
```

Linked the archive into a DLL:

```sh
x86_64-w64-mingw32-g++ -std=c++11 -Wall -I. -shared -o beacon.dll wrapper.cpp ARCHITECTURAL_YOKE.a
```

Created a minimal loader to validate symbol resolution and invocation:

```C
#include <windows.h>
#include <stdio.h>

int main() {
    HMODULE h = LoadLibraryA("beacon.dll");
    if (!h) {
        printf("LoadLibrary failed: %lu\n", GetLastError());
        return 1;
    }

    FARPROC p = GetProcAddress(h, "StartW");
    printf("LoadLibrary OK, StartW=%p\n", p);

    FreeLibrary(h);
    return 0;
}
```

Created a simple application to test calls:

```C
#include <windows.h>
#include <stdio.h>

typedef void (*StartWFn)(void);

int main() {
    HMODULE h = LoadLibraryA("beacon.dll");
    if (!h) {
        printf("LoadLibrary failed: %lu\n", GetLastError());
        return 1;
    }

    StartWFn StartW = (StartWFn)GetProcAddress(h, "StartW");
    if (!StartW) {
        printf("GetProcAddress failed: %lu\n", GetLastError());
        return 1;
    }

    printf("Calling StartW...\n");
    StartW();

    printf("StartW returned\n");
    FreeLibrary(h);
    return 0;
}
```

Validated the generated artifact end-to-end in a local test environment:

<img width="913" height="576" alt="SliverCallerProof" src="https://github.com/user-attachments/assets/0e982a0b-dcf5-49b2-baca-d912322de054" />

Server-side validation:

<img width="829" height="569" alt="SliverKaliProof" src="https://github.com/user-attachments/assets/a68a5f55-3f02-4e6a-bd1b-49c6479c922d" />