### PR TITLE
fix(alias): keep alias args intact without "--"

### DIFF
--- a/client/command/alias/args.go
+++ b/client/command/alias/args.go
@@ -1,0 +1,215 @@
+package alias
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2021  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Alias commands run with cobra's DisableFlagParsing enabled (see LoadAlias),
+// the same treatment extension commands received for their arguments. Before
+// that, an unknown flag such as the payload's own `-pid` was rejected outright
+// by pflag ("unknown flag"), and operators had to inject cobra's "--"
+// separator (documented on the wiki) to pass arguments through at all (#2264).
+//
+// With flag parsing disabled cobra hands Run the raw, unstripped slice, and we
+// extract the Sliver-owned flags ourselves here. Everything we do not own is
+// passed to the payload untouched, so all of these now work:
+//
+//	amsi-bypass -pid 6969
+//	fakealias --process notepad.exe arg1 arg2
+//	fakealias -- --anything still-here     (existing workaround, unchanged)
+type ownedFlagKind int
+
+const (
+	ownedBool ownedFlagKind = iota
+	ownedString
+	ownedUint32
+	ownedInt64
+)
+
+// ownedFlagSpec describes one Sliver-owned flag that splitAliasArgs extracts
+// from the raw argument slice before the rest is handed to the alias payload.
+type ownedFlagSpec struct {
+	long  string        // canonical pflag name, e.g. "process-arguments"
+	short string        // shorthand letter, e.g. "A" ("" if the flag has none)
+	kind  ownedFlagKind // how the value is consumed and validated
+}
+
+// baseAliasOwnedFlags are registered for every alias command.
+var baseAliasOwnedFlags = []ownedFlagSpec{
+	{long: "process", short: "p", kind: ownedString},
+	{long: "process-arguments", short: "A", kind: ownedString},
+	{long: "ppid", short: "P", kind: ownedUint32},
+	{long: "save", short: "s", kind: ownedBool},
+	{long: "timeout", short: "t", kind: ownedInt64},
+}
+
+// assemblyAliasOwnedFlags are only owned when the alias wraps a .NET assembly;
+// for every other alias they are unknown tokens and pass through to the payload.
+var assemblyAliasOwnedFlags = []ownedFlagSpec{
+	{long: "method", short: "m", kind: ownedString},
+	{long: "class", short: "c", kind: ownedString},
+	{long: "app-domain", short: "d", kind: ownedString},
+	{long: "arch", short: "a", kind: ownedString},
+	{long: "in-process", short: "i", kind: ownedBool},
+	{long: "runtime", short: "r", kind: ownedString},
+	{long: "amsi-bypass", short: "M", kind: ownedBool},
+	{long: "etw-bypass", short: "E", kind: ownedBool},
+}
+
+// aliasOwnedFlagSpecs returns the flag set owned by a particular alias.
+func aliasOwnedFlagSpecs(isAssembly bool) []ownedFlagSpec {
+	if !isAssembly {
+		return baseAliasOwnedFlags
+	}
+	specs := make([]ownedFlagSpec, 0, len(baseAliasOwnedFlags)+len(assemblyAliasOwnedFlags))
+	specs = append(specs, baseAliasOwnedFlags...)
+	return append(specs, assemblyAliasOwnedFlags...)
+}
+
+// splitAliasArgs separates the Sliver-owned flags from the alias payload's own
+// arguments in a raw (DisableFlagParsing) argument slice. It accepts the long
+// forms --flag, --flag=value, --flag value and the shorthand forms -f, -f=value,
+// -f value, mirroring pflag. Two deliberate differences from pflag:
+//
+//   - a glued shorthand value (-pnotepad) does NOT match --process: tokens
+//     like the payload's own "-pid" must survive intact (#2264);
+//   - after a literal "--" every token is copied through verbatim, preserving
+//     the long-standing separator workaround.
+//
+// The returned map holds the raw string value of each flag that was provided;
+// callers re-publish the values with applyOwnedAliasFlags.
+func splitAliasArgs(raw []string, specs []ownedFlagSpec) (map[string]string, bool, []string, error) {
+	values := make(map[string]string)
+	extArgs := make([]string, 0, len(raw))
+
+	byLong := make(map[string]ownedFlagSpec, len(specs))
+	byShort := make(map[string]ownedFlagSpec, len(specs))
+	for _, spec := range specs {
+		byLong[spec.long] = spec
+		if spec.short != "" {
+			byShort[spec.short] = spec
+		}
+	}
+
+	passthrough := false
+	for i := 0; i < len(raw); i++ {
+		tok := raw[i]
+
+		// Once we have seen "--", copy everything through untouched.
+		if passthrough {
+			extArgs = append(extArgs, tok)
+			continue
+		}
+		if tok == "--" {
+			passthrough = true
+			continue
+		}
+		if tok == "--help" || tok == "-h" {
+			help := true
+			return values, help, extArgs, nil
+		}
+
+		var (
+			spec   ownedFlagSpec
+			value  string
+			inline bool
+			isFlag bool
+		)
+		switch {
+		case strings.HasPrefix(tok, "--"):
+			name, val, hasValue := strings.Cut(tok[2:], "=")
+			if spec, isFlag = byLong[name]; isFlag && hasValue {
+				value, inline = val, true
+			}
+		case strings.HasPrefix(tok, "-") && len(tok) > 1:
+			sh, val, hasValue := strings.Cut(tok[1:], "=")
+			if len(sh) == 1 {
+				if spec, isFlag = byShort[sh]; isFlag && hasValue {
+					value, inline = val, true
+				}
+			}
+		}
+
+		if !isFlag {
+			// Not one of ours (including glued shorthands and the payload's
+			// own flags): the alias owns the token, pass it through untouched.
+			extArgs = append(extArgs, tok)
+			continue
+		}
+
+		switch {
+		case spec.kind == ownedBool:
+			if !inline {
+				value = "true"
+			}
+			values[spec.long] = value
+		case inline:
+			values[spec.long] = value
+		case i+1 < len(raw):
+			i++
+			values[spec.long] = raw[i]
+		default:
+			// Value flag as the very last token with no value: keep the
+			// flag's default and drop the dangling token.
+		}
+	}
+
+	for _, spec := range specs {
+		value, provided := values[spec.long]
+		if !provided {
+			continue
+		}
+		var err error
+		switch spec.kind {
+		case ownedUint32:
+			_, err = strconv.ParseUint(value, 10, 32)
+		case ownedInt64:
+			_, err = strconv.ParseInt(value, 10, 64)
+		}
+		if err != nil {
+			return nil, false, nil, fmt.Errorf("invalid value %q for --%s", value, spec.long)
+		}
+	}
+
+	return values, false, extArgs, nil
+}
+
+// applyOwnedAliasFlags republishes the manually parsed Sliver-owned flag values
+// onto the command's flag set. DisableFlagParsing prevents pflag from
+// populating them, so readers such as runAliasCommand's Get* calls and
+// ActiveTarget.Request (which derives the gRPC timeout from --timeout) would
+// otherwise observe only the defaults.
+func applyOwnedAliasFlags(cmd *cobra.Command, values map[string]string) error {
+	for name, value := range values {
+		flag := cmd.Flags().Lookup(name)
+		if flag == nil {
+			continue // e.g. an assembly flag on a non-assembly alias
+		}
+		if err := flag.Value.Set(value); err != nil {
+			return fmt.Errorf("invalid value %q for --%s: %w", value, name, err)
+		}
+	}
+	return nil
+}

--- a/client/command/alias/args.go
+++ b/client/command/alias/args.go
@@ -88,6 +88,13 @@ func aliasOwnedFlagSpecs(isAssembly bool) []ownedFlagSpec {
 	return append(specs, assemblyAliasOwnedFlags...)
 }
 
+// ownedFlagMatch is a raw token that spelled one of the Sliver-owned flags.
+type ownedFlagMatch struct {
+	spec   ownedFlagSpec
+	value  string // value from a "--flag=value" / "-f=value" spelling
+	inline bool   // whether the token carried its value inline
+}
+
 // splitAliasArgs separates the Sliver-owned flags from the alias payload's own
 // arguments in a raw (DisableFlagParsing) argument slice. It accepts the long
 // forms --flag, --flag=value, --flag value and the shorthand forms -f, -f=value,
@@ -103,15 +110,7 @@ func aliasOwnedFlagSpecs(isAssembly bool) []ownedFlagSpec {
 func splitAliasArgs(raw []string, specs []ownedFlagSpec) (map[string]string, bool, []string, error) {
 	values := make(map[string]string)
 	extArgs := make([]string, 0, len(raw))
-
-	byLong := make(map[string]ownedFlagSpec, len(specs))
-	byShort := make(map[string]ownedFlagSpec, len(specs))
-	for _, spec := range specs {
-		byLong[spec.long] = spec
-		if spec.short != "" {
-			byShort[spec.short] = spec
-		}
-	}
+	byLong, byShort := ownedFlagTables(specs)
 
 	passthrough := false
 	for i := 0; i < len(raw); i++ {
@@ -127,55 +126,93 @@ func splitAliasArgs(raw []string, specs []ownedFlagSpec) (map[string]string, boo
 			continue
 		}
 		if tok == "--help" || tok == "-h" {
-			help := true
-			return values, help, extArgs, nil
+			return values, true, extArgs, nil
 		}
 
-		var (
-			spec   ownedFlagSpec
-			value  string
-			inline bool
-			isFlag bool
-		)
-		switch {
-		case strings.HasPrefix(tok, "--"):
-			name, val, hasValue := strings.Cut(tok[2:], "=")
-			if spec, isFlag = byLong[name]; isFlag && hasValue {
-				value, inline = val, true
-			}
-		case strings.HasPrefix(tok, "-") && len(tok) > 1:
-			sh, val, hasValue := strings.Cut(tok[1:], "=")
-			if len(sh) == 1 {
-				if spec, isFlag = byShort[sh]; isFlag && hasValue {
-					value, inline = val, true
-				}
-			}
-		}
-
-		if !isFlag {
+		match, ok := matchOwnedFlag(tok, byLong, byShort)
+		if !ok {
 			// Not one of ours (including glued shorthands and the payload's
 			// own flags): the alias owns the token, pass it through untouched.
 			extArgs = append(extArgs, tok)
 			continue
 		}
-
-		switch {
-		case spec.kind == ownedBool:
-			if !inline {
-				value = "true"
-			}
-			values[spec.long] = value
-		case inline:
-			values[spec.long] = value
-		case i+1 < len(raw):
-			i++
-			values[spec.long] = raw[i]
-		default:
-			// Value flag as the very last token with no value: keep the
-			// flag's default and drop the dangling token.
-		}
+		i = takeOwnedValue(match, raw, i, values)
 	}
 
+	if err := validateOwnedValues(specs, values); err != nil {
+		return nil, false, nil, err
+	}
+	return values, false, extArgs, nil
+}
+
+// ownedFlagTables indexes the specs by long name and shorthand.
+func ownedFlagTables(specs []ownedFlagSpec) (byLong, byShort map[string]ownedFlagSpec) {
+	byLong = make(map[string]ownedFlagSpec, len(specs))
+	byShort = make(map[string]ownedFlagSpec, len(specs))
+	for _, spec := range specs {
+		byLong[spec.long] = spec
+		if spec.short != "" {
+			byShort[spec.short] = spec
+		}
+	}
+	return byLong, byShort
+}
+
+// matchOwnedFlag checks whether tok spells one of the Sliver-owned flags, in
+// the long form (--name, --name=value) or shorthand form (-f, -f=value). A
+// glued shorthand value (-pnotepad) deliberately does not match: pflag would
+// read "-pid" as -p with value "id", which is exactly the mangling that broke
+// #2264, so such tokens must fall through to the payload.
+func matchOwnedFlag(tok string, byLong, byShort map[string]ownedFlagSpec) (ownedFlagMatch, bool) {
+	var match ownedFlagMatch
+	var name, value string
+	var hasValue, isShort bool
+
+	switch {
+	case strings.HasPrefix(tok, "--"):
+		name, value, hasValue = strings.Cut(tok[2:], "=")
+	case strings.HasPrefix(tok, "-") && len(tok) > 1:
+		name, value, hasValue = strings.Cut(tok[1:], "=")
+		isShort = len(name) == 1
+	default:
+		return match, false
+	}
+
+	spec, ok := byLong[name]
+	if isShort {
+		spec, ok = byShort[name]
+	}
+	if !ok {
+		return match, false
+	}
+	match.spec, match.value, match.inline = spec, value, hasValue
+	return match, true
+}
+
+// takeOwnedValue records the flag's value in values and returns the index of
+// the last raw token it consumed. The "--flag value" / "-f value" spellings
+// consume the following token; a bool without an inline value defaults to
+// true; a value flag as the very last token is dropped and keeps its default,
+// mirroring the extension behaviour.
+func takeOwnedValue(match ownedFlagMatch, raw []string, i int, values map[string]string) int {
+	switch {
+	case match.spec.kind == ownedBool:
+		if !match.inline {
+			match.value = "true"
+		}
+		values[match.spec.long] = match.value
+	case match.inline:
+		values[match.spec.long] = match.value
+	case i+1 < len(raw):
+		values[match.spec.long] = raw[i+1]
+		return i + 1
+	}
+	return i
+}
+
+// validateOwnedValues rejects non-numeric values for the numeric flag kinds,
+// the way pflag's typed values would have.
+func validateOwnedValues(specs []ownedFlagSpec, values map[string]string) error {
 	for _, spec := range specs {
 		value, provided := values[spec.long]
 		if !provided {
@@ -189,11 +226,10 @@ func splitAliasArgs(raw []string, specs []ownedFlagSpec) (map[string]string, boo
 			_, err = strconv.ParseInt(value, 10, 64)
 		}
 		if err != nil {
-			return nil, false, nil, fmt.Errorf("invalid value %q for --%s", value, spec.long)
+			return fmt.Errorf("invalid value %q for --%s", value, spec.long)
 		}
 	}
-
-	return values, false, extArgs, nil
+	return nil
 }
 
 // applyOwnedAliasFlags republishes the manually parsed Sliver-owned flag values

--- a/client/command/alias/args_test.go
+++ b/client/command/alias/args_test.go
@@ -1,0 +1,259 @@
+package alias
+
+/*
+	Sliver Implant Framework
+	Copyright (C) 2021  Bishop Fox
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// TestSplitAliasArgs covers the argument passthrough regression from #2264:
+// the alias payload's own flags must reach the payload intact, while the
+// Sliver-owned flags are extracted and validated.
+func TestSplitAliasArgs(t *testing.T) {
+	base := aliasOwnedFlagSpecs(false)
+	assembly := aliasOwnedFlagSpecs(true)
+
+	cases := []struct {
+		name    string
+		specs   []ownedFlagSpec
+		in      []string
+		values  map[string]string
+		help    bool
+		extArgs []string
+		wantErr bool
+	}{
+		{
+			name:    "payload flag without -- separator (#2264 regression)",
+			specs:   base,
+			in:      []string{"-pid", "6969"},
+			values:  map[string]string{},
+			extArgs: []string{"-pid", "6969"},
+		},
+		{
+			name:    "glued shorthand is not ours and passes through",
+			specs:   base,
+			in:      []string{"-pid"},
+			values:  map[string]string{},
+			extArgs: []string{"-pid"},
+		},
+		{
+			name:    "payload flag with -- separator (existing workaround)",
+			specs:   base,
+			in:      []string{"--", "--pid", "6969"},
+			values:  map[string]string{},
+			extArgs: []string{"--pid", "6969"},
+		},
+		{
+			name:    "owned flag after -- belongs to the payload",
+			specs:   base,
+			in:      []string{"--", "--save"},
+			values:  map[string]string{},
+			extArgs: []string{"--save"},
+		},
+		{
+			name:    "long flag with separate value, then payload args",
+			specs:   base,
+			in:      []string{"--process", "notepad.exe", "arg1", "arg2"},
+			values:  map[string]string{"process": "notepad.exe"},
+			extArgs: []string{"arg1", "arg2"},
+		},
+		{
+			name:    "long flag with equals value",
+			specs:   base,
+			in:      []string{"--process=notepad.exe", "arg1"},
+			values:  map[string]string{"process": "notepad.exe"},
+			extArgs: []string{"arg1"},
+		},
+		{
+			name:    "shorthand with separate value",
+			specs:   base,
+			in:      []string{"-p", "notepad.exe", "arg1"},
+			values:  map[string]string{"process": "notepad.exe"},
+			extArgs: []string{"arg1"},
+		},
+		{
+			name:    "shorthand with equals value",
+			specs:   base,
+			in:      []string{"-p=notepad.exe"},
+			values:  map[string]string{"process": "notepad.exe"},
+			extArgs: []string{},
+		},
+		{
+			name:    "bool shorthand and long false form",
+			specs:   base,
+			in:      []string{"-s", "--save=false", "arg1"},
+			values:  map[string]string{"save": "false"},
+			extArgs: []string{"arg1"},
+		},
+		{
+			name:    "quoted value containing spaces stays a single argument",
+			specs:   base,
+			in:      []string{"-A", "-kalc -kdisable", "arg1"},
+			values:  map[string]string{"process-arguments": "-kalc -kdisable"},
+			extArgs: []string{"arg1"},
+		},
+		{
+			name:    "valid uint32 and int64 values",
+			specs:   base,
+			in:      []string{"-P", "1234", "--timeout=90"},
+			values:  map[string]string{"ppid": "1234", "timeout": "90"},
+			extArgs: []string{},
+		},
+		{
+			name:    "invalid uint32 value errors",
+			specs:   base,
+			in:      []string{"--ppid", "notanumber"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid int64 value errors",
+			specs:   base,
+			in:      []string{"--timeout=x"},
+			wantErr: true,
+		},
+		{
+			name:  "assembly flags are owned for assembly aliases",
+			specs: assembly,
+			in:    []string{"--method", "Run", "--class", "Prog", "-i", "-M", "--arch", "x64", "payloadArg"},
+			values: map[string]string{
+				"method": "Run", "class": "Prog", "in-process": "true",
+				"amsi-bypass": "true", "arch": "x64",
+			},
+			extArgs: []string{"payloadArg"},
+		},
+		{
+			name:    "assembly flags pass through for non-assembly aliases",
+			specs:   base,
+			in:      []string{"--method", "Run"},
+			values:  map[string]string{},
+			extArgs: []string{"--method", "Run"},
+		},
+		{
+			name:    "help flags are detected",
+			specs:   base,
+			in:      []string{"--help"},
+			help:    true,
+			values:  map[string]string{},
+			extArgs: []string{},
+		},
+		{
+			name:    "short help is detected",
+			specs:   base,
+			in:      []string{"-h"},
+			help:    true,
+			values:  map[string]string{},
+			extArgs: []string{},
+		},
+		{
+			name:    "value flag as last token keeps its default",
+			specs:   base,
+			in:      []string{"arg1", "--process"},
+			values:  map[string]string{},
+			extArgs: []string{"arg1"},
+		},
+		{
+			name:    "empty input",
+			specs:   base,
+			in:      nil,
+			values:  map[string]string{},
+			extArgs: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			values, help, extArgs, err := splitAliasArgs(tc.in, tc.specs)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got values=%#v help=%v extArgs=%#v", values, help, extArgs)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if help != tc.help {
+				t.Errorf("help: got %v, want %v", help, tc.help)
+			}
+			if !reflect.DeepEqual(values, tc.values) {
+				t.Errorf("values: got %#v, want %#v", values, tc.values)
+			}
+			if !reflect.DeepEqual(extArgs, tc.extArgs) {
+				t.Errorf("extArgs: got %#v, want %#v", extArgs, tc.extArgs)
+			}
+		})
+	}
+}
+
+// TestApplyOwnedAliasFlags checks that manually parsed values are re-published
+// on the command's flag set for every value type an alias can own.
+func TestApplyOwnedAliasFlags(t *testing.T) {
+	cmd := &cobra.Command{}
+	f := pflag.NewFlagSet("alias-test", pflag.ContinueOnError)
+	f.StringP("process", "p", "", "host process")
+	f.StringP("process-arguments", "A", "", "host process arguments")
+	f.Uint32P("ppid", "P", 0, "parent pid")
+	f.BoolP("save", "s", false, "save output")
+	f.Int64P("timeout", "t", 60, "timeout")
+	f.BoolP("amsi-bypass", "M", false, "amsi bypass")
+	cmd.Flags().AddFlagSet(f)
+
+	err := applyOwnedAliasFlags(cmd, map[string]string{
+		"process":           "notepad.exe",
+		"process-arguments": "-k foo",
+		"ppid":              "1234",
+		"save":              "true",
+		"timeout":           "90",
+		"amsi-bypass":       "true",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	for name, want := range map[string]interface{}{
+		"process": "notepad.exe", "process-arguments": "-k foo",
+	} {
+		got, _ := cmd.Flags().GetString(name)
+		if got != want.(string) {
+			t.Errorf("%s: got %q, want %q", name, got, want)
+		}
+	}
+	if ppid, _ := cmd.Flags().GetUint32("ppid"); ppid != 1234 {
+		t.Errorf("ppid: got %d, want 1234", ppid)
+	}
+	if save, _ := cmd.Flags().GetBool("save"); !save {
+		t.Error("save: got false, want true")
+	}
+	if timeout, _ := cmd.Flags().GetInt64("timeout"); timeout != 90 {
+		t.Errorf("timeout: got %d, want 90", timeout)
+	}
+	if amsi, _ := cmd.Flags().GetBool("amsi-bypass"); !amsi {
+		t.Error("amsi-bypass: got false, want true")
+	}
+
+	// Unset flags keep their defaults.
+	if inProc := cmd.Flags().Lookup("in-process"); inProc != nil {
+		t.Error("in-process should not be registered on this command")
+	}
+}

--- a/client/command/alias/load.go
+++ b/client/command/alias/load.go
@@ -215,8 +215,6 @@ func LoadAlias(manifestPath string, cmd *cobra.Command, con *console.SliverClien
 			longHelp.WriteString(fmt.Sprintf("%s (%s):\t%s%s", strings.ToUpper(arg.Name), aType, optStr, arg.Desc))
 		}
 	}
-	longHelp.WriteString("\n\n⚠️  If you're having issues passing arguments to the alias please read:\n")
-	longHelp.WriteString("https://github.com/BishopFox/sliver/wiki/Aliases-&-Extensions#aliases-command-parsing")
 
 	// for each alias command, add a new app command
 	helpMsg := fmt.Sprintf("[%s] %s", aliasManifest.Name, aliasManifest.Help)
@@ -227,9 +225,14 @@ func LoadAlias(manifestPath string, cmd *cobra.Command, con *console.SliverClien
 		Run: func(cmd *cobra.Command, args []string) {
 			runAliasCommand(cmd, con, args)
 		},
-		Args:        cobra.ArbitraryArgs, // 	a.StringList("arguments", "arguments", grumble.Default([]string{}))
-		GroupID:     consts.AliasHelpGroup,
-		Annotations: makeAliasPlatformFilters(aliasManifest),
+		Args: cobra.ArbitraryArgs, // 	a.StringList("arguments", "arguments", grumble.Default([]string{}))
+		// DisableFlagParsing keeps the alias payload's own flags (which are
+		// unknown to pflag) from being rejected or swallowed; we split the
+		// Sliver-owned flags out of the raw slice ourselves in
+		// runAliasCommand (#2264, same treatment as extensions).
+		DisableFlagParsing: true,
+		GroupID:            consts.AliasHelpGroup,
+		Annotations:        makeAliasPlatformFilters(aliasManifest),
 	}
 
 	if aliasManifest.IsAssembly {
@@ -333,6 +336,27 @@ func runAliasCommand(cmd *cobra.Command, con *console.SliverClient, args []strin
 		return
 	}
 	aliasManifest := loadedAlias.Manifest
+
+	// The command runs with DisableFlagParsing, so args is the raw, unstripped
+	// slice. Separate the Sliver-owned flags from the payload's own arguments
+	// and re-publish them on the flag set (so the Get* readers below and
+	// Request()'s --timeout still work), then hand only the payload arguments
+	// to the execution paths (#2264, same treatment as extensions in #2323).
+	ownedValues, helpRequested, payloadArgs, err := splitAliasArgs(args, aliasOwnedFlagSpecs(aliasManifest.IsAssembly))
+	if err != nil {
+		con.PrintErrorf("%s\n", err)
+		return
+	}
+	if helpRequested {
+		_ = cmd.Help()
+		return
+	}
+	if err := applyOwnedAliasFlags(cmd, ownedValues); err != nil {
+		con.PrintErrorf("%s\n", err)
+		return
+	}
+	args = payloadArgs
+
 	binPath, err := aliasManifest.getFileForTarget(cmd.Name(), goos, goarch)
 	if err != nil {
 		con.PrintErrorf("Fail to find alias file: %s\n", err)


### PR DESCRIPTION
Closes #2264. Follow-up to #2323, same fix applied to aliases.

Aliases had it worse than extensions: instead of silently dropping unknown flags, pflag rejects them outright, so `amsi-bypass -pid 6969` errors out unless the operator knows the `--` trick — which is why every alias help text links to a wiki page explaining it.

What changed:

- alias commands run with `DisableFlagParsing`; `runAliasCommand` splits the Sliver-owned flags out of the raw slice and writes them back onto the flag set, so `Request()`'s `--timeout` and the `Get*` readers are unaffected
- `args.go` owns `--process/-p`, `--process-arguments/-A`, `--ppid/-P`, `--save/-s`, `--timeout/-t`, `--help` for all aliases, plus `--method`, `--class`, `--app-domain`, `--arch`, `--in-process`, `--runtime`, `--amsi-bypass`, `--etw-bypass` for `.NET` assembly aliases only
- everything not in the table goes to the payload verbatim. Glued shorthands included: `-pid` is not read as `-p id` — that misparse is precisely what broke #2264
- `--` still hands everything after it to the payload (for real name collisions), same as before
- wiki workaround warning removed from the generated help text

Note: cobra no longer intercepts `--help` under `DisableFlagParsing`, so the splitter detects it explicitly. This mirrors what the `aka` commands already do with `DisableFlagParsing` for capturing forwarded flags.

Tested: `go test ./client/command/alias`, gofmt clean on Go 1.26. args_test.go covers the exact #2264 command, glued shorthands, `--f v` / `--f=v` / `-f v` / `-f=value` forms, bools, invalid numeric values, both flag tables, `--` passthrough and help.
