### PR TITLE
Fix Armory extension updates and archive installs

### DIFF
--- a/client/command/armory/install.go
+++ b/client/command/armory/install.go
@@ -301,32 +301,44 @@ func getCommandsInCache(armoryPK string) []string {
 	return commandNames
 }
 
+func packageMatchesInstallName(cacheEntry pkgCacheEntry, name string) bool {
+	if cacheEntry.Pkg.IsAlias {
+		return cacheEntry.Alias != nil && cacheEntry.Alias.CommandName == name
+	}
+	if cacheEntry.Extension == nil {
+		return false
+	}
+	if cacheEntry.Pkg.CommandName == name || cacheEntry.Extension.PackageName == name {
+		return true
+	}
+	for _, command := range cacheEntry.Extension.ExtCommand {
+		if command.CommandName == name {
+			return true
+		}
+	}
+	return false
+}
+
 func getPackagesWithCommandName(name, armoryPK, minimumVersion string) []*pkgCacheEntry {
 	packages := []*pkgCacheEntry{}
 
 	pkgCache.Range(func(key, value interface{}) bool {
 		cacheEntry := value.(pkgCacheEntry)
-		if cacheEntry.LastErr == nil {
-			if cacheEntry.Pkg.IsAlias {
-				if cacheEntry.Alias.CommandName == name {
-					if minimumVersion == "" || (minimumVersion != "" && cacheEntry.Alias.Version >= minimumVersion) {
-						if armoryPK == "" || (armoryPK != "" && cacheEntry.ArmoryConfig.PublicKey == armoryPK) {
-							packages = append(packages, &cacheEntry)
-						}
-					}
-				}
-			} else {
-				for _, command := range cacheEntry.Extension.ExtCommand {
-					if command.CommandName == name {
-						if minimumVersion == "" || (minimumVersion != "" && cacheEntry.Extension.Version >= minimumVersion) {
-							if armoryPK == "" || (armoryPK != "" && cacheEntry.ArmoryConfig.PublicKey == armoryPK) {
-								packages = append(packages, &cacheEntry)
-							}
-							break
-						}
-					}
-				}
-			}
+		if cacheEntry.LastErr != nil || !packageMatchesInstallName(cacheEntry, name) {
+			return true
+		}
+		if armoryPK != "" && cacheEntry.ArmoryConfig.PublicKey != armoryPK {
+			return true
+		}
+
+		packageVersion := ""
+		if cacheEntry.Pkg.IsAlias {
+			packageVersion = cacheEntry.Alias.Version
+		} else {
+			packageVersion = cacheEntry.Extension.Version
+		}
+		if minimumVersion == "" || packageVersion >= minimumVersion {
+			packages = append(packages, &cacheEntry)
 		}
 		return true
 	})
@@ -732,9 +744,7 @@ func installExtensionPackage(entry *pkgCacheEntry, promptToOverwrite bool, clien
 
 	con.Printf(console.Clearln + "\r") // Clear download message
 
-	extensions.InstallFromDir(tmpFileName, promptToOverwrite, con, true)
-
-	return nil
+	return extensions.InstallFromDir(tmpFileName, promptToOverwrite, con, true)
 }
 
 func writeArmoryTempFile(data []byte) (string, error) {

--- a/client/command/armory/install_test.go
+++ b/client/command/armory/install_test.go
@@ -13,12 +13,12 @@ import (
 
 func resetPackageCache(t *testing.T) {
 	t.Helper()
-	pkgCache.Range(func(key, value any) bool {
+	pkgCache.Range(func(key, _ any) bool {
 		pkgCache.Delete(key)
 		return true
 	})
 	t.Cleanup(func() {
-		pkgCache.Range(func(key, value any) bool {
+		pkgCache.Range(func(key, _ any) bool {
 			pkgCache.Delete(key)
 			return true
 		})

--- a/client/command/armory/install_test.go
+++ b/client/command/armory/install_test.go
@@ -1,0 +1,218 @@
+package armory
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bishopfox/sliver/client/assets"
+	"github.com/bishopfox/sliver/client/command/alias"
+	"github.com/bishopfox/sliver/client/command/extensions"
+)
+
+func resetPackageCache(t *testing.T) {
+	t.Helper()
+	pkgCache.Range(func(key, value any) bool {
+		pkgCache.Delete(key)
+		return true
+	})
+	t.Cleanup(func() {
+		pkgCache.Range(func(key, value any) bool {
+			pkgCache.Delete(key)
+			return true
+		})
+	})
+}
+
+func testExtensionCacheEntry() pkgCacheEntry {
+	manifest := &extensions.ExtensionManifest{
+		Name:        "ADCS Request (Remote)",
+		PackageName: "remote-adcs-package",
+		Version:     "v0.1.5",
+		ArmoryName:  "Default Armory",
+		ArmoryPK:    "armory-public-key",
+		ExtCommand: []*extensions.ExtCommand{
+			{CommandName: "remote-adcs-request"},
+			{CommandName: "remote-adcs-request-on-behalf"},
+		},
+	}
+	return pkgCacheEntry{
+		ArmoryConfig: &assets.ArmoryConfig{PublicKey: "armory-public-key"},
+		Pkg: ArmoryPackage{
+			Name:        "Remote ADCS package",
+			CommandName: "remote-adcs-index",
+		},
+		Extension: manifest,
+		ID:        "remote-adcs-request-id",
+	}
+}
+
+func TestGetPackageForCommandAcceptsStableExtensionIdentities(t *testing.T) {
+	resetPackageCache(t)
+	entry := testExtensionCacheEntry()
+	pkgCache.Store(entry.ID, entry)
+
+	for _, name := range []string{
+		"remote-adcs-index",
+		"remote-adcs-request",
+		"remote-adcs-request-on-behalf",
+		"remote-adcs-package",
+	} {
+		t.Run(name, func(t *testing.T) {
+			found, err := getPackageForCommand(name, "armory-public-key", "v0.1.5")
+			if err != nil {
+				t.Fatalf("lookup %q failed: %v", name, err)
+			}
+			if found.ID != entry.ID {
+				t.Fatalf("lookup %q returned %q, want %q", name, found.ID, entry.ID)
+			}
+		})
+	}
+
+	if _, err := getPackageForCommand("remote-adcs-package", "other-armory", "v0.1.5"); !errors.Is(err, ErrPackageNotFound) {
+		t.Fatalf("wrong-armory lookup error = %v, want %v", err, ErrPackageNotFound)
+	}
+	if _, err := getPackageForCommand("remote-adcs-package", "armory-public-key", "v0.1.6"); !errors.Is(err, ErrPackageNotFound) {
+		t.Fatalf("newer-version lookup error = %v, want %v", err, ErrPackageNotFound)
+	}
+	for _, name := range []string{"ADCS Request (Remote)", "Remote ADCS package", "unknown-package"} {
+		if _, err := getPackageForCommand(name, "", ""); !errors.Is(err, ErrPackageNotFound) {
+			t.Fatalf("unstable identity %q lookup error = %v, want %v", name, err, ErrPackageNotFound)
+		}
+	}
+}
+
+func TestPackageMatchesInstallNameLeavesAliasesCommandOnly(t *testing.T) {
+	entry := pkgCacheEntry{
+		Pkg: ArmoryPackage{
+			Name:        "Human Alias Name",
+			CommandName: "alias-command",
+			IsAlias:     true,
+		},
+		Alias: &alias.AliasManifest{CommandName: "alias-command"},
+	}
+	if packageMatchesInstallName(entry, "Human Alias Name") {
+		t.Fatal("alias unexpectedly matched its display name")
+	}
+	if !packageMatchesInstallName(entry, "alias-command") {
+		t.Fatal("alias did not match its command name")
+	}
+}
+
+func TestExtensionManifestsMatch(t *testing.T) {
+	manifest := func(name, packageName string, commands ...string) *extensions.ExtensionManifest {
+		extCommands := make([]*extensions.ExtCommand, 0, len(commands))
+		for _, command := range commands {
+			extCommands = append(extCommands, &extensions.ExtCommand{CommandName: command})
+		}
+		return &extensions.ExtensionManifest{Name: name, PackageName: packageName, ExtCommand: extCommands}
+	}
+
+	tests := []struct {
+		name   string
+		local  *extensions.ExtensionManifest
+		latest *extensions.ExtensionManifest
+		want   bool
+	}{
+		{
+			name:   "v2 package identity",
+			local:  manifest("Old Display Name", "stable-package", "old-command"),
+			latest: manifest("New Display Name", "stable-package", "new-command"),
+			want:   true,
+		},
+		{
+			name:   "different v2 packages",
+			local:  manifest("Shared Display Name", "package-one", "shared-command"),
+			latest: manifest("Shared Display Name", "package-two", "shared-command"),
+			want:   false,
+		},
+		{
+			name:   "v2 does not downgrade to legacy identity",
+			local:  manifest("Human Display Name", "stable-package", "shared-command"),
+			latest: manifest("legacy-command", "", "shared-command"),
+			want:   false,
+		},
+		{
+			name:   "legacy command identity",
+			local:  manifest("legacy-command", "", "legacy-command"),
+			latest: manifest("Human Display Name", "stable-package", "other-command", "legacy-command"),
+			want:   true,
+		},
+		{
+			name:   "display names are not identity",
+			local:  manifest("Shared Name", "", "old-command"),
+			latest: manifest("Shared Name", "stable-package", "new-command"),
+			want:   false,
+		},
+		{
+			name:   "unrelated legacy package",
+			local:  manifest("Old Name", "", "old-command"),
+			latest: manifest("New Name", "stable-package", "new-command"),
+			want:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := extensionManifestsMatch(test.local, test.latest); got != test.want {
+				t.Fatalf("extensionManifestsMatch() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestExtensionUpdateDisplayNameResolvesPackage(t *testing.T) {
+	resetPackageCache(t)
+	t.Setenv("SLIVER_CLIENT_ROOT_DIR", t.TempDir())
+
+	installedManifest := []byte(`{
+		"name":"ADCS Request (Remote)",
+		"package_name":"remote-adcs-package",
+		"version":"v0.1.3",
+		"commands":[{
+			"command_name":"remote-adcs-request",
+			"help":"Request a certificate",
+			"files":[{"os":"windows","arch":"amd64","path":"adcs_request.x64.o"}]
+		}]
+	}`)
+	installDir := filepath.Join(assets.GetExtensionsDir(), "remote-adcs-request")
+	if err := os.MkdirAll(installDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installDir, extensions.ManifestFileName), installedManifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	entry := testExtensionCacheEntry()
+	pkgCache.Store(entry.ID, entry)
+	otherEntry := testExtensionCacheEntry()
+	otherEntry.ID = "other-armory-package-id"
+	otherEntry.ArmoryConfig = &assets.ArmoryConfig{PublicKey: "other-armory"}
+	otherManifest := *otherEntry.Extension
+	otherManifest.Version = "v9.0.0"
+	otherManifest.ArmoryName = "Other Armory"
+	otherManifest.ArmoryPK = "other-armory"
+	otherEntry.Extension = &otherManifest
+	pkgCache.Store(otherEntry.ID, otherEntry)
+
+	updates := checkForExtensionUpdates("armory-public-key")
+	versionInfo, ok := updates["ADCS Request (Remote)"]
+	if !ok {
+		t.Fatal("display-name update was not detected")
+	}
+	if versionInfo.OldVersion != "v0.1.3" || versionInfo.NewVersion != "v0.1.5" {
+		t.Fatalf("unexpected versions: %#v", versionInfo)
+	}
+	if versionInfo.PackageID != entry.ID {
+		t.Fatalf("update package ID = %q, want %q", versionInfo.PackageID, entry.ID)
+	}
+
+	found := packageCacheLookupByID(versionInfo.PackageID)
+	if found == nil {
+		t.Fatal("detected update package is missing from the cache")
+	}
+	if found.ID != entry.ID {
+		t.Fatalf("resolved package %q, want %q", found.ID, entry.ID)
+	}
+}

--- a/client/command/armory/update.go
+++ b/client/command/armory/update.go
@@ -200,7 +200,7 @@ func checkForExtensionUpdates(armoryPK string) map[string]VersionInformation {
 		if err != nil {
 			continue
 		}
-		pkgCache.Range(func(key, value interface{}) bool {
+		pkgCache.Range(func(_, value interface{}) bool {
 			cacheEntry, ok := value.(pkgCacheEntry)
 			if !ok || cacheEntry.LastErr != nil || cacheEntry.Pkg.IsAlias || cacheEntry.Extension == nil {
 				return true

--- a/client/command/armory/update.go
+++ b/client/command/armory/update.go
@@ -40,6 +40,7 @@ type VersionInformation struct {
 	OldVersion string
 	NewVersion string
 	ArmoryName string
+	PackageID  string
 }
 
 type PackageType uint
@@ -124,9 +125,9 @@ func ArmoryUpdateCmd(cmd *cobra.Command, con *console.SliverClient, args []strin
 			if !ok {
 				continue
 			}
-			updatedPackage, err := getPackageForCommand(update.Name, armoryPK, extVersionInfo.NewVersion)
-			if err != nil {
-				con.PrintErrorf("Could not get update package for extension %s: %s\n", update.Name, err)
+			updatedPackage := packageCacheLookupByID(extVersionInfo.PackageID)
+			if updatedPackage == nil {
+				con.PrintErrorf("Could not get update package for extension %s: %s\n", update.Name, ErrPackageNotFound)
 				continue
 			}
 			err = installExtensionPackage(updatedPackage, false, clientConfig, con)
@@ -173,8 +174,21 @@ func checkForAliasUpdates(armoryPK string) map[string]VersionInformation {
 	return results
 }
 
+func extensionManifestsMatch(localManifest, latestManifest *extensions.ExtensionManifest) bool {
+	if localManifest.PackageName != "" {
+		return latestManifest.PackageName != "" && localManifest.PackageName == latestManifest.PackageName
+	}
+	for _, localCommand := range localManifest.ExtCommand {
+		for _, latestCommand := range latestManifest.ExtCommand {
+			if localCommand.CommandName == latestCommand.CommandName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func checkForExtensionUpdates(armoryPK string) map[string]VersionInformation {
-	_, cachedExtensions := packageManifestsInCache()
 	// Return a map of extension name to minimum version to install
 	results := make(map[string]VersionInformation)
 	for _, extManifestPath := range assets.GetInstalledExtensionManifests() {
@@ -186,7 +200,12 @@ func checkForExtensionUpdates(armoryPK string) map[string]VersionInformation {
 		if err != nil {
 			continue
 		}
-		for _, latestExt := range cachedExtensions {
+		pkgCache.Range(func(key, value interface{}) bool {
+			cacheEntry, ok := value.(pkgCacheEntry)
+			if !ok || cacheEntry.LastErr != nil || cacheEntry.Pkg.IsAlias || cacheEntry.Extension == nil {
+				return true
+			}
+			latestExt := cacheEntry.Extension
 			/*
 				We used to check if the version identifiers were different between the installed version and the
 				version in the armory. This worked when we had one armory, but with multiple potential armories,
@@ -194,16 +213,22 @@ func checkForExtensionUpdates(armoryPK string) map[string]VersionInformation {
 				so we will rely on the author of the package incrementing the version identifier somehow to determine
 				if a package is newer.
 			*/
-			if latestExt.Name == localManifest.Name && latestExt.Version > localManifest.Version {
+			if extensionManifestsMatch(localManifest, latestExt) && latestExt.Version > localManifest.Version {
 				if latestExt.ArmoryPK == armoryPK || armoryPK == "" {
-					results[localManifest.Name] = VersionInformation{
-						OldVersion: localManifest.Version,
-						NewVersion: latestExt.Version,
-						ArmoryName: latestExt.ArmoryName,
+					current, found := results[localManifest.Name]
+					if !found || latestExt.Version > current.NewVersion ||
+						(latestExt.Version == current.NewVersion && cacheEntry.ID < current.PackageID) {
+						results[localManifest.Name] = VersionInformation{
+							OldVersion: localManifest.Version,
+							NewVersion: latestExt.Version,
+							ArmoryName: latestExt.ArmoryName,
+							PackageID:  cacheEntry.ID,
+						}
 					}
 				}
 			}
-		}
+			return true
+		})
 	}
 
 	return results

--- a/client/command/extensions/install.go
+++ b/client/command/extensions/install.go
@@ -43,6 +43,20 @@ func ExtensionsInstallCmd(cmd *cobra.Command, con *console.SliverClient, args []
 	_ = InstallFromDir(extLocalPath, true, con, strings.HasSuffix(extLocalPath, ".tar.gz"))
 }
 
+func readExtensionManifest(extLocalPath string, isGz bool) ([]byte, error) {
+	if isGz {
+		return util.ReadFileFromTarGz(extLocalPath, fmt.Sprintf("./%s", ManifestFileName))
+	}
+	return os.ReadFile(filepath.Join(extLocalPath, ManifestFileName))
+}
+
+func extensionPackageID(manifest *ExtensionManifest) string {
+	if manifest.PackageName != "" {
+		return manifest.PackageName
+	}
+	return manifest.Name
+}
+
 // InstallFromDir installs a Sliver extension from either a local directory or gzipped archive.
 // It reads the extension manifest, validates it, and copies all required files to the extensions
 // directory. If an extension with the same name already exists, it can optionally prompt for
@@ -61,14 +75,7 @@ func ExtensionsInstallCmd(cmd *cobra.Command, con *console.SliverClient, args []
 //
 // Declining an overwrite prompt cancels the installation without an error.
 func InstallFromDir(extLocalPath string, promptToOverwrite bool, con *console.SliverClient, isGz bool) error {
-	var manifestData []byte
-	var err error
-
-	if isGz {
-		manifestData, err = util.ReadFileFromTarGz(extLocalPath, fmt.Sprintf("./%s", ManifestFileName))
-	} else {
-		manifestData, err = os.ReadFile(filepath.Join(extLocalPath, ManifestFileName))
-	}
+	manifestData, err := readExtensionManifest(extLocalPath, isGz)
 	if err != nil {
 		con.PrintErrorf("Error reading %s: %s", ManifestFileName, err)
 		return fmt.Errorf("read %s: %w", ManifestFileName, err)
@@ -82,10 +89,7 @@ func InstallFromDir(extLocalPath string, promptToOverwrite bool, con *console.Sl
 
 	// Use package name if available, otherwise use extension name
 	// (Note, for v1 manifests this will actually be command_name)
-	packageID := manifestF.Name
-	if manifestF.PackageName != "" {
-		packageID = manifestF.PackageName
-	}
+	packageID := extensionPackageID(manifestF)
 
 	//create repo path
 	minstallPath := filepath.Join(assets.GetExtensionsDir(), filepath.Base(packageID))

--- a/client/command/extensions/install.go
+++ b/client/command/extensions/install.go
@@ -40,7 +40,7 @@ func ExtensionsInstallCmd(cmd *cobra.Command, con *console.SliverClient, args []
 		con.PrintErrorf("Extension path '%s' does not exist", extLocalPath)
 		return
 	}
-	InstallFromDir(extLocalPath, true, con, strings.HasSuffix(extLocalPath, ".tar.gz"))
+	_ = InstallFromDir(extLocalPath, true, con, strings.HasSuffix(extLocalPath, ".tar.gz"))
 }
 
 // InstallFromDir installs a Sliver extension from either a local directory or gzipped archive.
@@ -54,12 +54,13 @@ func ExtensionsInstallCmd(cmd *cobra.Command, con *console.SliverClient, args []
 //   - con: Sliver console client for displaying status and error messages
 //   - isGz: Whether the source is a gzipped archive (true) or directory (false)
 //
-// The function will return early with error messages printed to console if:
+// The function returns errors after printing them to the console if:
 //   - The manifest cannot be read or parsed
 //   - Required directories cannot be created
 //   - File copy operations fail
-//   - User declines overwrite when prompted
-func InstallFromDir(extLocalPath string, promptToOverwrite bool, con *console.SliverClient, isGz bool) {
+//
+// Declining an overwrite prompt cancels the installation without an error.
+func InstallFromDir(extLocalPath string, promptToOverwrite bool, con *console.SliverClient, isGz bool) error {
 	var manifestData []byte
 	var err error
 
@@ -70,13 +71,13 @@ func InstallFromDir(extLocalPath string, promptToOverwrite bool, con *console.Sl
 	}
 	if err != nil {
 		con.PrintErrorf("Error reading %s: %s", ManifestFileName, err)
-		return
+		return fmt.Errorf("read %s: %w", ManifestFileName, err)
 	}
 
 	manifestF, err := ParseExtensionManifest(manifestData)
 	if err != nil {
 		con.PrintErrorf("Error parsing %s: %s", ManifestFileName, err)
-		return
+		return fmt.Errorf("parse %s: %w", ManifestFileName, err)
 	}
 
 	// Use package name if available, otherwise use extension name
@@ -94,7 +95,7 @@ func InstallFromDir(extLocalPath string, promptToOverwrite bool, con *console.Sl
 			confirm := false
 			_ = forms.Confirm("Overwrite current install?", &confirm)
 			if !confirm {
-				return
+				return nil
 			}
 		}
 		forceRemoveAll(minstallPath)
@@ -103,13 +104,13 @@ func InstallFromDir(extLocalPath string, promptToOverwrite bool, con *console.Sl
 	err = os.MkdirAll(minstallPath, 0o700)
 	if err != nil {
 		con.PrintErrorf("Error creating extension directory: %s\n", err)
-		return
+		return fmt.Errorf("create extension directory: %w", err)
 	}
 	err = os.WriteFile(filepath.Join(minstallPath, ManifestFileName), manifestData, 0o600)
 	if err != nil {
 		con.PrintErrorf("Failed to write %s: %s\n", ManifestFileName, err)
 		forceRemoveAll(minstallPath)
-		return
+		return fmt.Errorf("write %s: %w", ManifestFileName, err)
 	}
 
 	for _, manifest := range manifestF.ExtCommand {
@@ -125,7 +126,7 @@ func InstallFromDir(extLocalPath string, promptToOverwrite bool, con *console.Sl
 					if err != nil {
 						con.PrintErrorf("\nError creating extension directory: %s\n", err)
 						forceRemoveAll(installPath)
-						return
+						return fmt.Errorf("create extension artifact directory: %w", err)
 					}
 					err = util.CopyFile(src, dst)
 					if err != nil {
@@ -135,11 +136,12 @@ func InstallFromDir(extLocalPath string, promptToOverwrite bool, con *console.Sl
 				if err != nil {
 					con.PrintErrorf("Error installing command: %s\n", err)
 					forceRemoveAll(installPath)
-					return
+					return fmt.Errorf("install extension artifact: %w", err)
 				}
 			}
 		}
 	}
+	return nil
 }
 
 func installArtifact(extGzFilePath string, installPath string, artifactPath string) error {

--- a/client/command/extensions/install_test.go
+++ b/client/command/extensions/install_test.go
@@ -1,0 +1,135 @@
+package extensions
+
+import (
+	"archive/tar"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bishopfox/sliver/client/assets"
+	"github.com/bishopfox/sliver/client/console"
+	"github.com/klauspost/compress/gzip"
+	"github.com/spf13/cobra"
+)
+
+type installArchiveMember struct {
+	name string
+	data []byte
+}
+
+const installTestManifest = `{
+	"name": "Test Extension",
+	"package_name": "test-extension",
+	"version": "v1.0.0",
+	"commands": [{
+		"command_name": "test-command",
+		"help": "test command",
+		"files": [{"os": "windows", "arch": "amd64", "path": "foo/test.dll"}]
+	}]
+}`
+
+func writeInstallArchive(t *testing.T, prefix string, members ...installArchiveMember) string {
+	t.Helper()
+	archivePath := filepath.Join(t.TempDir(), "extension.tar.gz")
+	archive, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gzipWriter := gzip.NewWriter(archive)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for _, member := range members {
+		header := &tar.Header{
+			Name:     prefix + member.name,
+			Mode:     0o600,
+			Size:     int64(len(member.data)),
+			Typeflag: tar.TypeReg,
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tarWriter.Write(member.data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return archivePath
+}
+
+func testInstallConsole(t *testing.T) *console.SliverClient {
+	t.Helper()
+	con := console.NewConsole(false)
+	emptyCommands := func() *cobra.Command { return &cobra.Command{Use: "test"} }
+	if err := console.StartClient(
+		con, nil, nil, nil, emptyCommands, emptyCommands, false, "",
+	); err != nil {
+		t.Fatal(err)
+	}
+	return con
+}
+
+func TestInstallFromDirAcceptsPrefixedAndUnprefixedArchives(t *testing.T) {
+	for _, prefix := range []string{"./", ""} {
+		name := "unprefixed"
+		if prefix != "" {
+			name = "prefixed"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("SLIVER_CLIENT_ROOT_DIR", t.TempDir())
+			archivePath := writeInstallArchive(t, prefix,
+				installArchiveMember{name: ManifestFileName, data: []byte(installTestManifest)},
+				installArchiveMember{name: "foo/test.dll", data: []byte("extension data")},
+			)
+
+			if err := InstallFromDir(archivePath, false, testInstallConsole(t), true); err != nil {
+				t.Fatal(err)
+			}
+			installRoot := filepath.Join(assets.GetExtensionsDir(), "test-extension")
+			if _, err := os.Stat(filepath.Join(installRoot, ManifestFileName)); err != nil {
+				t.Fatalf("installed manifest: %v", err)
+			}
+			artifact, err := os.ReadFile(filepath.Join(installRoot, "foo", "test.dll"))
+			if err != nil {
+				t.Fatalf("installed artifact: %v", err)
+			}
+			if string(artifact) != "extension data" {
+				t.Fatalf("artifact data = %q", artifact)
+			}
+		})
+	}
+}
+
+func TestInstallFromDirReturnsMissingManifest(t *testing.T) {
+	t.Setenv("SLIVER_CLIENT_ROOT_DIR", t.TempDir())
+	archivePath := writeInstallArchive(t, "./",
+		installArchiveMember{name: "foo/test.dll", data: []byte("extension data")},
+	)
+	err := InstallFromDir(archivePath, false, testInstallConsole(t), true)
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("error = %v, want fs.ErrNotExist", err)
+	}
+}
+
+func TestInstallFromDirReturnsMissingArtifactAndCleansUp(t *testing.T) {
+	t.Setenv("SLIVER_CLIENT_ROOT_DIR", t.TempDir())
+	archivePath := writeInstallArchive(t, "./",
+		installArchiveMember{name: ManifestFileName, data: []byte(installTestManifest)},
+	)
+	err := InstallFromDir(archivePath, false, testInstallConsole(t), true)
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("error = %v, want fs.ErrNotExist", err)
+	}
+	installRoot := filepath.Join(assets.GetExtensionsDir(), "test-extension")
+	if _, err := os.Stat(installRoot); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("install directory was not cleaned up: %v", err)
+	}
+}

--- a/util/files.go
+++ b/util/files.go
@@ -24,8 +24,10 @@ import (
 
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/klauspost/compress/flate"
 	"github.com/klauspost/compress/gzip"
@@ -82,6 +84,7 @@ func ReadFileFromTarGz(tarGzFile string, tarPath string) ([]byte, error) {
 	defer gzf.Close()
 
 	tarReader := tar.NewReader(gzf)
+	normalizedTarPath := normalizeTarPath(tarPath)
 	for {
 		header, err := tarReader.Next()
 		if err == io.EOF {
@@ -90,7 +93,7 @@ func ReadFileFromTarGz(tarGzFile string, tarPath string) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		if header.Name == tarPath {
+		if normalizeTarPath(header.Name) == normalizedTarPath {
 			switch header.Typeflag {
 			case tar.TypeDir: // = directory
 				continue
@@ -99,7 +102,14 @@ func ReadFileFromTarGz(tarGzFile string, tarPath string) ([]byte, error) {
 			}
 		}
 	}
-	return nil, nil
+	return nil, fmt.Errorf("archive member %q: %w", tarPath, fs.ErrNotExist)
+}
+
+func normalizeTarPath(tarPath string) string {
+	for strings.HasPrefix(tarPath, "./") {
+		tarPath = strings.TrimPrefix(tarPath, "./")
+	}
+	return tarPath
 }
 
 // CopyFile - Copy a file from src to dst

--- a/util/files_test.go
+++ b/util/files_test.go
@@ -1,0 +1,126 @@
+package util
+
+import (
+	"archive/tar"
+	"errors"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/klauspost/compress/gzip"
+)
+
+type tarTestMember struct {
+	name     string
+	typeflag byte
+	data     []byte
+}
+
+func writeTestTarGz(t *testing.T, members ...tarTestMember) string {
+	t.Helper()
+	archivePath := t.TempDir() + "/test.tar.gz"
+	archive, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gzipWriter := gzip.NewWriter(archive)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for _, member := range members {
+		memberSize := int64(0)
+		if member.typeflag == tar.TypeReg {
+			memberSize = int64(len(member.data))
+		}
+		header := &tar.Header{
+			Name:     member.name,
+			Mode:     0o600,
+			Size:     memberSize,
+			Typeflag: member.typeflag,
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			t.Fatal(err)
+		}
+		if member.typeflag == tar.TypeReg {
+			if _, err := tarWriter.Write(member.data); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return archivePath
+}
+
+func TestReadFileFromTarGzNormalizesLeadingDotSlash(t *testing.T) {
+	tests := []struct {
+		name        string
+		archiveName string
+		requestName string
+	}{
+		{name: "both prefixed", archiveName: "./file.txt", requestName: "./file.txt"},
+		{name: "archive prefixed", archiveName: "./file.txt", requestName: "file.txt"},
+		{name: "request prefixed", archiveName: "file.txt", requestName: "./file.txt"},
+		{name: "repeated prefix", archiveName: "././file.txt", requestName: "./file.txt"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			archivePath := writeTestTarGz(t, tarTestMember{
+				name: test.archiveName, typeflag: tar.TypeReg, data: []byte("contents"),
+			})
+			data, err := ReadFileFromTarGz(archivePath, test.requestName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != "contents" {
+				t.Fatalf("data = %q, want contents", data)
+			}
+		})
+	}
+}
+
+func TestReadFileFromTarGzRejectsDifferentOrNonRegularPaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		archiveName string
+		requestName string
+		typeflag    byte
+	}{
+		{name: "missing", archiveName: "other.txt", requestName: "file.txt", typeflag: tar.TypeReg},
+		{name: "parent path", archiveName: "file.txt", requestName: "../file.txt", typeflag: tar.TypeReg},
+		{name: "absolute path", archiveName: "file.txt", requestName: "/file.txt", typeflag: tar.TypeReg},
+		{name: "archive parent path", archiveName: "../file.txt", requestName: "file.txt", typeflag: tar.TypeReg},
+		{name: "archive absolute path", archiveName: "/file.txt", requestName: "file.txt", typeflag: tar.TypeReg},
+		{name: "directory", archiveName: "file.txt", requestName: "file.txt", typeflag: tar.TypeDir},
+		{name: "symlink", archiveName: "file.txt", requestName: "file.txt", typeflag: tar.TypeSymlink},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			archivePath := writeTestTarGz(t, tarTestMember{
+				name: test.archiveName, typeflag: test.typeflag, data: []byte("contents"),
+			})
+			_, err := ReadFileFromTarGz(archivePath, test.requestName)
+			if !errors.Is(err, fs.ErrNotExist) {
+				t.Fatalf("error = %v, want fs.ErrNotExist", err)
+			}
+		})
+	}
+}
+
+func TestReadFileFromTarGzReturnsEmptyRegularFile(t *testing.T) {
+	archivePath := writeTestTarGz(t, tarTestMember{name: "file.txt", typeflag: tar.TypeReg})
+	data, err := ReadFileFromTarGz(archivePath, "./file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("data length = %d, want 0", len(data))
+	}
+}


### PR DESCRIPTION
## Summary

- carry the exact selected Armory package cache ID from extension update discovery through installation
- match V2 extension updates by stable `package_name`, scoped to the selected Armory, while retaining command-based fallback for legacy V1 manifests
- keep human-readable extension names as display data instead of treating them as install identities
- accept both `./extension.json` and `extension.json` tar member spellings without broad path cleaning
- return archive/install failures to Armory instead of printing and silently succeeding

## Root cause

Extension update discovery compares the installed and latest human-readable manifest names. For example, it correctly detects an update for `ADCS Request (Remote)`, whose package and command identity is `remote-adcs-request`.

The update path then passed the human-readable name back through `getPackageForCommand`. That resolver only compared actual command names, so it searched for a command literally named `ADCS Request (Remote)` and returned `ErrPackageNotFound` before downloading the selected package.

This primarily affects V2 extensions whose display name differs from `package_name`. Legacy V1 manifests often avoided the bug because conversion made their effective name equal their command name.

## Compatibility

V2 packages use `package_name` as their stable update identity. Legacy installed V1 extensions continue to use command intersection as a fallback. The selected package is installed by its exact cache ID, avoiding a second ambiguous lookup or cross-Armory match.

Tar path normalization strips only repeated leading `./`; it does not use `path.Clean` or alias absolute/traversal paths. Missing and non-regular members return wrapped `fs.ErrNotExist` errors.

## Validation

- `gofmt` and `git diff --check`
- `./go-tests.sh --unit-only` with the repository's Go 1.26.6 toolchain
- regression coverage for V1/V2 identity matching, multiple Armories, exact package selection, archive prefix variants, unsafe paths, missing members/artifacts, zero-length files, cleanup, and error propagation
- all 51 public [CS-Remote-OPs-BOF v0.1.7](https://github.com/sliverarmory/CS-Remote-OPs-BOF/releases/tag/v0.1.7) archives parsed successfully through Sliver's manifest reader, including every manifest-referenced object
