### PR TITLE
fix(client): pass through extension arguments

### DIFF
--- a/client/command/extensions/argparser.go
+++ b/client/command/extensions/argparser.go
@@ -87,7 +87,11 @@ func bofSetupAndParseFlags(args []string, ext *ExtCommand) (*flag.FlagSet,
 	}
 
 	// Parse the arguments
-	if err := fs.Parse(args); err != nil {
+	normalizedArgs, err := normalizeBOFArguments(args, ext)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	if err := fs.Parse(normalizedArgs); err != nil {
 		return nil, nil, nil, nil, nil, nil, err
 	}
 

--- a/client/command/extensions/argument_passthrough_test.go
+++ b/client/command/extensions/argument_passthrough_test.go
@@ -1,0 +1,213 @@
+package extensions
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/bishopfox/sliver/client/console"
+	consts "github.com/bishopfox/sliver/client/constants"
+	"github.com/spf13/cobra"
+)
+
+func newTestExtensionCommand(t *testing.T) (*cobra.Command, *cobra.Command) {
+	t.Helper()
+
+	previous := loadedExtensions
+	loadedExtensions = map[string]*ExtCommand{}
+	t.Cleanup(func() {
+		loadedExtensions = previous
+	})
+
+	root := &cobra.Command{Use: "root", SilenceErrors: true, SilenceUsage: true}
+	root.AddGroup(&cobra.Group{ID: consts.ExtensionHelpGroup, Title: "Extensions"})
+	ExtensionRegisterCommand(&ExtCommand{
+		CommandName: "delegationbof",
+		Help:        "Test BOF",
+		Arguments: []*extensionArgument{
+			{Name: "type", Type: "int", Desc: "Delegation type"},
+			{Name: "fqdn", Type: "string", Desc: "Child domain"},
+		},
+	}, root, &console.SliverClient{})
+
+	extensionCmd, _, err := root.Find([]string{"delegationbof"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root, extensionCmd
+}
+
+func TestExtensionRegisterCommandPassesThroughArguments(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		want        []string
+		wantTimeout int64
+		wantSave    bool
+	}{
+		{
+			name:        "named flags without separator",
+			args:        []string{"--type", "6", "--fqdn", "child.htb.local"},
+			want:        []string{"--type", "6", "--fqdn", "child.htb.local"},
+			wantTimeout: defaultTimeout,
+		},
+		{
+			name:        "named flags with existing separator",
+			args:        []string{"--", "--type", "6", "--fqdn", "child.htb.local"},
+			want:        []string{"--type", "6", "--fqdn", "child.htb.local"},
+			wantTimeout: defaultTimeout,
+		},
+		{
+			name:        "quoted value containing spaces",
+			args:        []string{"--type", "6", "--fqdn", "child domain.htb.local"},
+			want:        []string{"--type", "6", "--fqdn", "child domain.htb.local"},
+			wantTimeout: defaultTimeout,
+		},
+		{
+			name:        "positional arguments",
+			args:        []string{"6", "child.htb.local"},
+			want:        []string{"6", "child.htb.local"},
+			wantTimeout: defaultTimeout,
+		},
+		{
+			name:        "single dash extension flags",
+			args:        []string{"-type", "6", "-fqdn", "child.htb.local"},
+			want:        []string{"-type", "6", "-fqdn", "child.htb.local"},
+			wantTimeout: defaultTimeout,
+		},
+		{
+			name:        "Sliver flags before extension arguments",
+			args:        []string{"--timeout", "90", "--save", "--type", "6", "--fqdn", "child.htb.local"},
+			want:        []string{"--type", "6", "--fqdn", "child.htb.local"},
+			wantTimeout: 90,
+			wantSave:    true,
+		},
+		{
+			name:        "Sliver flags before existing separator",
+			args:        []string{"-t90", "-s", "--", "--type", "6", "--fqdn", "child.htb.local"},
+			want:        []string{"--type", "6", "--fqdn", "child.htb.local"},
+			wantTimeout: 90,
+			wantSave:    true,
+		},
+		{
+			name:        "Sliver-looking flag after extension arguments",
+			args:        []string{"--type", "6", "--timeout", "12"},
+			want:        []string{"--type", "6", "--timeout", "12"},
+			wantTimeout: defaultTimeout,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root, extensionCmd := newTestExtensionCommand(t)
+
+			var got []string
+			var parseErr error
+			var helpRequested bool
+			extensionCmd.Run = func(cmd *cobra.Command, args []string) {
+				got, helpRequested, parseErr = parseExtensionCommandArgs(cmd, args)
+			}
+
+			root.SetArgs(append([]string{"delegationbof"}, test.args...))
+			if err := root.Execute(); err != nil {
+				t.Fatal(err)
+			}
+			if parseErr != nil {
+				t.Fatal(parseErr)
+			}
+			if helpRequested {
+				t.Fatal("help unexpectedly requested")
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("extension args = %#v, want %#v", got, test.want)
+			}
+
+			timeout, err := extensionCmd.Flags().GetInt64("timeout")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if timeout != test.wantTimeout {
+				t.Fatalf("timeout = %d, want %d", timeout, test.wantTimeout)
+			}
+			save, err := extensionCmd.Flags().GetBool("save")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if save != test.wantSave {
+				t.Fatalf("save = %v, want %v", save, test.wantSave)
+			}
+		})
+	}
+}
+
+func TestExtensionCommandHelpShowsDirectAndLegacySyntax(t *testing.T) {
+	_, extensionCmd := newTestExtensionCommand(t)
+
+	if !strings.Contains(extensionCmd.Use, "delegationbof --type TYPE --fqdn FQDN") {
+		t.Fatalf("Use = %q", extensionCmd.Use)
+	}
+	if !strings.Contains(extensionCmd.Example, "delegationbof --type TYPE --fqdn FQDN") {
+		t.Fatalf("Example does not show direct syntax: %q", extensionCmd.Example)
+	}
+	if !strings.Contains(extensionCmd.Example, "delegationbof -- --type TYPE --fqdn FQDN") {
+		t.Fatalf("Example does not show legacy syntax: %q", extensionCmd.Example)
+	}
+}
+
+func TestBOFSetupAndParseFlagsAcceptsNamedAndPositionalArguments(t *testing.T) {
+	ext := &ExtCommand{
+		Arguments: []*extensionArgument{
+			{Name: "type", Type: "int"},
+			{Name: "fqdn", Type: "string"},
+		},
+	}
+	tests := []struct {
+		name     string
+		args     []string
+		wantFQDN string
+	}{
+		{
+			name:     "double dash flags",
+			args:     []string{"--type", "6", "--fqdn", "child.htb.local"},
+			wantFQDN: "child.htb.local",
+		},
+		{
+			name:     "existing separator",
+			args:     []string{"--", "--type", "6", "--fqdn", "child.htb.local"},
+			wantFQDN: "child.htb.local",
+		},
+		{
+			name:     "single dash flags",
+			args:     []string{"-type", "6", "-fqdn", "child.htb.local"},
+			wantFQDN: "child.htb.local",
+		},
+		{
+			name:     "quoted value containing spaces",
+			args:     []string{"--type", "6", "--fqdn", "child domain.htb.local"},
+			wantFQDN: "child domain.htb.local",
+		},
+		{
+			name:     "positional arguments",
+			args:     []string{"6", "child.htb.local"},
+			wantFQDN: "child.htb.local",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fs, stringValues, _, intValues, _, _, err := bofSetupAndParseFlags(test.args, ext)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bofFlagWasProvided(fs, "type") || !bofFlagWasProvided(fs, "fqdn") {
+				t.Fatal("normalized BOF flags were not marked as provided")
+			}
+			if got := *intValues["type"]; got != 6 {
+				t.Fatalf("type = %d, want 6", got)
+			}
+			if got := *stringValues["fqdn"]; got != test.wantFQDN {
+				t.Fatalf("fqdn = %q, want %q", got, test.wantFQDN)
+			}
+		})
+	}
+}

--- a/client/command/extensions/command_args.go
+++ b/client/command/extensions/command_args.go
@@ -1,0 +1,136 @@
+package extensions
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func parseExtensionCommandArgs(cmd *cobra.Command, args []string) ([]string, bool, error) {
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "--":
+			return append([]string(nil), args[index+1:]...), false, nil
+		case arg == "--help" || arg == "-h":
+			return nil, true, nil
+		case arg == "--save" || arg == "-s":
+			if err := setExtensionCommandFlag(cmd, "save", "true"); err != nil {
+				return nil, false, err
+			}
+		case strings.HasPrefix(arg, "--save="):
+			if err := setExtensionCommandFlag(cmd, "save", strings.TrimPrefix(arg, "--save=")); err != nil {
+				return nil, false, err
+			}
+		case strings.HasPrefix(arg, "-s="):
+			if err := setExtensionCommandFlag(cmd, "save", strings.TrimPrefix(arg, "-s=")); err != nil {
+				return nil, false, err
+			}
+		case arg == "--timeout" || arg == "-t":
+			if index+1 >= len(args) {
+				return nil, false, fmt.Errorf("%s requires a value", arg)
+			}
+			index++
+			if err := setExtensionCommandFlag(cmd, "timeout", args[index]); err != nil {
+				return nil, false, err
+			}
+		case strings.HasPrefix(arg, "--timeout="):
+			if err := setExtensionCommandFlag(cmd, "timeout", strings.TrimPrefix(arg, "--timeout=")); err != nil {
+				return nil, false, err
+			}
+		case strings.HasPrefix(arg, "-t="):
+			if err := setExtensionCommandFlag(cmd, "timeout", strings.TrimPrefix(arg, "-t=")); err != nil {
+				return nil, false, err
+			}
+		case isAttachedTimeoutShorthand(arg):
+			if err := setExtensionCommandFlag(cmd, "timeout", strings.TrimPrefix(arg, "-t")); err != nil {
+				return nil, false, err
+			}
+		default:
+			return append([]string(nil), args[index:]...), false, nil
+		}
+	}
+	return []string{}, false, nil
+}
+
+func setExtensionCommandFlag(cmd *cobra.Command, name string, value string) error {
+	if err := cmd.Flags().Set(name, value); err != nil {
+		return fmt.Errorf("invalid Sliver --%s value %q: %w", name, value, err)
+	}
+	return nil
+}
+
+func isAttachedTimeoutShorthand(arg string) bool {
+	if !strings.HasPrefix(arg, "-t") || len(arg) <= 2 {
+		return false
+	}
+	_, err := strconv.ParseInt(strings.TrimPrefix(arg, "-t"), 10, 64)
+	return err == nil
+}
+
+func normalizeBOFArguments(args []string, ext *ExtCommand) ([]string, error) {
+	argumentsByName := make(map[string]*extensionArgument, len(ext.Arguments))
+	for _, argument := range ext.Arguments {
+		argumentsByName[argument.Name] = argument
+	}
+
+	normalized := make([]string, 0, len(args))
+	provided := make(map[string]bool, len(ext.Arguments))
+	positionalIndex := 0
+
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		if arg == "--" {
+			continue
+		}
+
+		name, value, hasValue, isFlag := splitBOFFlag(arg)
+		if isFlag {
+			if _, ok := argumentsByName[name]; !ok {
+				return nil, fmt.Errorf("flag provided but not defined: -%s", name)
+			}
+			if !hasValue {
+				if index+1 >= len(args) {
+					return nil, fmt.Errorf("flag needs an argument: -%s", name)
+				}
+				index++
+				value = args[index]
+			}
+		} else {
+			for positionalIndex < len(ext.Arguments) && provided[ext.Arguments[positionalIndex].Name] {
+				positionalIndex++
+			}
+			if positionalIndex >= len(ext.Arguments) {
+				return nil, fmt.Errorf("unexpected positional argument %q", arg)
+			}
+			name = ext.Arguments[positionalIndex].Name
+			value = arg
+			positionalIndex++
+		}
+
+		normalized = append(normalized, "-"+name, value)
+		provided[name] = true
+	}
+
+	return normalized, nil
+}
+
+func splitBOFFlag(arg string) (name string, value string, hasValue bool, isFlag bool) {
+	if len(arg) < 2 || arg[0] != '-' || arg == "--" {
+		return "", "", false, false
+	}
+
+	nameValue := strings.TrimPrefix(arg, "-")
+	nameValue = strings.TrimPrefix(nameValue, "-")
+	if nameValue == "" {
+		return "", "", false, false
+	}
+
+	parts := strings.SplitN(nameValue, "=", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1], true, true
+	}
+	return parts[0], "", false, true
+}

--- a/client/command/extensions/load.go
+++ b/client/command/extensions/load.go
@@ -322,6 +322,9 @@ func ExtensionRegisterCommand(extCmd *ExtCommand, cmd *cobra.Command, con *conso
 		if arg.Optional {
 			usage.WriteString("[")
 		}
+		usage.WriteString("--")
+		usage.WriteString(arg.Name)
+		usage.WriteString(" ")
 		usage.WriteString(strings.ToUpper(arg.Name))
 		if arg.Optional {
 			usage.WriteString("]")
@@ -362,13 +365,33 @@ func ExtensionRegisterCommand(extCmd *ExtCommand, cmd *cobra.Command, con *conso
 		longHelp.WriteString(fmt.Sprintf("%s (%s):\t%s%s", strings.ToUpper(arg.Name), aType, optStr, arg.Desc))
 	}
 
+	example := ""
+	if len(extCmd.Arguments) > 0 {
+		longHelp.WriteString("\n\n[[.Bold]]Syntax:[[.Normal]] Pass extension arguments directly. The legacy -- separator is also supported.\n")
+		argumentUsage := strings.TrimPrefix(usage.String(), extCmd.CommandName+" ")
+		example = fmt.Sprintf("  %s\n  %s -- %s", usage.String(), extCmd.CommandName, argumentUsage)
+	}
+
 	// Command
 	extensionCmd := &cobra.Command{
-		Use:   usage.String(),
-		Short: extCmd.Help,
-		Long:  help.FormatHelpTmpl(longHelp.String()),
+		Use:                usage.String(),
+		Short:              extCmd.Help,
+		Long:               help.FormatHelpTmpl(longHelp.String()),
+		Example:            example,
+		DisableFlagParsing: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			runExtensionCmd(cmd, con, args)
+			extensionArgs, helpRequested, err := parseExtensionCommandArgs(cmd, args)
+			if err != nil {
+				con.PrintErrorf("Extension args error: %s\n", err)
+				return
+			}
+			if helpRequested {
+				if err := cmd.Help(); err != nil {
+					con.PrintErrorf("Extension help error: %s\n", err)
+				}
+				return
+			}
+			runExtensionCmd(cmd, con, extensionArgs)
 		},
 		GroupID:     consts.ExtensionHelpGroup,
 		Annotations: makeCommandPlatformFilters(extCmd),
@@ -379,7 +402,6 @@ func ExtensionRegisterCommand(extCmd *ExtCommand, cmd *cobra.Command, con *conso
 	f.BoolP("save", "s", false, "Save output to disk")
 	f.Int64P("timeout", "t", defaultTimeout, "command timeout in seconds")
 	extensionCmd.Flags().AddFlagSet(f)
-	extensionCmd.Flags().ParseErrorsWhitelist.UnknownFlags = true
 
 	// Completions
 	comps := carapace.Gen(extensionCmd)
@@ -751,8 +773,8 @@ func checkExtensionArgs(extCmd *ExtCommand) error {
 
 // makeExtensionArgCompleter builds the positional and dash arguments completer for the extension.
 // It provides completion for:
-// 1. Positional arguments (before --)
-// 2. Flag-style arguments after -- (e.g., --process, --shellcode)
+// 1. Positional arguments
+// 2. Flag-style arguments with or without -- (e.g., --process, --shellcode)
 func makeExtensionArgCompleter(extCmd *ExtCommand, _ *cobra.Command, comps *carapace.Carapace) {
 	var actions []carapace.Action
 
@@ -782,7 +804,7 @@ func makeExtensionArgCompleter(extCmd *ExtCommand, _ *cobra.Command, comps *cara
 
 	comps.PositionalCompletion(actions...)
 
-	// Add dash completion for flag-style arguments after --
+	// Add dash completion for flag-style arguments
 	// The extension arguments are parsed as flags (--name value) by argparser.go
 	if len(extCmd.Arguments) > 0 {
 		// Pre-build the flag completions at registration time (not in a callback)


### PR DESCRIPTION
## Summary

- pass extension-owned arguments through without requiring Cobra's -- separator
- consume Sliver-owned help, save, and timeout flags only while they lead the argument list
- preserve the existing -- separator for compatibility and flag-name collisions
- normalize BOF single-dash, double-dash, equals, and positional forms against manifest argument order
- update generated extension usage and examples to show direct syntax

## Root cause

Dynamic extension commands enabled pflag's unknown-flag allowlist. That setting suppresses parse errors, but pflag removes each unknown flag and usually its following value instead of retaining them in the argument slice. Manifest-defined BOF flags therefore never reached the BOF parser unless Cobra parsing was terminated with -- first.

## Implementation

Dynamic extension commands now opt out of Cobra flag parsing. A small prefix parser handles Sliver's own --timeout/-t, --save/-s, and help flags before returning the remaining tokens unchanged to the extension.

The BOF parser normalizes manifest-defined named or positional values before its existing typed packing step. Quoted values are already delivered as single tokens and remain intact.

Leading Sliver flags retain ownership. After the first extension argument, or after --, all remaining tokens belong to the extension. This keeps the old separator useful when an extension argument name collides with a Sliver flag.

## Validation

- reproduced the pre-fix callback receiving no arguments for delegationbof --type 6 --fqdn child.htb.local
- gofmt on all touched Go files
- go test ./client/command/extensions
- go test -tags=client,osusergo,netgo,go_sqlite ./client/command/extensions

Coverage includes named flags with and without --, quoted values containing spaces, positional arguments, single- and double-dash forms, leading Sliver flags, and generated help examples.

Fixes #2309
