### PR TITLE
Fix extensions rm deleting external directories

### DIFF
--- a/client/command/extensions/extensions_test.go
+++ b/client/command/extensions/extensions_test.go
@@ -152,6 +152,82 @@ func newExtensionTestConsole(t *testing.T, rpc rpcpb.SliverRPCClient, session *c
 	return con
 }
 
+func TestRemoveExtensionByManifestNameOnlyDeletesManagedExtensions(t *testing.T) {
+	clientRoot := t.TempDir()
+	t.Setenv("SLIVER_CLIENT_ROOT_DIR", clientRoot)
+
+	originalManifests := loadedManifests
+	originalExtensions := loadedExtensions
+	t.Cleanup(func() {
+		loadedManifests = originalManifests
+		loadedExtensions = originalExtensions
+	})
+
+	tests := []struct {
+		name        string
+		extPath     string
+		wantDeleted bool
+	}{
+		{
+			name:        "installed extension",
+			extPath:     filepath.Join(clientRoot, "extensions", "installed"),
+			wantDeleted: true,
+		},
+		{
+			name:        "temporarily loaded extension",
+			extPath:     t.TempDir(),
+			wantDeleted: false,
+		},
+		{
+			name:        "extensions directory sibling",
+			extPath:     filepath.Join(clientRoot, "extensions-backup"),
+			wantDeleted: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := os.MkdirAll(test.extPath, 0o700); err != nil {
+				t.Fatalf("create extension directory: %v", err)
+			}
+			markerPath := filepath.Join(test.extPath, "source-code.txt")
+			if err := os.WriteFile(markerPath, []byte("keep me"), 0o600); err != nil {
+				t.Fatalf("create marker file: %v", err)
+			}
+
+			manifestName := "test-extension"
+			commandName := "test-command"
+			command := &ExtCommand{CommandName: commandName}
+			loadedManifests = map[string]*ExtensionManifest{
+				manifestName: {RootPath: test.extPath, ExtCommand: []*ExtCommand{command}},
+			}
+			loadedExtensions = map[string]*ExtCommand{commandName: command}
+
+			found, err := RemoveExtensionByManifestName(manifestName, nil)
+			if err != nil {
+				t.Fatalf("remove extension: %v", err)
+			}
+			if !found {
+				t.Fatal("expected extension manifest to be found")
+			}
+			if _, ok := loadedManifests[manifestName]; ok {
+				t.Error("manifest was not unloaded")
+			}
+			if _, ok := loadedExtensions[commandName]; ok {
+				t.Error("command was not unloaded")
+			}
+
+			_, err = os.Stat(markerPath)
+			if test.wantDeleted && !os.IsNotExist(err) {
+				t.Errorf("managed extension directory was not deleted: %v", err)
+			}
+			if !test.wantDeleted && err != nil {
+				t.Errorf("external extension directory was modified: %v", err)
+			}
+		})
+	}
+}
+
 func TestParseExtensionManifest(t *testing.T) {
 	expectedPath := util.ResolvePath("foo/test1.dll")
 

--- a/client/command/extensions/remove.go
+++ b/client/command/extensions/remove.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/bishopfox/sliver/client/assets"
 	"github.com/bishopfox/sliver/client/console"
@@ -100,21 +99,11 @@ func RemoveExtensionByManifestName(manifestName string, con *console.SliverClien
 			return true, nil
 		}
 
-		// If path is outside extensions directory, prompt for confirmation
-		if !strings.HasPrefix(extPath, assets.GetExtensionsDir()) {
-			confirm := false
-			_ = forms.Confirm(fmt.Sprintf("Remove '%s' extension directory from filesystem?", manifestName), &confirm)
-			if !confirm {
-				// Skip the forceRemoveAll but continue with the rest
-				delete(loadedManifests, manifestName)
-				for _, cmd := range man.ExtCommand {
-					delete(loadedExtensions, cmd.CommandName)
-				}
-				return true, nil
-			}
+		// Only installed extensions are owned by Sliver and may be deleted.
+		// Temporarily loaded extensions can live in arbitrary source directories.
+		if isWithinExtensionsDir(extPath) {
+			forceRemoveAll(extPath)
 		}
-
-		forceRemoveAll(extPath)
 		delete(loadedManifests, manifestName)
 		for _, cmd := range man.ExtCommand {
 			delete(loadedExtensions, cmd.CommandName)
@@ -122,6 +111,14 @@ func RemoveExtensionByManifestName(manifestName string, con *console.SliverClien
 		return true, nil
 	}
 	return false, nil
+}
+
+func isWithinExtensionsDir(extPath string) bool {
+	relPath, err := filepath.Rel(assets.GetExtensionsDir(), extPath)
+	if err != nil {
+		return false
+	}
+	return relPath != "." && filepath.IsLocal(relPath)
 }
 
 func forceRemoveAll(rootPath string) {


### PR DESCRIPTION
## Summary
- only delete extension directories managed beneath the Sliver client extensions directory
- unload temporarily loaded extensions without deleting their source directory
- use filepath.Rel and filepath.IsLocal for path containment
- add regression tests for managed, external, and sibling-prefix directories

## Testing
- gofmt
- git diff --check
- ./go-tests.sh --unit-only (client tests ran; the suite later failed in an unrelated test/e2e armory test because the sandbox blocked an httptest listener)