### PR TITLE
fix(server): guard Session.ToProtobuf against nil Connection

### DIFF
--- a/server/core/sessions.go
+++ b/server/core/sessions.go
@@ -117,6 +117,15 @@ func (s *Session) IsDead() bool {
 
 // ToProtobuf - Get the protobuf version of the object
 func (s *Session) ToProtobuf() *clientpb.Session {
+	var transport, remoteAddress string
+	var lastCheckin int64
+	var isDead bool
+	if s.Connection != nil {
+		transport = s.Connection.Transport
+		remoteAddress = s.Connection.RemoteAddress
+		lastCheckin = s.LastCheckin().Unix()
+		isDead = s.IsDead()
+	}
 	return &clientpb.Session{
 		ID:                s.ID,
 		Name:              s.Name,
@@ -128,13 +137,13 @@ func (s *Session) ToProtobuf() *clientpb.Session {
 		OS:                s.OS,
 		Version:           s.Version,
 		Arch:              s.Arch,
-		Transport:         s.Connection.Transport,
-		RemoteAddress:     s.Connection.RemoteAddress,
+		Transport:         transport,
+		RemoteAddress:     remoteAddress,
 		PID:               int32(s.PID),
 		Filename:          s.Filename,
-		LastCheckin:       s.LastCheckin().Unix(),
+		LastCheckin:       lastCheckin,
 		ActiveC2:          s.ActiveC2,
-		IsDead:            s.IsDead(),
+		IsDead:            isDead,
 		ReconnectInterval: s.ReconnectInterval,
 		ProxyURL:          s.ProxyURL,
 		Burned:            s.Burned,

--- a/server/core/sessions_test.go
+++ b/server/core/sessions_test.go
@@ -1,0 +1,21 @@
+package core
+
+import "testing"
+
+func TestSessionToProtobufNilConnection(t *testing.T) {
+	s := &Session{Name: "test-canary"}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ToProtobuf panicked with nil Connection: %v", r)
+		}
+	}()
+
+	pb := s.ToProtobuf()
+	if pb.Name != "test-canary" {
+		t.Fatalf("expected Name=%q, got %q", "test-canary", pb.Name)
+	}
+	if pb.Transport != "" {
+		t.Fatalf("expected empty Transport, got %q", pb.Transport)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes a server panic (nil pointer dereference) when a DNS canary is triggered (#1435).
- `handleCanary` in `server/c2/dns.go` publishes an event with a `Session` containing only `Name` — `Connection` is nil. The RPC event stream calls `ToProtobuf()` on it, which dereferences `Connection` for `Transport`, `RemoteAddress`, `LastCheckin()`, and `IsDead()`, crashing the server.
- Guards the `Connection`-dependent fields in `ToProtobuf()` so they return zero values when `Connection` is nil instead of panicking.

## Test plan

- [x] `TestSessionToProtobufNilConnection` — verifies `ToProtobuf` does not panic with nil `Connection` and correctly returns the `Name` field
- [x] Existing `server/core` tests pass

Fixes #1435