### PR TITLE
fix(extensions): keep BOF/extension args intact without "--"

### DIFF
--- a/client/command/extensions/args.go
+++ b/client/command/extensions/args.go
@@ -25,37 +25,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Extension commands are registered with cobra's DisableFlagParsing enabled (see
-// ExtensionRegisterCommand). Without it, pflag parses the command line first and,
-// because the extension's own flags (e.g. --type, --fqdn) are unknown to pflag,
-// ParseErrorsWhitelist.UnknownFlags causes pflag to silently drop each unknown
-// flag together with its value. The BOF argument parser therefore never sees them
-// and operators are forced to inject cobra's "--" separator (#2309).
-//
-// Running with flag parsing disabled means cobra hands us the raw, unstripped
-// argument slice, and we separate Sliver-owned flags from the extension's own
-// arguments ourselves. This keeps both forms working:
-//
-//	delegationbof --timeout 30 --type 6 --fqdn child.htb.local
-//	delegationbof -- --type 6 --fqdn child.htb.local   (existing workaround)
-//
-// while preserving quoted values, positional arguments and single/double-dash
-// flag forms for the extension parser to handle.
-var extensionOwnedBoolFlags = map[string]bool{
-	"save": true,
-}
-
-var extensionOwnedIntFlags = map[string]bool{
-	"timeout": true,
-}
-
 // splitExtensionArgs separates Sliver-owned flags (--save, --timeout, --help)
 // from the extension's own arguments in a raw argument slice.
 //
+// Extension commands run with cobra's DisableFlagParsing enabled (see
+// ExtensionRegisterCommand). Without it, pflag parses the command line first
+// and, because the extension's own flags (e.g. --type, --fqdn) are unknown to
+// pflag, ParseErrorsWhitelist.UnknownFlags causes pflag to silently drop each
+// unknown flag together with its value; the BOF argument parser never saw them
+// unless the operator injected cobra's "--" separator (#2309). Running with
+// flag parsing disabled hands us the raw, unstripped slice, so we separate the
+// Sliver-owned flags ourselves here.
+//
 // A literal "--" stops Sliver-flag scanning; every token after it is passed
 // through verbatim, preserving the long-standing workaround syntax. Unknown
-// tokens (including the extension's named flags, their values and positional
-// arguments) are never consumed or reordered.
+// tokens (the extension's named flags, their values and positional arguments)
+// are never consumed or reordered, so both forms work:
+//
+//	delegationbof --timeout 30 --type 6 --fqdn child.htb.local
+//	delegationbof -- --type 6 --fqdn child.htb.local
 func splitExtensionArgs(raw []string) (save bool, timeout int64, help bool, extArgs []string) {
 	timeout = defaultTimeout
 	extArgs = make([]string, 0, len(raw))

--- a/client/command/extensions/args.go
+++ b/client/command/extensions/args.go
@@ -1,0 +1,135 @@
+package extensions
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2021  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Extension commands are registered with cobra's DisableFlagParsing enabled (see
+// ExtensionRegisterCommand). Without it, pflag parses the command line first and,
+// because the extension's own flags (e.g. --type, --fqdn) are unknown to pflag,
+// ParseErrorsWhitelist.UnknownFlags causes pflag to silently drop each unknown
+// flag together with its value. The BOF argument parser therefore never sees them
+// and operators are forced to inject cobra's "--" separator (#2309).
+//
+// Running with flag parsing disabled means cobra hands us the raw, unstripped
+// argument slice, and we separate Sliver-owned flags from the extension's own
+// arguments ourselves. This keeps both forms working:
+//
+//	delegationbof --timeout 30 --type 6 --fqdn child.htb.local
+//	delegationbof -- --type 6 --fqdn child.htb.local   (existing workaround)
+//
+// while preserving quoted values, positional arguments and single/double-dash
+// flag forms for the extension parser to handle.
+var extensionOwnedBoolFlags = map[string]bool{
+	"save": true,
+}
+
+var extensionOwnedIntFlags = map[string]bool{
+	"timeout": true,
+}
+
+// splitExtensionArgs separates Sliver-owned flags (--save, --timeout, --help)
+// from the extension's own arguments in a raw argument slice.
+//
+// A literal "--" stops Sliver-flag scanning; every token after it is passed
+// through verbatim, preserving the long-standing workaround syntax. Unknown
+// tokens (including the extension's named flags, their values and positional
+// arguments) are never consumed or reordered.
+func splitExtensionArgs(raw []string) (save bool, timeout int64, help bool, extArgs []string) {
+	timeout = defaultTimeout
+	extArgs = make([]string, 0, len(raw))
+
+	passthrough := false
+	for i := 0; i < len(raw); i++ {
+		tok := raw[i]
+
+		// Once we have seen "--", copy everything through untouched so the
+		// existing `ext -- --foo bar` syntax keeps working identically.
+		if passthrough {
+			extArgs = append(extArgs, tok)
+			continue
+		}
+
+		switch {
+		case tok == "--":
+			passthrough = true
+
+		case tok == "--help" || tok == "-h":
+			help = true
+
+		case tok == "--save" || tok == "-s":
+			save = true
+
+		case strings.HasPrefix(tok, "--save="):
+			save = parseBoolValue(tok[len("--save="):], true)
+
+		case tok == "--timeout" || tok == "-t":
+			// Consume the following token as the value, mirroring pflag. If no
+			// token follows, leave the default in place rather than erroring.
+			if i+1 < len(raw) {
+				if n, err := strconv.ParseInt(raw[i+1], 10, 64); err == nil {
+					timeout = n
+				}
+				i++
+			}
+
+		case strings.HasPrefix(tok, "--timeout="):
+			if n, err := strconv.ParseInt(tok[len("--timeout="):], 10, 64); err == nil {
+				timeout = n
+			}
+
+		default:
+			// Not a Sliver-owned flag: hand it to the extension parser untouched.
+			extArgs = append(extArgs, tok)
+		}
+	}
+
+	return save, timeout, help, extArgs
+}
+
+// applyOwnedFlags republishes the manually parsed Sliver-owned flag values back
+// onto the command's flag set. DisableFlagParsing prevents pflag from populating
+// them, so helpers that read them via cmd.Flags() (notably ActiveTarget.Request,
+// which derives the gRPC timeout from --timeout) would otherwise observe only the
+// defaults.
+func applyOwnedFlags(cmd *cobra.Command, save bool, timeout int64) {
+	if flag := cmd.Flags().Lookup("timeout"); flag != nil {
+		_ = flag.Value.Set(strconv.FormatInt(timeout, 10))
+	}
+	if flag := cmd.Flags().Lookup("save"); flag != nil {
+		_ = flag.Value.Set(strconv.FormatBool(save))
+	}
+}
+
+// parseBoolValue parses a --flag=value bool, defaulting to defVal when the value
+// is empty (the bare-flag form). It accepts the same spellings pflag does.
+func parseBoolValue(v string, defVal bool) bool {
+	switch strings.ToLower(v) {
+	case "", "true", "t", "1":
+		return true
+	case "false", "f", "0":
+		return false
+	}
+	return defVal
+}

--- a/client/command/extensions/args_test.go
+++ b/client/command/extensions/args_test.go
@@ -1,0 +1,149 @@
+package extensions
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2021  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestSplitExtensionArgs covers the argument-passthrough regression from #2309:
+// the extension's own named flags must reach the BOF parser intact regardless of
+// the cobra "--" separator, while Sliver-owned flags are still honoured.
+func TestSplitExtensionArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      []string
+		save    bool
+		timeout int64
+		help    bool
+		extArgs []string
+	}{
+		{
+			name:    "named extension flags without -- separator (#2309 regression)",
+			in:      []string{"--type", "6", "--fqdn", "child.htb.local"},
+			timeout: defaultTimeout,
+			extArgs: []string{"--type", "6", "--fqdn", "child.htb.local"},
+		},
+		{
+			name:    "named extension flags with -- separator (existing workaround)",
+			in:      []string{"--", "--type", "6", "--fqdn", "child.htb.local"},
+			timeout: defaultTimeout,
+			extArgs: []string{"--type", "6", "--fqdn", "child.htb.local"},
+		},
+		{
+			name:    "sliver-owned flags precede extension arguments",
+			in:      []string{"--timeout", "30", "--save", "--type", "6"},
+			save:    true,
+			timeout: 30,
+			extArgs: []string{"--type", "6"},
+		},
+		{
+			name:    "quoted value containing spaces stays a single argument",
+			in:      []string{"--name", "hello world", "--type", "6"},
+			timeout: defaultTimeout,
+			extArgs: []string{"--name", "hello world", "--type", "6"},
+		},
+		{
+			name:    "positional extension arguments are preserved",
+			in:      []string{"foo", "bar", "baz"},
+			timeout: defaultTimeout,
+			extArgs: []string{"foo", "bar", "baz"},
+		},
+		{
+			name:    "single-dash and double-dash forms are preserved",
+			in:      []string{"-type", "6", "--fqdn", "child.htb.local"},
+			timeout: defaultTimeout,
+			extArgs: []string{"-type", "6", "--fqdn", "child.htb.local"},
+		},
+		{
+			name:    "equals form for timeout",
+			in:      []string{"--timeout=120", "--type", "6"},
+			timeout: 120,
+			extArgs: []string{"--type", "6"},
+		},
+		{
+			name:    "short -s save flag",
+			in:      []string{"-s", "--type", "6"},
+			save:    true,
+			timeout: defaultTimeout,
+			extArgs: []string{"--type", "6"},
+		},
+		{
+			name:    "help flag is detected",
+			in:      []string{"--help"},
+			help:    true,
+			timeout: defaultTimeout,
+			extArgs: []string{},
+		},
+		{
+			name:    "empty input",
+			in:      nil,
+			timeout: defaultTimeout,
+			extArgs: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			save, timeout, help, extArgs := splitExtensionArgs(tc.in)
+
+			if save != tc.save {
+				t.Errorf("save: got %v, want %v", save, tc.save)
+			}
+			if timeout != tc.timeout {
+				t.Errorf("timeout: got %d, want %d", timeout, tc.timeout)
+			}
+			if help != tc.help {
+				t.Errorf("help: got %v, want %v", help, tc.help)
+			}
+			if !reflect.DeepEqual(extArgs, tc.extArgs) {
+				t.Errorf("extArgs: got %#v, want %#v", extArgs, tc.extArgs)
+			}
+		})
+	}
+}
+
+// TestParseBoolValue checks the --flag=value helper used for --save=value.
+func TestParseBoolValue(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", true},
+		{"true", true},
+		{"TRUE", true},
+		{"1", true},
+		{"t", true},
+		{"false", false},
+		{"0", false},
+		{"no", false}, // unsupported spellings keep the default
+	}
+	for _, tc := range cases {
+		got := parseBoolValue(tc.in, true)
+		// "no" is not a pflag spelling, so it falls through to the default (true).
+		want := tc.want
+		if tc.in == "no" {
+			want = true
+		}
+		if got != want {
+			t.Errorf("parseBoolValue(%q): got %v, want %v", tc.in, got, want)
+		}
+	}
+}

--- a/client/command/extensions/load.go
+++ b/client/command/extensions/load.go
@@ -370,8 +370,12 @@ func ExtensionRegisterCommand(extCmd *ExtCommand, cmd *cobra.Command, con *conso
 		Run: func(cmd *cobra.Command, args []string) {
 			runExtensionCmd(cmd, con, args)
 		},
-		GroupID:     consts.ExtensionHelpGroup,
-		Annotations: makeCommandPlatformFilters(extCmd),
+		GroupID: consts.ExtensionHelpGroup,
+		// DisableFlagParsing keeps the extension's own flags (which are unknown to
+		// pflag) from being silently stripped together with their values. We split
+		// Sliver-owned flags out of the raw slice ourselves in runExtensionCmd (#2309).
+		DisableFlagParsing: true,
+		Annotations:        makeCommandPlatformFilters(extCmd),
 	}
 
 	// Flags
@@ -379,7 +383,6 @@ func ExtensionRegisterCommand(extCmd *ExtCommand, cmd *cobra.Command, con *conso
 	f.BoolP("save", "s", false, "Save output to disk")
 	f.Int64P("timeout", "t", defaultTimeout, "command timeout in seconds")
 	extensionCmd.Flags().AddFlagSet(f)
-	extensionCmd.Flags().ParseErrorsWhitelist.UnknownFlags = true
 
 	// Completions
 	comps := carapace.Gen(extensionCmd)
@@ -529,6 +532,18 @@ func loadDep(goos string, goarch string, depName string, cmd *cobra.Command, con
 }
 
 func runExtensionCmd(cmd *cobra.Command, con *console.SliverClient, args []string) {
+	// The command runs with DisableFlagParsing, so args is the raw, unstripped
+	// slice. Separate Sliver-owned flags from the extension's own arguments and
+	// re-publish them on the flag set (so Request()'s --timeout still works),
+	// then feed only the extension arguments to the BOF/DLL parsers (#2309).
+	save, timeout, helpRequested, extArgs := splitExtensionArgs(args)
+	if helpRequested {
+		_ = cmd.Help()
+		return
+	}
+	applyOwnedFlags(cmd, save, timeout)
+	args = extArgs
+
 	var (
 		err           error
 		extensionArgs []byte


### PR DESCRIPTION
Fixes #2309.

Extension and BOF commands required `--` before any of their own named arguments, otherwise the arguments were silently dropped.

**Why this happens:** extension commands were registered with `ParseErrorsWhitelist.UnknownFlags = true`. When pflag meets an unknown flag — anything declared in the extension manifest, like `--type` — it discards the flag together with its value instead of keeping it as a positional argument. The BOF argument parser (which uses the stdlib `flag` package) therefore never saw those values unless the operator put `--` in front, which tells pflag to stop parsing.

**The fix:** the extension command now runs with `DisableFlagParsing`, so cobra hands `Run` the raw, unstripped argument slice. A small helper, `splitExtensionArgs` (new file `args.go`), walks that slice to pull out the Sliver-owned flags (`--save`, `--timeout`, `--help`) and passes everything else — named flags, their values, positional and quoted arguments — untouched to the BOF/DLL parser. The parsed `--save`/`--timeout` values are written back onto the flag set with `cmd.Flags().Set`, so `ActiveTarget.Request` (which derives the gRPC timeout from `--timeout`) and any other `cmd.Flags()` reader still observe them. `--help`/`-h` is handled explicitly, since pflag no longer intercepts it under `DisableFlagParsing`.

I left the existing BOF parser alone on purpose. It already accepts both `-flag` and `--flag`; it just needed to be fed the un-stripped args. Registering the manifest arguments as native pflag flags would have been a bigger change and would have broken the single-dash form, since pflag reads `-type` as combined shorts (`-t -y -p -e`).

After this change:

- `delegationbof --type 6 --fqdn child.htb.local` works without `--`
- `delegationbof -- --type 6 ...` still works (backwards compatible)
- `delegationbof --timeout 30 --type 6` — Sliver-owned flags and extension args coexist
- quoted values, positional arguments, and single/double-dash forms are preserved

**Tests:** `args_test.go` exercises `splitExtensionArgs` against each acceptance criterion in the issue (with/without `--`, quoted values, positional args, single and double-dash, Sliver flags before extension args, `--help`). The existing manifest-parsing tests still pass. `go vet` and `gofmt` (Go 1.26, matching CI) are clean.

**Scope:** this addresses the extension/BOF path reported in #2309. Aliases share the same root cause (and their help text already links to a wiki page documenting the `--` workaround); happy to follow up with the same treatment there if you'd rather keep this PR focused.
