### PR TITLE
Replace Go Report Card with golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,56 @@
+name: golangci-lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+    paths:
+      - ".golangci.yml"
+      - ".github/workflows/golangci-lint.yml"
+      - "go.mod"
+      - "go.sum"
+      - "go.work"
+      - "go.work.sum"
+      - "Makefile"
+      - "vendor/**"
+      - "**/*.go"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint:
+    name: golangci-lint (${{ matrix.goos }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        goos:
+          - linux
+          - darwin
+          - windows
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: amd64
+      CGO_ENABLED: "0"
+    steps:
+      - name: Check Out Code
+        uses: actions/checkout@v6
+
+      - name: Go 1.26.2
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.2"
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+          # Keep legacy findings visible without making them blockers.
+          only-new-issues: true
+          args: ./client/... ./server/... ./util/... ./protobuf/... ./docs ./implant/...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,27 @@
+version: "2"
+
+run:
+  timeout: 10m
+  modules-download-mode: vendor
+  build-tags:
+    - client
+    - server
+    - osusergo
+    - netgo
+    - go_sqlite
+    # Raw implant entry points are Go templates; lint their supporting packages.
+    - sliver_lint
+
+linters:
+  default: standard
+  enable:
+    - gocyclo
+    - misspell
+    - revive
+  settings:
+    gocyclo:
+      min-complexity: 15
+
+formatters:
+  enable:
+    - gofmt

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,24 @@
 # Makefile for Sliver
 #
 
+.DEFAULT_GOAL := default
+
 GO ?= go
 ARTIFACT_SUFFIX ?=
 ENV =
 TAGS ?= -tags go_sqlite
 CGO_ENABLED = 0
+GOLANGCI_LINT ?= golangci-lint
+# The tree has legacy lint findings, so gate issues introduced by this change.
+GOLANGCI_LINT_BASE ?= master
+GOLANGCI_LINT_ARGS ?= --new-from-merge-base=$(GOLANGCI_LINT_BASE)
+GOLANGCI_LINT_PACKAGES = \
+	./client/... \
+	./server/... \
+	./util/... \
+	./protobuf/... \
+	./docs \
+	./implant/...
 
 ifneq (,$(findstring cgo_sqlite,$(TAGS)))
 	CGO_ENABLED = 1
@@ -22,6 +35,10 @@ ARMORY_REPO_URL ?= https://api.github.com/repos/sliverarmory/armory/releases
 CLIENT_ASSETS_PKG = github.com/bishopfox/sliver/client/assets
 SLIVER_UPDATE_PKG = github.com/bishopfox/sliver/client/command/update
 PB_COMPILERS = protoc protoc-gen-go protoc-gen-go-grpc
+
+.PHONY: lint
+lint:
+	$(GOLANGCI_LINT) run $(GOLANGCI_LINT_ARGS) $(GOLANGCI_LINT_PACKAGES)
 
 ifneq ($(OS),Windows_NT)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Sliver is an open source cross-platform adversary emulation/red team framework, 
 
 The server and client support MacOS, Windows, and Linux. Implants are supported on MacOS, Windows, and Linux (and possibly every Golang compiler target but we've not tested them all).
 
-[![Release](https://github.com/BishopFox/sliver/actions/workflows/autorelease.yml/badge.svg)](https://github.com/BishopFox/sliver/actions/workflows/autorelease.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/BishopFox/sliver)](https://goreportcard.com/report/github.com/BishopFox/sliver) [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Release](https://github.com/BishopFox/sliver/actions/workflows/autorelease.yml/badge.svg)](https://github.com/BishopFox/sliver/actions/workflows/autorelease.yml) [![golangci-lint](https://github.com/BishopFox/sliver/actions/workflows/golangci-lint.yml/badge.svg)](https://github.com/BishopFox/sliver/actions/workflows/golangci-lint.yml) [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 Visit [https://sliver.sh/](https://sliver.sh/) for tutorials and documentation.
 

--- a/implant/sliver/main.go
+++ b/implant/sliver/main.go
@@ -1,3 +1,5 @@
+//go:build !sliver_lint
+
 package main
 
 /*

--- a/implant/sliver/runner/runner.go
+++ b/implant/sliver/runner/runner.go
@@ -1,3 +1,5 @@
+//go:build !sliver_lint
+
 package runner
 
 /*

--- a/implant/sliver/transports/httpclient/drivers/win/wininet/client_generic.go
+++ b/implant/sliver/transports/httpclient/drivers/win/wininet/client_generic.go
@@ -1,6 +1,7 @@
 //go:build !windows
 
-package http
+// Package wininet provides the Windows WinINet HTTP transport.
+package wininet
 
 import "errors"
 

--- a/server/assets/assets_darwin_amd64.go
+++ b/server/assets/assets_darwin_amd64.go
@@ -1,4 +1,4 @@
-//go:build server
+//go:build server && !sliver_lint
 
 package assets
 

--- a/server/assets/assets_darwin_arm64.go
+++ b/server/assets/assets_darwin_arm64.go
@@ -1,4 +1,4 @@
-//go:build server
+//go:build server && !sliver_lint
 
 package assets
 

--- a/server/assets/assets_lint.go
+++ b/server/assets/assets_lint.go
@@ -1,0 +1,9 @@
+//go:build server && sliver_lint
+
+package assets
+
+import "embed"
+
+// Linting does not execute the embedded toolchains, so it can use an empty
+// filesystem instead of downloading the generated asset bundle.
+var assetsFs embed.FS

--- a/server/assets/assets_linux_amd64.go
+++ b/server/assets/assets_linux_amd64.go
@@ -1,4 +1,4 @@
-//go:build server
+//go:build server && !sliver_lint
 
 package assets
 

--- a/server/assets/assets_linux_arm64.go
+++ b/server/assets/assets_linux_arm64.go
@@ -1,4 +1,4 @@
-//go:build server
+//go:build server && !sliver_lint
 
 package assets
 

--- a/server/assets/assets_windows_amd64.go
+++ b/server/assets/assets_windows_amd64.go
@@ -1,4 +1,4 @@
-//go:build server
+//go:build server && !sliver_lint
 
 package assets
 

--- a/server/assets/assets_windows_arm64.go
+++ b/server/assets/assets_windows_arm64.go
@@ -1,4 +1,4 @@
-//go:build server
+//go:build server && !sliver_lint
 
 package assets
 


### PR DESCRIPTION
## Summary

- replace the Go Report Card badge with a repository-owned golangci-lint status badge
- add a pinned golangci-lint v2 configuration and cross-GOOS GitHub Actions matrix
- add a local `make lint` target that gates new findings across the full branch diff
- make raw implant templates lint-aware and fix the stale mixed-package WinINet stub so recursive implant packages load

## Why

Go Report Card is an external snapshot rather than a repository-owned check. This makes linting reproducible locally, visible in CI, and scoped to newly introduced findings so the migration does not bundle unrelated legacy cleanup.

## Validation

- `golangci-lint config verify` with v2.12.2
- `make lint` with golangci-lint v2.12.2
- merge-base lint runs for `GOOS=linux`, `darwin`, and `windows`
- `actionlint .github/workflows/golangci-lint.yml`
- `./go-tests.sh --unit-only`
- synthetic negative fixture confirmed that new implant findings fail the lint target
- `git diff --check`