### PR TITLE
fix(client): allow immediate no-PTY shell escape

### DIFF
--- a/client/command/shell/ioloop.go
+++ b/client/command/shell/ioloop.go
@@ -13,6 +13,8 @@ import (
 	"github.com/bishopfox/sliver/client/core"
 )
 
+const shellEscapeByte = byte(0x1d) // Ctrl-]
+
 // runAttachedIO forwards local stdin to a shell tunnel while attached to the shell.
 // It returns:
 // - detached=true when user hit escape (Ctrl-])
@@ -22,7 +24,6 @@ func runAttachedIO(tunnel *core.TunnelIO, con *console.SliverClient) (detached b
 	// (network hang, server gone, etc.) tunnel.Write can block forever and "lock" the
 	// client in shell mode. Instead, buffer stdin locally and look for a local escape key.
 	const (
-		shellEscapeByte = byte(0x1d) // Ctrl-]
 		stdinBufSize    = 32 * 1024
 		stdinQueueDepth = 128
 	)

--- a/client/command/shell/shell.go
+++ b/client/command/shell/shell.go
@@ -254,8 +254,6 @@ func runInteractive(cmd *cobra.Command, shellPath string, noPty bool, con *conso
 		tunnel      *core.TunnelIO
 		managed     *managedShell
 		enablePTY   bool
-		oldState    *term.State
-		stateSaved  bool
 		stopPtySize = func() {}
 		err         error
 	)
@@ -342,26 +340,24 @@ func runInteractive(cmd *cobra.Command, shellPath string, noPty bool, con *conso
 		con.PrintInfof("Attached shell [%d] (pid %d)\n\n", managed.ID, managed.Pid)
 	}
 
-	if enablePTY {
-		oldState, err = term.MakeRaw(0)
-		log.Printf("Saving terminal state: %v", oldState)
-		if err != nil {
-			con.PrintErrorf("Failed to save terminal state\n")
-			managed.SetOutput(io.Discard)
-			managed.setState(shellStateDetached)
-			return shellAttachFailed
+	restoreTerminal, err := configureShellTerminal(enablePTY)
+	if err != nil {
+		con.PrintErrorf("Failed to configure terminal state\n")
+		managed.SetOutput(io.Discard)
+		managed.setState(shellStateDetached)
+		return shellAttachFailed
+	}
+	defer func() {
+		log.Printf("Restoring terminal state ...")
+		if err := restoreTerminal(); err != nil {
+			log.Printf("Failed to restore terminal state: %v", err)
 		}
-		stateSaved = true
+	}()
+
+	if enablePTY {
 		stopPtySize = startPtyResizeWatcher(con, cmd, tunnel.ID)
 	}
 	defer stopPtySize()
-
-	if stateSaved {
-		defer func() {
-			log.Printf("Restoring terminal state ...")
-			term.Restore(0, oldState)
-		}()
-	}
 
 	detached, _ := runAttachedIO(tunnel, con)
 	if detached {

--- a/client/command/shell/terminal.go
+++ b/client/command/shell/terminal.go
@@ -1,0 +1,31 @@
+package shell
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+func configureShellTerminal(enablePTY bool) (func() error, error) {
+	if !enablePTY {
+		return configureNoPTYTerminal(int(os.Stdin.Fd()), shellEscapeByte)
+	}
+
+	const stdinFD = 0
+	oldState, err := term.MakeRaw(stdinFD)
+	if err != nil {
+		return nil, err
+	}
+	return func() error {
+		return term.Restore(stdinFD, oldState)
+	}, nil
+}
+
+func replaceControlChar(controlChars []uint8, index int, value uint8) (uint8, bool) {
+	if index < 0 || index >= len(controlChars) {
+		return 0, false
+	}
+	original := controlChars[index]
+	controlChars[index] = value
+	return original, true
+}

--- a/client/command/shell/terminal_no_pty_bsd.go
+++ b/client/command/shell/terminal_no_pty_bsd.go
@@ -1,0 +1,13 @@
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
+
+package shell
+
+import "golang.org/x/sys/unix"
+
+func getTermios(fd int) (*unix.Termios, error) {
+	return unix.IoctlGetTermios(fd, unix.TIOCGETA)
+}
+
+func setTermios(fd int, state *unix.Termios) error {
+	return unix.IoctlSetTermios(fd, unix.TIOCSETA, state)
+}

--- a/client/command/shell/terminal_no_pty_linux.go
+++ b/client/command/shell/terminal_no_pty_linux.go
@@ -1,0 +1,13 @@
+//go:build linux
+
+package shell
+
+import "golang.org/x/sys/unix"
+
+func getTermios(fd int) (*unix.Termios, error) {
+	return unix.IoctlGetTermios(fd, unix.TCGETS)
+}
+
+func setTermios(fd int, state *unix.Termios) error {
+	return unix.IoctlSetTermios(fd, unix.TCSETS, state)
+}

--- a/client/command/shell/terminal_no_pty_other.go
+++ b/client/command/shell/terminal_no_pty_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package shell
+
+func configureNoPTYTerminal(_ int, _ byte) (func() error, error) {
+	return func() error { return nil }, nil
+}

--- a/client/command/shell/terminal_no_pty_solaris.go
+++ b/client/command/shell/terminal_no_pty_solaris.go
@@ -1,0 +1,13 @@
+//go:build solaris
+
+package shell
+
+import "golang.org/x/sys/unix"
+
+func getTermios(fd int) (*unix.Termios, error) {
+	return unix.IoctlGetTermios(fd, unix.TCGETA)
+}
+
+func setTermios(fd int, state *unix.Termios) error {
+	return unix.IoctlSetTermios(fd, unix.TCSETA, state)
+}

--- a/client/command/shell/terminal_no_pty_unix.go
+++ b/client/command/shell/terminal_no_pty_unix.go
@@ -1,0 +1,39 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package shell
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
+)
+
+func configureNoPTYTerminal(fd int, escapeByte byte) (func() error, error) {
+	if !term.IsTerminal(fd) {
+		return func() error { return nil }, nil
+	}
+
+	state, err := getTermios(fd)
+	if err != nil {
+		return nil, err
+	}
+	originalEOL, ok := replaceControlChar(state.Cc[:], unix.VEOL, escapeByte)
+	if !ok {
+		return nil, fmt.Errorf("VEOL index %d is outside terminal control characters", unix.VEOL)
+	}
+	if err := setTermios(fd, state); err != nil {
+		return nil, err
+	}
+
+	return func() error {
+		current, err := getTermios(fd)
+		if err != nil {
+			return err
+		}
+		if _, ok := replaceControlChar(current.Cc[:], unix.VEOL, originalEOL); !ok {
+			return fmt.Errorf("VEOL index %d is outside terminal control characters", unix.VEOL)
+		}
+		return setTermios(fd, current)
+	}, nil
+}

--- a/client/command/shell/terminal_no_pty_unix_test.go
+++ b/client/command/shell/terminal_no_pty_unix_test.go
@@ -1,0 +1,25 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package shell
+
+import (
+	"os"
+	"testing"
+)
+
+func TestConfigureNoPTYTerminalIgnoresNonTerminal(t *testing.T) {
+	stdin, stdout, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stdin.Close()
+	defer stdout.Close()
+
+	restore, err := configureNoPTYTerminal(int(stdin.Fd()), shellEscapeByte)
+	if err != nil {
+		t.Fatalf("configureNoPTYTerminal() error = %v", err)
+	}
+	if err := restore(); err != nil {
+		t.Fatalf("restore() error = %v", err)
+	}
+}

--- a/client/command/shell/terminal_test.go
+++ b/client/command/shell/terminal_test.go
@@ -1,0 +1,21 @@
+package shell
+
+import "testing"
+
+func TestReplaceControlChar(t *testing.T) {
+	controlChars := []uint8{1, 2, 3}
+	original, ok := replaceControlChar(controlChars, 1, shellEscapeByte)
+	if !ok {
+		t.Fatal("replaceControlChar() unexpectedly rejected a valid index")
+	}
+	if original != 2 {
+		t.Fatalf("replaceControlChar() original = %d, want 2", original)
+	}
+	if controlChars[1] != shellEscapeByte {
+		t.Fatalf("replaceControlChar() value = %d, want %d", controlChars[1], shellEscapeByte)
+	}
+
+	if _, ok := replaceControlChar(controlChars, len(controlChars), shellEscapeByte); ok {
+		t.Fatal("replaceControlChar() accepted an out-of-range index")
+	}
+}


### PR DESCRIPTION
## Summary

- configure Ctrl+] as a temporary canonical VEOL character for Unix no-PTY shell attachments
- preserve the existing raw-mode and resize behavior for PTY shells
- restore the original terminal setting after detach, shell exit, and input errors
- leave non-terminal stdin and unsupported client platforms unchanged

## Root cause

Windows shell sessions disable the remote PTY. The Sliver client previously coupled local raw terminal mode to remote PTY support, so Unix clients stayed in canonical mode for these sessions. As a result, Ctrl+] was echoed and buffered until Enter even though the shell I/O loop expects byte 0x1d immediately.

## Implementation

The shell attachment now configures local terminal handling independently from remote PTY support. Unix no-PTY sessions temporarily set VEOL to Ctrl+], retaining canonical echo and line editing while releasing the escape byte immediately. Restoration reads the current terminal state and resets only the original VEOL value.

## Risk

The new behavior is limited to no-PTY attachments with terminal stdin on supported Unix clients. Piped stdin is detected and left untouched. PTY sessions retain their existing raw-mode path.

## Validation

- gofmt on all touched Go files
- go test ./client/command/shell (Ubuntu WSL)
- GOOS=darwin CGO_ENABLED=0 go test -exec /bin/true ./client/command/shell

Fixes #2307
