### PR TITLE
fix(implant): bound mTLS and WireGuard envelope allocation from length prefix

### DIFF
--- a/implant/sliver/transports/mtls/mtls.go
+++ b/implant/sliver/transports/mtls/mtls.go
@@ -62,6 +62,10 @@ var (
 
 const mtlsEnvelopeSigningSeedPrefix = "env-signing-v1:"
 
+const maxEnvelopeLength = 512 * 1024 * 1024
+
+var errEnvelopeTooLarge = errors.New("[mtls] envelope exceeds maximum length")
+
 var (
 	envelopeSigningOnce  sync.Once
 	envelopeSigningErr   error
@@ -207,9 +211,16 @@ func ReadEnvelope(r io.Reader) (*pb.Envelope, error) {
 
 	if dataLength <= 0 {
 		// {{if .Config.Debug}}
-		log.Printf("[pivot] read error: %s\n", err)
+		log.Printf("[mtls] read error: %s\n", err)
 		// {{end}}
 		return nil, errors.New("[mtls] zero data length")
+	}
+
+	if dataLength > maxEnvelopeLength {
+		// {{if .Config.Debug}}
+		log.Printf("[mtls] read error: envelope length %d exceeds max %d\n", dataLength, maxEnvelopeLength)
+		// {{end}}
+		return nil, errEnvelopeTooLarge
 	}
 
 	dataBuf := make([]byte, dataLength)

--- a/implant/sliver/transports/mtls/read_envelope_test.go
+++ b/implant/sliver/transports/mtls/read_envelope_test.go
@@ -1,0 +1,61 @@
+package mtls
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bishopfox/sliver/implant/sliver/cryptography"
+)
+
+func rawSigStub() []byte {
+	return make([]byte, cryptography.RawSigSize)
+}
+
+func lengthPrefix(n uint32) []byte {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, n)
+	return b
+}
+
+func readEnvelopeWithTimeout(t *testing.T, buf *bytes.Reader) error {
+	t.Helper()
+	ch := make(chan error, 1)
+	go func() {
+		_, err := ReadEnvelope(buf)
+		ch <- err
+	}()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(3 * time.Second):
+		t.Fatal("ReadEnvelope did not return in time (possible unbounded allocation)")
+		return nil
+	}
+}
+
+func TestReadEnvelopeRejectsOversizedFrame(t *testing.T) {
+	var frame []byte
+	frame = append(frame, rawSigStub()...)
+	frame = append(frame, lengthPrefix(uint32(maxEnvelopeLength)+1)...)
+	buf := bytes.NewReader(frame)
+
+	err := readEnvelopeWithTimeout(t, buf)
+	if !errors.Is(err, errEnvelopeTooLarge) {
+		t.Fatalf("expected errEnvelopeTooLarge, got %v", err)
+	}
+}
+
+func TestReadEnvelopeRejectsZeroLength(t *testing.T) {
+	var frame []byte
+	frame = append(frame, rawSigStub()...)
+	frame = append(frame, lengthPrefix(0)...)
+	buf := bytes.NewReader(frame)
+
+	err := readEnvelopeWithTimeout(t, buf)
+	if err == nil {
+		t.Fatal("expected error for zero-length envelope")
+	}
+}

--- a/implant/sliver/transports/wireguard/read_envelope_test.go
+++ b/implant/sliver/transports/wireguard/read_envelope_test.go
@@ -1,0 +1,71 @@
+//go:build windows || darwin || linux
+
+package wireguard
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bishopfox/sliver/implant/sliver/cryptography"
+)
+
+func rawSigStub() []byte {
+	return make([]byte, cryptography.RawSigSize)
+}
+
+func lengthPrefix(n uint32) []byte {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, n)
+	return b
+}
+
+func readEnvelopeWithTimeout(t *testing.T, conn net.Conn) error {
+	t.Helper()
+	ch := make(chan error, 1)
+	go func() {
+		_, err := ReadEnvelope(conn)
+		ch <- err
+	}()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(3 * time.Second):
+		t.Fatal("ReadEnvelope did not return in time (possible unbounded allocation)")
+		return nil
+	}
+}
+
+func TestReadEnvelopeRejectsOversizedFrame(t *testing.T) {
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	go func() {
+		_, _ = client.Write(rawSigStub())
+		_, _ = client.Write(lengthPrefix(uint32(maxEnvelopeLength) + 1))
+	}()
+
+	err := readEnvelopeWithTimeout(t, server)
+	if !errors.Is(err, errEnvelopeTooLarge) {
+		t.Fatalf("expected errEnvelopeTooLarge, got %v", err)
+	}
+}
+
+func TestReadEnvelopeRejectsZeroLength(t *testing.T) {
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	go func() {
+		_, _ = client.Write(rawSigStub())
+		_, _ = client.Write(lengthPrefix(0))
+	}()
+
+	err := readEnvelopeWithTimeout(t, server)
+	if err == nil {
+		t.Fatal("expected error for zero-length envelope")
+	}
+}

--- a/implant/sliver/transports/wireguard/read_envelope_test.go
+++ b/implant/sliver/transports/wireguard/read_envelope_test.go
@@ -1,5 +1,6 @@
 //go:build windows || darwin || linux
 
+// Package wireguard implements the WireGuard transport for Sliver implants.
 package wireguard
 
 import (

--- a/implant/sliver/transports/wireguard/wireguard.go
+++ b/implant/sliver/transports/wireguard/wireguard.go
@@ -76,6 +76,10 @@ var (
 
 const wgEnvelopeSigningSeedPrefix = "env-signing-v1:"
 
+const maxEnvelopeLength = 512 * 1024 * 1024
+
+var errEnvelopeTooLarge = errors.New("[wireguard] envelope exceeds maximum length")
+
 var (
 	envelopeSigningOnce  sync.Once
 	envelopeSigningErr   error
@@ -200,9 +204,16 @@ func ReadEnvelope(connection net.Conn) (*pb.Envelope, error) {
 
 	if dataLength <= 0 {
 		// {{if .Config.Debug}}
-		log.Printf("[pivot] read error: %s\n", err)
+		log.Printf("[wireguard] read error: %s\n", err)
 		// {{end}}
 		return nil, errors.New("[wireguard] zero data length")
+	}
+
+	if dataLength > maxEnvelopeLength {
+		// {{if .Config.Debug}}
+		log.Printf("[wireguard] read error: envelope length %d exceeds max %d\n", dataLength, maxEnvelopeLength)
+		// {{end}}
+		return nil, errEnvelopeTooLarge
 	}
 
 	dataBuf := make([]byte, dataLength)


### PR DESCRIPTION
## Summary

- The same unbounded-allocation vulnerability fixed for pivots in #2292 exists in the mTLS and WireGuard implant-side `ReadEnvelope` functions — a corrupted or desynced 4-byte length prefix can trigger an allocation up to ~4 GiB, crashing the implant.
- Adds a `maxEnvelopeLength` cap (512 MiB, matching the pivot transport) to both mTLS and WireGuard `ReadEnvelope`, returning a descriptive error instead of allocating.
- Also fixes stale `[pivot]` debug log tags in both transports' zero-length error paths.

Note: the **server side** already has bounds via `ServerMaxMessageSize` — this fix closes the gap on the **implant (client) side**.

## Test plan

- [x] New `TestReadEnvelopeRejectsOversizedFrame` for mTLS — passes
- [x] New `TestReadEnvelopeRejectsZeroLength` for mTLS — passes
- [x] New `TestReadEnvelopeRejectsOversizedFrame` for WireGuard — passes
- [x] New `TestReadEnvelopeRejectsZeroLength` for WireGuard — passes
- [x] All existing tests in both packages pass with no regressions