### PR TITLE
fix(mcp): make `mcp start` usable without the interactive confirmation

### DIFF
--- a/client/command/mcp/commands.go
+++ b/client/command/mcp/commands.go
@@ -38,6 +38,7 @@ func Commands(con *console.SliverClient) []*cobra.Command {
 		f.String("listen", defaultConfig.ListenAddress, "listen address for the MCP server")
 		f.String("name", defaultConfig.ServerName, "server name for MCP initialize")
 		f.String("version", defaultConfig.ServerVersion, "server version for MCP initialize")
+		f.BoolP("yes", "y", false, "skip the prompt-injection confirmation (broken or non-interactive terminals)")
 	})
 	flags.BindFlagCompletions(startCmd, func(comp *carapace.ActionMap) {
 		(*comp)["transport"] = carapace.ActionValues("http", "sse")

--- a/client/command/mcp/mcp.go
+++ b/client/command/mcp/mcp.go
@@ -32,6 +32,9 @@ func McpCmd(cmd *cobra.Command, con *console.SliverClient, args []string) {
 	if status.AuthToken != "" {
 		con.Printf("Auth Token: %s\n", status.AuthToken)
 	}
+	if status.AuthConfigPath != "" {
+		con.Printf("Auth Config: %s\n", status.AuthConfigPath)
+	}
 
 	if status.Running && !status.StartedAt.IsZero() {
 		uptime := time.Since(status.StartedAt).Truncate(time.Second)

--- a/client/command/mcp/start.go
+++ b/client/command/mcp/start.go
@@ -28,8 +28,10 @@ func McpStartCmd(cmd *cobra.Command, con *console.SliverClient, args []string) {
 	}.WithDefaults()
 
 	msg := `Do you know what prompt injection is and are you an adult?`
-	if !settings.IsUserAnAdultWithPrompt(con, msg) {
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+	if !skipConfirm && !settings.IsUserAnAdultWithPrompt(con, msg) {
 		con.PrintErrorf("Failed to start MCP server, the user is not qualified to use feature\n")
+		con.PrintInfof("Use --yes to skip the confirmation prompt, or toggle it with 'settings autoadult'\n")
 		return
 	}
 
@@ -49,5 +51,8 @@ func McpStartCmd(cmd *cobra.Command, con *console.SliverClient, args []string) {
 	}
 	if status.AuthToken != "" {
 		con.PrintInfof("Auth Token: %s\n", status.AuthToken)
+	}
+	if status.AuthConfigPath != "" {
+		con.PrintInfof("Auth Config: %s\n", status.AuthConfigPath)
 	}
 }

--- a/client/command/settings/opsec.go
+++ b/client/command/settings/opsec.go
@@ -50,7 +50,12 @@ func IsUserAnAdultWithPrompt(con *console.SliverClient, prompt string) bool {
 		return true
 	}
 	confirm := false
-	_ = forms.Confirm(prompt, &confirm)
+	if err := forms.Confirm(prompt, &confirm); err != nil {
+		// The interactive form is known to fail on some terminals (#2133);
+		// surface the error instead of silently treating it as a rejection.
+		con.PrintErrorf("Confirmation prompt failed: %s\n", err)
+		return false
+	}
 	return confirm
 }
 


### PR DESCRIPTION
Closes #2294. Follow-up style fix in the same area as my previous arg-passthrough PRs (#2323/#2326), this time on the MCP server startup path.

**Root cause:** the token generation and persistence in `client/mcp` are fine (`ResolveAuthInfo` creates the token and writes `~/.sliver-client/mcp.yaml`, unit-tested). What breaks is that `mcp start` gates the entire startup behind an interactive huh confirmation. On the terminals where those forms are known to break (#2133), `IsUserAnAdultWithPrompt` discarded the form error, the confirm value stayed false, and the command exited with the unrelated "user is not qualified" message before `Start()` ever ran. Result: no `Auth Token:` line and no `mcp.yaml`, exactly what #2294 reports. There was no flag to bypass the prompt, which is the usual workaround recommended in #2133.

**What changed:**

- `mcp start --yes/-y` skips the prompt-injection confirmation for broken or non-interactive terminals; the rejection message now points at the flag and at `settings autoadult`
- `mcp start` and `mcp` status print `Auth Config: <path>` next to the token, so users can actually find mcp.yaml (the reporter went looking for it)
- `IsUserAnAdultWithPrompt` prints the form error instead of swallowing it, so a terminal incompatibility reports itself rather than masquerading as the user answering "no". Return semantics unchanged (fail closed)

**Testing:** `go test ./client/mcp` (token generation/persistence/middleware) passes unchanged. Verified build, vet and gofmt with the Go 1.26.6 toolchain CI uses. The confirmation path itself is interactive so it's covered by inspection rather than unit tests; happy to add a form-bypass test if there's a seam you'd prefer.
