### PR TITLE
fix(implant): bound pivot frame allocation from length prefix

### DIFF
--- a/implant/sliver/pivots/pivots.go
+++ b/implant/sliver/pivots/pivots.go
@@ -38,11 +38,20 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// MaxFrameLength bounds the payload size a pivot will allocate from a peer's
+// 4-byte length prefix. A corrupted or desynced prefix can otherwise be read as
+// a value up to ~4GiB and trigger an allocation large enough to crash the
+// implant (see BishopFox/sliver#1452). 512MiB is far above any realistic
+// relayed message but well below a fatal allocation.
+const MaxFrameLength = 512 * 1024 * 1024
+
 var (
 	// ErrFailedWrite - Failed to write to a connection
 	ErrFailedWrite = errors.New("failed to write")
 	// ErrFailedKeyExchange - Failed to exchange session and/or peer keys
 	ErrFailedKeyExchange = errors.New("failed key exchange")
+	// ErrFrameTooLarge - A peer's declared frame length exceeds MaxFrameLength
+	ErrFrameTooLarge = errors.New("pivot frame exceeds maximum length")
 
 	pivotListeners        = &sync.Map{}
 	stoppedPivotListeners = &sync.Map{}
@@ -495,6 +504,12 @@ func (p *NetConnPivot) read() ([]byte, error) {
 		log.Printf("[pivot] read error: %s\n", err)
 		// {{end}}
 		return nil, errors.New("[pivot] zero data length")
+	}
+	if dataLength > MaxFrameLength {
+		// {{if .Config.Debug}}
+		log.Printf("[pivot] read error: frame length %d exceeds max %d\n", dataLength, MaxFrameLength)
+		// {{end}}
+		return nil, ErrFrameTooLarge
 	}
 	dataBuf := make([]byte, dataLength)
 

--- a/implant/sliver/pivots/pivots_test.go
+++ b/implant/sliver/pivots/pivots_test.go
@@ -1,0 +1,100 @@
+package pivots
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2019  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func framePrefix(n uint32) []byte {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, n)
+	return b
+}
+
+// readWithTimeout runs read() with a deadline so a regression (an unbounded
+// read that blocks waiting for a bogus multi-GB body) fails fast instead of
+// hanging the whole test binary.
+func readWithTimeout(t *testing.T, read func() ([]byte, error)) ([]byte, error) {
+	t.Helper()
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		d, e := read()
+		ch <- result{d, e}
+	}()
+	select {
+	case r := <-ch:
+		return r.data, r.err
+	case <-time.After(3 * time.Second):
+		t.Fatal("read() did not return in time (possible unbounded read)")
+		return nil, nil
+	}
+}
+
+// A corrupted/desynced 4-byte length prefix that reads as a huge value must be
+// rejected before allocating, instead of triggering a multi-GB allocation that
+// crashes the implant (BishopFox/sliver#1452).
+func TestNetConnPivotReadRejectsOversizedFrame(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	p := &NetConnPivot{conn: server, readMutex: &sync.Mutex{}}
+
+	go func() {
+		// Only the length prefix is ever sent; no body follows.
+		_, _ = client.Write(framePrefix(uint32(MaxFrameLength) + 1))
+	}()
+
+	if _, err := readWithTimeout(t, p.read); !errors.Is(err, ErrFrameTooLarge) {
+		t.Fatalf("expected ErrFrameTooLarge, got %v", err)
+	}
+}
+
+// A well-formed frame within the bound must still round-trip unchanged.
+func TestNetConnPivotReadAcceptsValidFrame(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	p := &NetConnPivot{conn: server, readMutex: &sync.Mutex{}}
+
+	payload := []byte("hello pivot")
+	go func() {
+		_, _ = client.Write(framePrefix(uint32(len(payload))))
+		_, _ = client.Write(payload)
+	}()
+
+	data, err := readWithTimeout(t, p.read)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != string(payload) {
+		t.Fatalf("got %q, want %q", data, payload)
+	}
+}

--- a/implant/sliver/pivots/pivots_test.go
+++ b/implant/sliver/pivots/pivots_test.go
@@ -61,8 +61,8 @@ func readWithTimeout(t *testing.T, read func() ([]byte, error)) ([]byte, error) 
 // crashes the implant (BishopFox/sliver#1452).
 func TestNetConnPivotReadRejectsOversizedFrame(t *testing.T) {
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	p := &NetConnPivot{conn: server, readMutex: &sync.Mutex{}}
 
@@ -79,8 +79,8 @@ func TestNetConnPivotReadRejectsOversizedFrame(t *testing.T) {
 // A well-formed frame within the bound must still round-trip unchanged.
 func TestNetConnPivotReadAcceptsValidFrame(t *testing.T) {
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	p := &NetConnPivot{conn: server, readMutex: &sync.Mutex{}}
 

--- a/implant/sliver/transports/pivotclients/pivotclient.go
+++ b/implant/sliver/transports/pivotclients/pivotclient.go
@@ -247,6 +247,13 @@ func (p *NetConnPivotClient) read() ([]byte, error) {
 		return nil, errors.New("[pivot] zero data length")
 	}
 
+	if dataLength > pivots.MaxFrameLength {
+		// {{if .Config.Debug}}
+		log.Printf("[pivot] read error: frame length %d exceeds max %d\n", dataLength, pivots.MaxFrameLength)
+		// {{end}}
+		return nil, pivots.ErrFrameTooLarge
+	}
+
 	dataBuf := make([]byte, dataLength)
 
 	n, err = io.ReadFull(p.conn, dataBuf)

--- a/implant/sliver/transports/pivotclients/pivotclient_test.go
+++ b/implant/sliver/transports/pivotclients/pivotclient_test.go
@@ -1,0 +1,96 @@
+package pivotclients
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2019  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bishopfox/sliver/implant/sliver/pivots"
+)
+
+func framePrefix(n uint32) []byte {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, n)
+	return b
+}
+
+func readWithTimeout(t *testing.T, read func() ([]byte, error)) ([]byte, error) {
+	t.Helper()
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		d, e := read()
+		ch <- result{d, e}
+	}()
+	select {
+	case r := <-ch:
+		return r.data, r.err
+	case <-time.After(3 * time.Second):
+		t.Fatal("read() did not return in time (possible unbounded read)")
+		return nil, nil
+	}
+}
+
+// A corrupted/desynced length prefix must be rejected before allocating rather
+// than triggering a multi-GB allocation that crashes the implant.
+func TestNetConnPivotClientReadRejectsOversizedFrame(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	p := &NetConnPivotClient{conn: server, readMutex: &sync.Mutex{}}
+
+	go func() {
+		_, _ = client.Write(framePrefix(uint32(pivots.MaxFrameLength) + 1))
+	}()
+
+	if _, err := readWithTimeout(t, p.read); !errors.Is(err, pivots.ErrFrameTooLarge) {
+		t.Fatalf("expected pivots.ErrFrameTooLarge, got %v", err)
+	}
+}
+
+func TestNetConnPivotClientReadAcceptsValidFrame(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	p := &NetConnPivotClient{conn: server, readMutex: &sync.Mutex{}}
+
+	payload := []byte("hello pivot client")
+	go func() {
+		_, _ = client.Write(framePrefix(uint32(len(payload))))
+		_, _ = client.Write(payload)
+	}()
+
+	data, err := readWithTimeout(t, p.read)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != string(payload) {
+		t.Fatalf("got %q, want %q", data, payload)
+	}
+}

--- a/implant/sliver/transports/pivotclients/pivotclient_test.go
+++ b/implant/sliver/transports/pivotclients/pivotclient_test.go
@@ -59,8 +59,8 @@ func readWithTimeout(t *testing.T, read func() ([]byte, error)) ([]byte, error) 
 // than triggering a multi-GB allocation that crashes the implant.
 func TestNetConnPivotClientReadRejectsOversizedFrame(t *testing.T) {
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	p := &NetConnPivotClient{conn: server, readMutex: &sync.Mutex{}}
 
@@ -75,8 +75,8 @@ func TestNetConnPivotClientReadRejectsOversizedFrame(t *testing.T) {
 
 func TestNetConnPivotClientReadAcceptsValidFrame(t *testing.T) {
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	p := &NetConnPivotClient{conn: server, readMutex: &sync.Mutex{}}
 


### PR DESCRIPTION
## Problem

Both pivot readers — `NetConnPivot.read()` ([`implant/sliver/pivots/pivots.go`](https://github.com/BishopFox/sliver/blob/master/implant/sliver/pivots/pivots.go)) and `NetConnPivotClient.read()` ([`implant/sliver/transports/pivotclients/pivotclient.go`](https://github.com/BishopFox/sliver/blob/master/implant/sliver/transports/pivotclients/pivotclient.go)) — read a 4-byte little-endian length prefix and then `make([]byte, dataLength)` with only a lower-bound (`<= 0`) check. A corrupted or desynced prefix (e.g. a framing desync during a transfer over a pivot) is therefore read as a value up to ~4 GiB and triggers an allocation large enough to crash the implant.

This matches the failure mode reported in #1452 ("Downloading 300KiB file over http->named pipe pivot breaks implant and fails") — the tiny payload rules out a legitimately-large frame, pointing at an oversized/garbage declared length.

## Change

- Add `MaxFrameLength` (512 MiB) and reject frames whose declared length exceeds it with a new `ErrFrameTooLarge`, **before** allocating.
- The constant/error are defined once in the `pivots` package and reused by `pivotclients` (which already imports it).
- 512 MiB is far above any realistic relayed message but well below the point where the allocation itself is fatal — tight enough to catch a garbage length that reads as ~1 GiB (which a 2 GiB-style cap would miss), generous enough never to reject a real frame.

## Testing

- New tests in both packages: an oversized length prefix is rejected with `ErrFrameTooLarge` (with a timeout guard so a regression fails fast instead of hanging), and a valid frame still round-trips unchanged.
- `go test ./implant/sliver/pivots/... ./implant/sliver/transports/pivotclients/...` pass; `go vet` and `gofmt` clean.

## Note / possible follow-up

The identical unbounded `make([]byte, dataLength)` pattern also exists in the implant's mTLS ([`mtls.go`](https://github.com/BishopFox/sliver/blob/master/implant/sliver/transports/mtls/mtls.go)) and WireGuard ([`wireguard.go`](https://github.com/BishopFox/sliver/blob/master/implant/sliver/transports/wireguard/wireguard.go)) readers. I kept this PR scoped to the pivot path (the one #1452 is about) to keep it small, but I'm happy to extend the same bound to those readers here or in a follow-up — whichever you prefer.
