### PR TITLE
fix(server): prevent nil session dereference crash in tunnel/socks/pivot paths

### DIFF
--- a/server/core/pivots.go
+++ b/server/core/pivots.go
@@ -106,9 +106,14 @@ func (e *PivotGraphEntry) ToProtobuf() *clientpb.PivotGraphEntry {
 	for _, child := range e.Children {
 		children = append(children, child.ToProtobuf())
 	}
+	session := Sessions.Get(e.SessionID)
+	var sessionPB *clientpb.Session
+	if session != nil {
+		sessionPB = session.ToProtobuf()
+	}
 	return &clientpb.PivotGraphEntry{
 		PeerID:   e.PeerID,
-		Session:  Sessions.Get(e.SessionID).ToProtobuf(),
+		Session:  sessionPB,
 		Name:     e.Name,
 		Children: children,
 	}

--- a/server/core/socks.go
+++ b/server/core/socks.go
@@ -49,9 +49,12 @@ type tcpTunnel struct {
 	mutex   *sync.Mutex
 }
 
-func (t *tcpTunnel) Create(sessionID string) *TcpTunnel {
+func (t *tcpTunnel) Create(sessionID string) (*TcpTunnel, error) {
 	tunnelID := NewTunnelID()
 	session := Sessions.Get(sessionID)
+	if session == nil {
+		return nil, ErrInvalidSessionID
+	}
 	tunnel := &TcpTunnel{
 		ID:        tunnelID,
 		SessionID: session.ID,
@@ -62,7 +65,7 @@ func (t *tcpTunnel) Create(sessionID string) *TcpTunnel {
 	defer t.mutex.Unlock()
 	t.tunnels[tunnel.ID] = tunnel
 
-	return tunnel
+	return tunnel, nil
 }
 
 func (t *tcpTunnel) Close(tunnelID uint64) error {

--- a/server/core/tunnels.go
+++ b/server/core/tunnels.go
@@ -39,6 +39,9 @@ var (
 
 	// ErrInvalidTunnelID - Invalid tunnel ID value
 	ErrInvalidTunnelID = errors.New("invalid tunnel ID")
+
+	// ErrInvalidSessionID - Invalid session ID value
+	ErrInvalidSessionID = errors.New("invalid session ID")
 )
 
 const (
@@ -105,9 +108,12 @@ type tunnels struct {
 	mutex   *sync.Mutex
 }
 
-func (t *tunnels) Create(sessionID string) *Tunnel {
+func (t *tunnels) Create(sessionID string) (*Tunnel, error) {
 	tunnelID := NewTunnelID()
 	session := Sessions.Get(sessionID)
+	if session == nil {
+		return nil, ErrInvalidSessionID
+	}
 
 	tunnel := NewTunnel(
 		tunnelID,
@@ -118,7 +124,7 @@ func (t *tunnels) Create(sessionID string) *Tunnel {
 	defer t.mutex.Unlock()
 	t.tunnels[tunnel.ID] = tunnel
 
-	return tunnel
+	return tunnel, nil
 }
 
 // ScheduleClose - schedules a close for tunnel, must be called as routine.

--- a/server/core/tunnels_test.go
+++ b/server/core/tunnels_test.go
@@ -1,0 +1,83 @@
+package core
+
+import (
+	"testing"
+)
+
+func newTestSession() *Session {
+	conn := NewImplantConnection("mtls", "test-conn")
+	return NewSession(conn)
+}
+
+func TestTunnelsCreateUnknownSession(t *testing.T) {
+	tunnel, err := Tunnels.Create("does-not-exist")
+	if err == nil {
+		t.Fatalf("expected error for unknown session, got tunnel %+v", tunnel)
+	}
+	if tunnel != nil {
+		t.Fatalf("expected nil tunnel on error, got %+v", tunnel)
+	}
+}
+
+func TestTunnelsCreateKnownSession(t *testing.T) {
+	session := newTestSession()
+	Sessions.Add(session)
+	defer Sessions.Remove(session.ID)
+
+	tunnel, err := Tunnels.Create(session.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tunnel == nil {
+		t.Fatal("expected non-nil tunnel")
+	}
+	if tunnel.SessionID != session.ID {
+		t.Fatalf("expected SessionID %q, got %q", session.ID, tunnel.SessionID)
+	}
+}
+
+func TestSocksTunnelsCreateUnknownSession(t *testing.T) {
+	tunnel, err := SocksTunnels.Create("does-not-exist")
+	if err == nil {
+		t.Fatalf("expected error for unknown session, got tunnel %+v", tunnel)
+	}
+	if tunnel != nil {
+		t.Fatalf("expected nil tunnel on error, got %+v", tunnel)
+	}
+}
+
+func TestSocksTunnelsCreateKnownSession(t *testing.T) {
+	session := newTestSession()
+	Sessions.Add(session)
+	defer Sessions.Remove(session.ID)
+
+	tunnel, err := SocksTunnels.Create(session.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tunnel == nil {
+		t.Fatal("expected non-nil tunnel")
+	}
+	if tunnel.SessionID != session.ID {
+		t.Fatalf("expected SessionID %q, got %q", session.ID, tunnel.SessionID)
+	}
+}
+
+func TestPivotGraphEntryToProtobufUnknownSession(t *testing.T) {
+	entry := &PivotGraphEntry{
+		PeerID:    1,
+		SessionID: "does-not-exist",
+		Name:      "ghost",
+		Children:  map[int64]*PivotGraphEntry{},
+	}
+	pb := entry.ToProtobuf()
+	if pb == nil {
+		t.Fatal("expected non-nil protobuf entry")
+	}
+	if pb.Session != nil {
+		t.Fatalf("expected nil session for unknown session, got %+v", pb.Session)
+	}
+	if pb.PeerID != 1 || pb.Name != "ghost" {
+		t.Fatalf("unexpected entry fields: %+v", pb)
+	}
+}

--- a/server/rpc/errors.go
+++ b/server/rpc/errors.go
@@ -75,6 +75,8 @@ func rpcError(err error) error {
 		return status.Error(codes.Unimplemented, err.Error())
 	case errors.Is(err, core.ErrInvalidTunnelID):
 		return status.Error(codes.InvalidArgument, err.Error())
+	case errors.Is(err, core.ErrInvalidSessionID):
+		return status.Error(codes.InvalidArgument, err.Error())
 	case errors.Is(err, core.ErrDuplicateHosts):
 		return status.Error(codes.AlreadyExists, err.Error())
 	case errors.Is(err, core.ErrDuplicateExternalBuilderName):

--- a/server/rpc/rpc-socks.go
+++ b/server/rpc/rpc-socks.go
@@ -402,7 +402,10 @@ func (s *Server) CreateSocks(ctx context.Context, req *sliverpb.Socks) (*sliverp
 	if session == nil {
 		return nil, ErrInvalidSessionID
 	}
-	tunnel := core.SocksTunnels.Create(session.ID)
+	tunnel, err := core.SocksTunnels.Create(session.ID)
+	if err != nil {
+		return nil, rpcError(err)
+	}
 	if tunnel == nil {
 		return nil, ErrTunnelInitFailure
 	}

--- a/server/rpc/rpc-tunnel.go
+++ b/server/rpc/rpc-tunnel.go
@@ -97,7 +97,10 @@ func (s *Server) CreateTunnel(ctx context.Context, req *sliverpb.Tunnel) (*slive
 	if session == nil {
 		return nil, ErrInvalidSessionID
 	}
-	tunnel := core.Tunnels.Create(session.ID)
+	tunnel, err := core.Tunnels.Create(session.ID)
+	if err != nil {
+		return nil, rpcError(err)
+	}
 	if tunnel == nil {
 		return nil, ErrTunnelInitFailure
 	}
@@ -179,6 +182,10 @@ func (s *Server) TunnelData(stream rpcpb.SliverRPC_TunnelDataServer) error {
 						if ok {
 							tunnelLog.Debugf("Tunnel %d: Resending cached msg: %d", tunnel.ID, tunnelData.Ack)
 							session := core.Sessions.Get(tunnel.SessionID)
+							if session == nil {
+								tunnelLog.Warnf("Tunnel %d: session not found, dropping resend", tunnel.ID)
+								continue
+							}
 							data, err := proto.Marshal(origtunnelData)
 							if err != nil {
 								// {{if .Config.Debug}}
@@ -207,6 +214,10 @@ func (s *Server) TunnelData(stream rpcpb.SliverRPC_TunnelDataServer) error {
 				session := core.Sessions.Get(tunnel.SessionID)
 				for data := range tunnel.ToImplant {
 					tunnelLog.Debugf("Tunnel %d: To implant %d byte(s), seq: %d", tunnel.ID, len(data), tunnel.ToImplantSequence)
+					if session == nil {
+						tunnelLog.Warnf("Tunnel %d: session not found, dropping data to implant", tunnel.ID)
+						continue
+					}
 					tunnelData := sliverpb.TunnelData{
 						Sequence:  tunnel.ToImplantSequence,
 						TunnelID:  tunnel.ID,
@@ -233,9 +244,11 @@ func (s *Server) TunnelData(stream rpcpb.SliverRPC_TunnelDataServer) error {
 					Data:      make([]byte, 0),
 					Closed:    true,
 				})
-				session.Connection.Send <- &sliverpb.Envelope{
-					Type: sliverpb.MsgTunnelData,
-					Data: data,
+				if session != nil {
+					session.Connection.Send <- &sliverpb.Envelope{
+						Type: sliverpb.MsgTunnelData,
+						Data: data,
+					}
 				}
 			}()
 


### PR DESCRIPTION
## Summary

Fixes a server crash (nil pointer dereference) that matches https://github.com/BishopFox/sliver/issues/1969: when implant sessions die while socks5/tunnel/pivot operations are in flight, the whole server process goes down and all sessions are lost.

### Root cause

`Sessions.Get()` returns nil once a session has been removed (implant timeout / death cleanup). Two functions dereferenced the result unconditionally:

- `core/tunnels.Create` (server/core/tunnels.go)
- `core.SocksTunnels.Create` (server/core/socks.go)

The RPC handlers check for a nil session first (`rpc-socks.go`, `rpc-tunnel.go`), but there is a TOCTOU window: the session can be removed between the handler's check and the `Create` call. Since the gRPC server installs no panic-recovery interceptor, the panic propagates and kills the entire server.

### Changes

- `core/tunnels.Create` / `core.SocksTunnels.Create` now return `(*Tunnel, error)` / `(*TcpTunnel, error)` and fail with a new `core.ErrInvalidSessionID` when the session is gone; the RPC handlers propagate it via `rpcError()` (mapped to `codes.InvalidArgument`).
- The tunnel data goroutines in `rpc-tunnel.go` (resend path, to-implant sender, close notification) no longer dereference `session.Connection` when the session has vanished; they log and skip instead.
- `pivots.go` `PivotGraphEntry.ToProtobuf` tolerates a session that disappeared between graph construction and serialization (returns entry with nil Session instead of panicking).

### Testing

Added 5 unit tests in `server/core/tunnels_test.go` covering unknown-session creation for both tunnel types and the pivot graph serialization. Ran:

```
$ go test -tags "server,go_sqlite" ./server/core/ ./server/rpc/
ok  github.com/bishopfox/sliver/server/core
ok  github.com/bishopfox/sliver/server/rpc
```

All commits are signed.