### PR TITLE
Connection log at client console

### DIFF
--- a/client/command/jobs/commands.go
+++ b/client/command/jobs/commands.go
@@ -67,6 +67,7 @@ func Commands(con *console.SliverClient) []*cobra.Command {
 	flags.Bind("mTLS listener", false, mtlsCmd, func(f *pflag.FlagSet) {
 		f.StringP("lhost", "L", "", "interface to bind server to")
 		f.Uint32P("lport", "l", generate.DefaultMTLSLPort, "tcp listen port")
+		f.BoolP("disable-console-log", "C", false, "disable console log of incoming connections")
 	})
 
 	// Wireguard
@@ -121,6 +122,7 @@ func Commands(con *console.SliverClient) []*cobra.Command {
 		f.BoolP("disable-otp", "D", false, "disable otp authentication")
 		f.StringP("long-poll-timeout", "T", "1s", "server-side long poll timeout")
 		f.StringP("long-poll-jitter", "J", "2s", "server-side long poll jitter")
+		f.BoolP("disable-console-log", "C", false, "disable console log of http requests")
 	})
 	flags.BindFlagCompletions(httpCmd, func(comp *carapace.ActionMap) {
 		(*comp)["website"] = WebsiteNameCompleter(con)
@@ -150,6 +152,8 @@ func Commands(con *console.SliverClient) []*cobra.Command {
 		f.StringP("key", "k", "", "PEM encoded private key file")
 		f.BoolP("lets-encrypt", "e", false, "attempt to provision a let's encrypt certificate")
 		f.BoolP("disable-randomized-jarm", "E", false, "disable randomized jarm fingerprints")
+
+		f.BoolP("disable-console-log", "C", false, "disable console log of https requests")
 	})
 	flags.BindFlagCompletions(httpsCmd, func(comp *carapace.ActionMap) {
 		(*comp)["website"] = WebsiteNameCompleter(con)

--- a/client/command/jobs/http.go
+++ b/client/command/jobs/http.go
@@ -36,6 +36,7 @@ func HTTPListenerCmd(cmd *cobra.Command, con *console.SliverClient, args []strin
 	pollTimeout, _ := cmd.Flags().GetString("long-poll-timeout")
 	pollJitter, _ := cmd.Flags().GetString("long-poll-jitter")
 	website, _ := cmd.Flags().GetString("website")
+	disableConsoleLog, _ := cmd.Flags().GetBool("disable-console-log")
 
 	longPollTimeout, err := time.ParseDuration(pollTimeout)
 	if err != nil {
@@ -58,6 +59,7 @@ func HTTPListenerCmd(cmd *cobra.Command, con *console.SliverClient, args []strin
 		EnforceOTP:      !disableOTP,
 		LongPollTimeout: int64(longPollTimeout),
 		LongPollJitter:  int64(longPollJitter),
+		EnforceConLog:   !disableConsoleLog,
 	})
 	if err != nil {
 		con.PrintErrorf("%s\n", err)

--- a/client/command/jobs/https.go
+++ b/client/command/jobs/https.go
@@ -41,6 +41,7 @@ func HTTPSListenerCmd(cmd *cobra.Command, con *console.SliverClient, args []stri
 	website, _ := cmd.Flags().GetString("website")
 	letsEncrypt, _ := cmd.Flags().GetBool("lets-encrypt")
 	disableRandomize, _ := cmd.Flags().GetBool("disable-randomized-jarm")
+	disableConsoleLog, _ := cmd.Flags().GetBool("disable-console-log")
 
 	longPollTimeout, err := time.ParseDuration(pollTimeout)
 	if err != nil {
@@ -74,6 +75,7 @@ func HTTPSListenerCmd(cmd *cobra.Command, con *console.SliverClient, args []stri
 		LongPollTimeout: int64(longPollTimeout),
 		LongPollJitter:  int64(longPollJitter),
 		RandomizeJARM:   !disableRandomize,
+		EnforceConLog:   !disableConsoleLog,
 	})
 	con.Println()
 	if err != nil {

--- a/client/command/jobs/mtls.go
+++ b/client/command/jobs/mtls.go
@@ -30,11 +30,13 @@ import (
 func MTLSListenerCmd(cmd *cobra.Command, con *console.SliverClient, args []string) {
 	lhost, _ := cmd.Flags().GetString("lhost")
 	lport, _ := cmd.Flags().GetUint32("lport")
+	disableConsoleLog, _ := cmd.Flags().GetBool("disable-console-log")
 
 	con.PrintInfof("Starting mTLS listener ...\n")
 	mtls, err := con.Rpc.StartMTLSListener(context.Background(), &clientpb.MTLSListenerReq{
-		Host: lhost,
-		Port: lport,
+		Host:          lhost,
+		Port:          lport,
+		EnforceConLog: !disableConsoleLog,
 	})
 	con.Println()
 	if err != nil {

--- a/client/console/console.go
+++ b/client/console/console.go
@@ -453,6 +453,13 @@ func (con *SliverClient) startEventLoop(ctx context.Context, rpc rpcpb.SliverRPC
 		case consts.BeaconTaskResultEvent:
 			con.triggerBeaconTaskCallback(event.Data)
 
+		case consts.ConsoleGenericEvent:
+			level := event.Level
+			if level == "" {
+				level = "info"
+			}
+			con.emitConsoleNotification(level, false, string(event.Data))
+
 		}
 
 		con.triggerReactions(event)

--- a/client/constants/constants.go
+++ b/client/constants/constants.go
@@ -122,6 +122,9 @@ const (
 
 	// ClientToastEvent - Local-only event used to surface console notifications inside TUIs.
 	ClientToastEvent = "client-toast"
+
+	//Console generic events
+	ConsoleGenericEvent = "console-generic"
 )
 
 // Commands.

--- a/protobuf/clientpb/client.pb.go
+++ b/protobuf/clientpb/client.pb.go
@@ -5109,6 +5109,7 @@ type MTLSListenerReq struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Host          string                 `protobuf:"bytes,1,opt,name=Host,proto3" json:"Host,omitempty"`
 	Port          uint32                 `protobuf:"varint,2,opt,name=Port,proto3" json:"Port,omitempty"`
+	EnforceConLog bool                   `protobuf:"varint,3,opt,name=EnforceConLog,proto3" json:"EnforceConLog,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -5155,6 +5156,13 @@ func (x *MTLSListenerReq) GetPort() uint32 {
 		return x.Port
 	}
 	return 0
+}
+
+func (x *MTLSListenerReq) GetEnforceConLog() bool {
+	if x != nil {
+		return x.EnforceConLog
+	}
+	return false
 }
 
 type WGListenerReq struct {
@@ -5323,6 +5331,7 @@ type HTTPListenerReq struct {
 	LongPollTimeout int64                  `protobuf:"varint,11,opt,name=LongPollTimeout,proto3" json:"LongPollTimeout,omitempty"`
 	LongPollJitter  int64                  `protobuf:"varint,12,opt,name=LongPollJitter,proto3" json:"LongPollJitter,omitempty"`
 	RandomizeJARM   bool                   `protobuf:"varint,13,opt,name=RandomizeJARM,proto3" json:"RandomizeJARM,omitempty"` // Only valid with Secure = true
+	EnforceConLog   bool                   `protobuf:"varint,14,opt,name=EnforceConLog,proto3" json:"EnforceConLog,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -5437,6 +5446,13 @@ func (x *HTTPListenerReq) GetLongPollJitter() int64 {
 func (x *HTTPListenerReq) GetRandomizeJARM() bool {
 	if x != nil {
 		return x.RandomizeJARM
+	}
+	return false
+}
+
+func (x *HTTPListenerReq) GetEnforceConLog() bool {
+	if x != nil {
+		return x.EnforceConLog
 	}
 	return false
 }
@@ -6941,6 +6957,7 @@ type Event struct {
 	Client        *Client                `protobuf:"bytes,4,opt,name=Client,proto3" json:"Client,omitempty"`
 	Data          []byte                 `protobuf:"bytes,5,opt,name=Data,proto3" json:"Data,omitempty"`
 	Err           string                 `protobuf:"bytes,6,opt,name=Err,proto3" json:"Err,omitempty"` // Can't trigger normal gRPC error
+	Level         string                 `protobuf:"bytes,7,opt,name=Level,proto3" json:"Level,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7013,6 +7030,13 @@ func (x *Event) GetData() []byte {
 func (x *Event) GetErr() string {
 	if x != nil {
 		return x.Err
+	}
+	return ""
+}
+
+func (x *Event) GetLevel() string {
+	if x != nil {
+		return x.Level
 	}
 	return ""
 }
@@ -13298,10 +13322,11 @@ const file_clientpb_client_proto_rawDesc = "" +
 	"\x16MultiplayerListenerReq\x12\x12\n" +
 	"\x04Host\x18\x01 \x01(\tR\x04Host\x12\x12\n" +
 	"\x04Port\x18\x02 \x01(\rR\x04Port\x12\x1c\n" +
-	"\tWireGuard\x18\x03 \x01(\bR\tWireGuard\"9\n" +
+	"\tWireGuard\x18\x03 \x01(\bR\tWireGuard\"_\n" +
 	"\x0fMTLSListenerReq\x12\x12\n" +
 	"\x04Host\x18\x01 \x01(\tR\x04Host\x12\x12\n" +
-	"\x04Port\x18\x02 \x01(\rR\x04Port\"}\n" +
+	"\x04Port\x18\x02 \x01(\rR\x04Port\x12$\n" +
+	"\rEnforceConLog\x18\x03 \x01(\bR\rEnforceConLog\"}\n" +
 	"\rWGListenerReq\x12\x12\n" +
 	"\x04Host\x18\x06 \x01(\tR\x04Host\x12\x12\n" +
 	"\x04Port\x18\x01 \x01(\rR\x04Port\x12\x14\n" +
@@ -13315,7 +13340,7 @@ const file_clientpb_client_proto_rawDesc = "" +
 	"\x04Port\x18\x04 \x01(\rR\x04Port\x12\x1e\n" +
 	"\n" +
 	"EnforceOTP\x18\x06 \x01(\bR\n" +
-	"EnforceOTP\"\xd5\x02\n" +
+	"EnforceOTP\"\xfb\x02\n" +
 	"\x0fHTTPListenerReq\x12\x16\n" +
 	"\x06Domain\x18\x01 \x01(\tR\x06Domain\x12\x12\n" +
 	"\x04Host\x18\x02 \x01(\tR\x04Host\x12\x12\n" +
@@ -13331,7 +13356,8 @@ const file_clientpb_client_proto_rawDesc = "" +
 	"EnforceOTP\x12(\n" +
 	"\x0fLongPollTimeout\x18\v \x01(\x03R\x0fLongPollTimeout\x12&\n" +
 	"\x0eLongPollJitter\x18\f \x01(\x03R\x0eLongPollJitter\x12$\n" +
-	"\rRandomizeJARM\x18\r \x01(\bR\rRandomizeJARM\"X\n" +
+	"\rRandomizeJARM\x18\r \x01(\bR\rRandomizeJARM\x12$\n" +
+	"\rEnforceConLog\x18\x0e \x01(\bR\rEnforceConLog\"X\n" +
 	"\rNamedPipesReq\x12\x1a\n" +
 	"\bPipeName\x18\x10 \x01(\tR\bPipeName\x12+\n" +
 	"\aRequest\x18\t \x01(\v2\x11.commonpb.RequestR\aRequest\"h\n" +
@@ -13442,14 +13468,15 @@ const file_clientpb_client_proto_rawDesc = "" +
 	"\x06Client\x12\x0e\n" +
 	"\x02ID\x18\x01 \x01(\rR\x02ID\x12\x12\n" +
 	"\x04Name\x18\x02 \x01(\tR\x04Name\x12.\n" +
-	"\bOperator\x18\x03 \x01(\v2\x12.clientpb.OperatorR\bOperator\"\xc3\x01\n" +
+	"\bOperator\x18\x03 \x01(\v2\x12.clientpb.OperatorR\bOperator\"\xd9\x01\n" +
 	"\x05Event\x12\x1c\n" +
 	"\tEventType\x18\x01 \x01(\tR\tEventType\x12+\n" +
 	"\aSession\x18\x02 \x01(\v2\x11.clientpb.SessionR\aSession\x12\x1f\n" +
 	"\x03Job\x18\x03 \x01(\v2\r.clientpb.JobR\x03Job\x12(\n" +
 	"\x06Client\x18\x04 \x01(\v2\x10.clientpb.ClientR\x06Client\x12\x12\n" +
 	"\x04Data\x18\x05 \x01(\fR\x04Data\x12\x10\n" +
-	"\x03Err\x18\x06 \x01(\tR\x03Err\"=\n" +
+	"\x03Err\x18\x06 \x01(\tR\x03Err\x12\x14\n" +
+	"\x05Level\x18\a \x01(\tR\x05Level\"=\n" +
 	"\tOperators\x120\n" +
 	"\tOperators\x18\x01 \x03(\v2\x12.clientpb.OperatorR\tOperators\"6\n" +
 	"\bOperator\x12\x16\n" +

--- a/protobuf/clientpb/client.proto
+++ b/protobuf/clientpb/client.proto
@@ -463,6 +463,7 @@ message MultiplayerListenerReq {
 message MTLSListenerReq {
   string Host = 1;
   uint32 Port = 2;
+  bool EnforceConLog = 3;
 }
 
 message WGListenerReq {
@@ -494,6 +495,7 @@ message HTTPListenerReq {
   int64 LongPollTimeout = 11;
   int64 LongPollJitter = 12;
   bool RandomizeJARM = 13; // Only valid with Secure = true
+  bool EnforceConLog = 14;
 }
 
 // Named Pipes Messages for pivoting
@@ -673,6 +675,7 @@ message Event {
   bytes Data = 5;
 
   string Err = 6; // Can't trigger normal gRPC error
+  string Level = 7;
 }
 
 message Operators { repeated Operator Operators = 1; }

--- a/server/c2/http.go
+++ b/server/c2/http.go
@@ -37,6 +37,7 @@ import (
 	"time"
 	"unicode"
 
+	consts "github.com/bishopfox/sliver/client/constants"
 	"github.com/bishopfox/sliver/protobuf/clientpb"
 	"github.com/bishopfox/sliver/protobuf/sliverpb"
 	"github.com/bishopfox/sliver/server/certs"
@@ -350,7 +351,7 @@ func (s *SliverHTTPC2) router() *mux.Router {
 
 	router.HandleFunc("/{rpath:.*}", s.mainHandler).Methods(http.MethodGet, http.MethodPost)
 
-	router.Use(loggingMiddleware)
+	router.Use(s.loggingMiddleware)
 	router.Use(s.DefaultRespHeaders)
 
 	return router
@@ -427,9 +428,18 @@ func digitsOnly(value string) string {
 	return buf.String()
 }
 
-func loggingMiddleware(next http.Handler) http.Handler {
+func (s *SliverHTTPC2) loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		accessLog.Infof("%s - %s - %v", getRemoteAddr(req), req.RequestURI, req.Header.Get("User-Agent"))
+
+		if (s.ServerConf.EnforceConLog) {
+			core.EventBroker.Publish(core.Event{
+				EventType: consts.ConsoleGenericEvent,
+				Level:     "info",
+				Data:      []byte(fmt.Sprintf("%s - %s - %v", getRemoteAddr(req), req.RequestURI, req.Header.Get("User-Agent"))),
+			})
+		}
+
 		next.ServeHTTP(resp, req)
 	})
 }

--- a/server/c2/jobs.go
+++ b/server/c2/jobs.go
@@ -45,7 +45,7 @@ var (
 // StartMTLSListenerJob - Start an mTLS listener as a job
 func StartMTLSListenerJob(mtlsListener *clientpb.MTLSListenerReq) (*core.Job, error) {
 	bind := fmt.Sprintf("%s:%d", mtlsListener.Host, mtlsListener.Port)
-	ln, err := StartMutualTLSListener(mtlsListener.Host, uint16(mtlsListener.Port))
+	ln, err := StartMutualTLSListener(mtlsListener.Host, uint16(mtlsListener.Port), mtlsListener.EnforceConLog)
 	if err != nil {
 		return nil, err // If we fail to bind don't setup the Job
 	}

--- a/server/c2/mtls.go
+++ b/server/c2/mtls.go
@@ -105,7 +105,7 @@ func lookupImplantSigKey(keyID uint64) (ed25519.PublicKey, bool, error) {
 }
 
 // StartMutualTLSListener - Start a mutual TLS listener
-func StartMutualTLSListener(bindIface string, port uint16) (net.Listener, error) {
+func StartMutualTLSListener(bindIface string, port uint16, consoleLog bool) (net.Listener, error) {
 	mtlsLog.Infof("Starting raw TCP/mTLS listener on %s:%d", bindIface, port)
 	host := bindIface
 	if host == "" {
@@ -121,11 +121,11 @@ func StartMutualTLSListener(bindIface string, port uint16) (net.Listener, error)
 		mtlsLog.Error(err)
 		return nil, err
 	}
-	go acceptSliverConnections(ln)
+	go acceptSliverConnections(ln, consoleLog)
 	return ln, nil
 }
 
-func acceptSliverConnections(ln net.Listener) {
+func acceptSliverConnections(ln net.Listener, consoleLog bool) {
 	defer recoverAndLogPanic(mtlsLog.Errorf, "mtls acceptSliverConnections")
 
 	for {
@@ -137,15 +137,23 @@ func acceptSliverConnections(ln net.Listener) {
 			mtlsLog.Errorf("Accept failed: %v", err)
 			continue
 		}
-		go handleSliverConnection(conn)
+		go handleSliverConnection(conn, consoleLog)
 	}
 }
 
-func handleSliverConnection(conn net.Conn) {
+func handleSliverConnection(conn net.Conn, consoleLog bool) {
 	defer recoverAndLogPanic(mtlsLog.Errorf, "mtls handleSliverConnection")
 
 	mtlsLog.Infof("Accepted incoming connection: %s", conn.RemoteAddr())
 	implantConn := core.NewImplantConnection(consts.MtlsStr, conn.RemoteAddr().String())
+
+	if consoleLog {
+		core.EventBroker.Publish(core.Event{
+			EventType: consts.ConsoleGenericEvent,
+			Level:     "info",
+			Data:      []byte(fmt.Sprintf("Accepted incoming connection: %s", conn.RemoteAddr())),
+		})
+	}
 
 	defer func() {
 		mtlsLog.Debugf("mtls connection closing")

--- a/server/configs/server.go
+++ b/server/configs/server.go
@@ -127,9 +127,10 @@ type MultiplayerJobConfig struct {
 
 // MTLSJobConfig - Per-type job configs
 type MTLSJobConfig struct {
-	Host  string `json:"host" yaml:"host"`
-	Port  uint16 `json:"port" yaml:"port"`
-	JobID string `json:"job_id" yaml:"job_id"`
+	Host          string `json:"host" yaml:"host"`
+	Port          uint16 `json:"port" yaml:"port"`
+	JobID         string `json:"job_id" yaml:"job_id"`
+	EnforceConLog bool   `json:"enforce_console_log" yaml:"enforce_console_log"`
 }
 
 // WGJobConfig - Per-type job configs
@@ -165,6 +166,7 @@ type HTTPJobConfig struct {
 	LongPollTimeout int64  `json:"long_poll_timeout" yaml:"long_poll_timeout"`
 	LongPollJitter  int64  `json:"long_poll_jitter" yaml:"long_poll_jitter"`
 	RandomizeJARM   bool   `json:"randomize_jarm" yaml:"randomize_jarm"`
+	EnforceConLog   bool   `json:"enforce_console_log" yaml:"enforce_console_log"`
 }
 
 // WatchTowerConfig - Watch Tower job config

--- a/server/core/events.go
+++ b/server/core/events.go
@@ -40,6 +40,8 @@ type Event struct {
 
 	Data []byte
 	Err  error
+
+	Level string
 }
 
 type eventBroker struct {

--- a/server/db/models/jobs.go
+++ b/server/db/models/jobs.go
@@ -57,6 +57,7 @@ type HTTPListener struct {
 	LongPollJitter  int64
 	RandomizeJarm   bool
 	Staging         bool
+	EnforceConLog   bool
 }
 
 type DNSListener struct {
@@ -85,6 +86,7 @@ type MtlsListener struct {
 	ListenerJobID uuid.UUID `gorm:"type:uuid;"`
 	Host          string
 	Port          uint32
+	EnforceConLog bool
 }
 
 type MultiplayerListener struct {
@@ -172,6 +174,7 @@ func (j *HTTPListener) ToProtobuf() *clientpb.HTTPListenerReq {
 		LongPollTimeout: int64(j.LongPollTimeout),
 		LongPollJitter:  int64(j.LongPollJitter),
 		RandomizeJARM:   j.RandomizeJarm,
+		EnforceConLog:	 j.EnforceConLog,
 	}
 }
 
@@ -201,8 +204,9 @@ func (j *WGListener) ToProtobuf() *clientpb.WGListenerReq {
 
 func (j *MtlsListener) ToProtobuf() *clientpb.MTLSListenerReq {
 	return &clientpb.MTLSListenerReq{
-		Host: j.Host,
-		Port: j.Port,
+		Host: 			j.Host,
+		Port: 			j.Port,
+		EnforceConLog:	j.EnforceConLog,
 	}
 }
 
@@ -236,6 +240,7 @@ func ListenerJobFromProtobuf(pbListenerJob *clientpb.ListenerJob) *ListenerJob {
 			LongPollTimeout: pbListenerJob.HTTPConf.LongPollTimeout,
 			LongPollJitter:  pbListenerJob.HTTPConf.LongPollJitter,
 			RandomizeJarm:   pbListenerJob.HTTPConf.RandomizeJARM,
+			EnforceConLog:	 pbListenerJob.HTTPConf.EnforceConLog,
 		}
 	case constants.HttpsStr:
 		cfg.HttpListener = HTTPListener{
@@ -251,11 +256,13 @@ func ListenerJobFromProtobuf(pbListenerJob *clientpb.ListenerJob) *ListenerJob {
 			LongPollTimeout: pbListenerJob.HTTPConf.LongPollTimeout,
 			LongPollJitter:  pbListenerJob.HTTPConf.LongPollJitter,
 			RandomizeJarm:   pbListenerJob.HTTPConf.RandomizeJARM,
+			EnforceConLog:	 pbListenerJob.HTTPConf.EnforceConLog,
 		}
 	case constants.MtlsStr:
 		cfg.MtlsListener = MtlsListener{
-			Host: pbListenerJob.MTLSConf.Host,
-			Port: pbListenerJob.MTLSConf.Port,
+			Host: 			pbListenerJob.MTLSConf.Host,
+			Port: 			pbListenerJob.MTLSConf.Port,
+			EnforceConLog:	pbListenerJob.MTLSConf.EnforceConLog,
 		}
 	case constants.DnsStr:
 		var domains []DnsDomain

--- a/server/rpc/rpc-events.go
+++ b/server/rpc/rpc-events.go
@@ -33,6 +33,7 @@ func (rpc *Server) Events(_ *commonpb.Empty, stream rpcpb.SliverRPC_EventsServer
 			pbEvent := &clientpb.Event{
 				EventType: event.EventType,
 				Data:      event.Data,
+				Level:     event.Level,
 			}
 
 			if event.Job != nil {


### PR DESCRIPTION
# Streaming Connection & HTTP Request Logs to the Client Console

## Problem

In Sliver's multiplayer model, an operator connects to a team server but does not
necessarily have shell access to the machine running that server. Until now, the record
of **incoming C2 activity** — inbound implant connections on the mTLS listener, and
HTTP/HTTPS requests hitting the web listeners — was written only to the **server-side log
files** (`accessLog`, `mtlsLog`, etc.). An operator without server access had no way to
see, in real time, who was connecting or what requests were arriving.

This change surfaces that same connection/request information **directly in the operator's
client console**, so it can be observed without ever touching the server's filesystem.

## How it works

The implementation reuses Sliver's existing **event broker → gRPC event stream → client**
pipeline rather than inventing a new transport:

1. **New generic console event.** A new event type, `ConsoleGenericEvent`
   (`"console-generic"`), was added to the client constants. It carries an arbitrary text
   payload plus a severity `Level` (defaulting to `"info"`).

2. **Event level propagation.** The `Event` struct (server `core`) and the `Event`
   protobuf message gained a new `Level` field (proto field `7`), and the RPC event stream
   (`rpc-events.go`) now forwards that level to the client. This lets the console render
   the message at the right severity.

3. **Server-side publishing at the point of logging.**
   - **mTLS** (`server/c2/mtls.go`): when `handleSliverConnection` accepts an inbound
     implant connection, in addition to writing to `mtlsLog` it now publishes an
     `Accepted incoming connection: <remote addr>` event to the broker.
   - **HTTP/HTTPS** (`server/c2/http.go`): the `loggingMiddleware` was turned into a method
     on `SliverHTTPC2` so it can access the listener config, and it now publishes each
     request line (`<remote addr> - <URI> - <User-Agent>`) as a console event alongside the
     existing `accessLog` entry.

4. **Client-side rendering.** The client event loop (`client/console/console.go`) handles
   `ConsoleGenericEvent` by calling `emitConsoleNotification(level, ...)`, printing the
   message into the operator's console as it arrives.

## Opt-out per listener

Because a busy listener could flood the console, this behavior is **enabled by default but
can be disabled per listener**. A new `EnforceConLog` boolean was threaded end-to-end:

- **Protobuf**: added to `MTLSListenerReq` and `HTTPListenerReq`.
- **CLI**: each of the `mtls`, `http`, and `https` listener commands gained a
  `--disable-console-log` / `-C` flag. The flag is inverted into `EnforceConLog` (i.e.
  console logging is on unless explicitly disabled).
- **Server config & persistence**: `EnforceConLog` was added to `MTLSJobConfig` /
  `HTTPJobConfig` and to the DB models (`HTTPListener`, `MtlsListener`), with the
  corresponding `ToProtobuf` / `ListenerJobFromProtobuf` mappings, so the setting survives
  listener persistence and restart. The server only publishes console events when the
  listener's `EnforceConLog` is true.

## Result

An operator working purely through the client console now sees live inbound mTLS
connections and HTTP/HTTPS request logs as they happen — the same data previously buried in
server logs — with no need for server access, and with a `-C` flag to silence any listener
whose traffic is too noisy.
