### PR TITLE
Add --service-name flag to generate for Windows service implants

### DIFF
--- a/client/command/generate/commands.go
+++ b/client/command/generate/commands.go
@@ -368,6 +368,7 @@ func coreImplantFlags(name string, cmd *cobra.Command) {
 		bindSpoofMetadataFlag(f)
 
 		f.StringP("format", "f", "exe", "Specifies the output formats, valid values are: 'exe', 'shared' (for dynamic libraries), 'archive' (for Go c-archives), 'service' (see: `psexec` for more info) and 'shellcode' (windows, darwin/arm64, linux/amd64, linux/arm64)")
+		f.String("service-name", "", "service name to register the implant under (service format only)")
 
 		// Shellcode generation options:
 		// - Windows: Donut

--- a/client/command/generate/generate.go
+++ b/client/command/generate/generate.go
@@ -405,6 +405,10 @@ func parseCompileFlags(cmd *cobra.Command, con *console.SliverClient) (string, *
 		// Default to exe
 		configFormat = clientpb.OutputFormat_EXECUTABLE
 	}
+	serviceName, _ := cmd.Flags().GetString("service-name")
+	if !isService {
+		serviceName = ""
+	}
 
 	targetOSF, _ := cmd.Flags().GetString("os")
 	targetOS := strings.ToLower(targetOSF)
@@ -541,6 +545,7 @@ func parseCompileFlags(cmd *cobra.Command, con *console.SliverClient) (string, *
 		IsService:   isService,
 		IsShellcode: isShellcode,
 		Exports:     exports,
+		ServiceName: serviceName,
 
 		RunAtLoad:              runAtLoad,
 		NetGoEnabled:           netGo,

--- a/implant/sliver/runner/runner.go
+++ b/implant/sliver/runner/runner.go
@@ -119,7 +119,7 @@ func Main() {
 	limits.ExecLimits() // Check to see if we should execute
 
 	// {{if .Config.IsService}}
-	svc.Run("", &sliverService{})
+	svc.Run("{{if .Config.ServiceName}}{{.Config.ServiceName}}{{else}}{{end}}", &sliverService{})
 	// {{else}}
 
 	// {{if .Config.IsBeacon}}

--- a/protobuf/clientpb/client.pb.go
+++ b/protobuf/clientpb/client.pb.go
@@ -4102,6 +4102,7 @@ type ImplantConfig struct {
 	TrafficEncodersEnabled bool             `protobuf:"varint,152,opt,name=TrafficEncodersEnabled,proto3" json:"TrafficEncodersEnabled,omitempty"`
 	TrafficEncoders        []string         `protobuf:"bytes,153,rep,name=TrafficEncoders,proto3" json:"TrafficEncoders,omitempty"`
 	Extension              string           `protobuf:"bytes,154,opt,name=Extension,proto3" json:"Extension,omitempty"`
+	ServiceName            string           `protobuf:"bytes,156,opt,name=ServiceName,proto3" json:"ServiceName,omitempty"`
 	Assets                 []*commonpb.File `protobuf:"bytes,200,rep,name=Assets,proto3" json:"Assets,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
@@ -4476,6 +4477,13 @@ func (x *ImplantConfig) GetTrafficEncoders() []string {
 func (x *ImplantConfig) GetExtension() string {
 	if x != nil {
 		return x.Extension
+	}
+	return ""
+}
+
+func (x *ImplantConfig) GetServiceName() string {
+	if x != nil {
+		return x.ServiceName
 	}
 	return ""
 }
@@ -16139,7 +16147,7 @@ const file_clientpb_client_proto_rawDesc = "" +
 	"\aHeaders\x18\x06 \x01(\rR\aHeaders\x12\x16\n" +
 	"\x06Thread\x18\a \x01(\bR\x06Thread\x12\x18\n" +
 	"\aUnicode\x18\b \x01(\bR\aUnicode\x12\x10\n" +
-	"\x03OEP\x18\t \x01(\rR\x03OEP\"\x8e\x0f\n" +
+	"\x03OEP\x18\t \x01(\rR\x03OEP\"\xb1\x0f\n" +
 	"\rImplantConfig\x12\x0e\n" +
 	"\x02ID\x18\x01 \x01(\tR\x02ID\x12<\n" +
 	"\rImplantBuilds\x18\x02 \x03(\v2\x16.clientpb.ImplantBuildR\rImplantBuilds\x12*\n" +
@@ -16196,7 +16204,8 @@ const file_clientpb_client_proto_rawDesc = "" +
 	"\fNetGoEnabled\x18\x97\x01 \x01(\bR\fNetGoEnabled\x127\n" +
 	"\x16TrafficEncodersEnabled\x18\x98\x01 \x01(\bR\x16TrafficEncodersEnabled\x12)\n" +
 	"\x0fTrafficEncoders\x18\x99\x01 \x03(\tR\x0fTrafficEncoders\x12\x1d\n" +
-	"\tExtension\x18\x9a\x01 \x01(\tR\tExtension\x12'\n" +
+	"\tExtension\x18\x9a\x01 \x01(\tR\tExtension\x12!\n" +
+	"\vServiceName\x18\x9c\x01 \x01(\tR\vServiceName\x12'\n" +
 	"\x06Assets\x18\xc8\x01 \x03(\v2\x0e.commonpb.FileR\x06AssetsJ\x06\b\x9b\x01\x10\x9c\x01R\tSpoofData\";\n" +
 	"\x11SpoofMetadataFile\x12\x12\n" +
 	"\x04Name\x18\x01 \x01(\tR\x04Name\x12\x12\n" +

--- a/protobuf/clientpb/client.proto
+++ b/protobuf/clientpb/client.proto
@@ -218,6 +218,7 @@ message ImplantConfig {
   bool TrafficEncodersEnabled = 152;
   repeated string TrafficEncoders = 153;
   string Extension = 154;
+  string ServiceName = 156;
   reserved 155;
   reserved "SpoofData";
 

--- a/server/db/models/implant.go
+++ b/server/db/models/implant.go
@@ -199,6 +199,7 @@ type ImplantConfig struct {
 	IsSharedLib bool
 	IsService   bool
 	IsShellcode bool
+	ServiceName string
 
 	RunAtLoad bool
 	// Shellcode options (Windows: Donut; macOS/Linux: Compress only)
@@ -276,6 +277,7 @@ func (ic *ImplantConfig) ToProtobuf() *clientpb.ImplantConfig {
 		IsSharedLib:       ic.IsSharedLib,
 		IsService:         ic.IsService,
 		IsShellcode:       ic.IsShellcode,
+		ServiceName:       ic.ServiceName,
 		Format:            ic.Format,
 		WGPeerTunIP:       ic.WGPeerTunIP,
 		WGKeyExchangePort: ic.WGKeyExchangePort,
@@ -503,6 +505,7 @@ func ImplantConfigFromProtobuf(pbConfig *clientpb.ImplantConfig) *ImplantConfig 
 	cfg.IsSharedLib = pbConfig.IsSharedLib
 	cfg.IsService = pbConfig.IsService
 	cfg.IsShellcode = pbConfig.IsShellcode
+	cfg.ServiceName = pbConfig.ServiceName
 	cfg.RunAtLoad = pbConfig.RunAtLoad
 	cfg.DebugFile = pbConfig.DebugFile
 	cfg.Exports = strings.Join(pbConfig.Exports, ",")


### PR DESCRIPTION
### Problem
`generate --format service` has no way to control the service name that the implant registers with the Service Control Manager (SCM). The implant template calls `svc.Run("", &sliverService{})` in `implant/sliver/runner/runner.go`. The empty string is passed directly into the `SERVICE_TABLE_ENTRY` dispatch table.

For `SERVICE_WIN32_SHARE_PROCESS` services, SCM validates that the name in the dispatch table matches the registered service name. An empty string does not match, and SCM rejects the start with error 1083 (`The executable program that this service is configured to run in does not implement the service`).

This matters when pointing an already-registered `SHARE_PROCESS` service at a Sliver service binary via `ImagePath`. SCM asks the binary to host the original service name. The dispatch table has to declare that name or the start fails. Re-registering the service as `OWN_PROCESS` avoids the validation, but that requires write access to the service key's `Type` value, which is not always available when only `ImagePath` is writable. It is also a more invasive change than re-pointing the binary path. `psexec` already exposes `--service-name` for this class of scenario, but the standalone `generate` path does not.

### Change
Add a `--service-name` flag to `generate`. When set, the value is embedded into the implant's `svc.Run` call through the existing template pipeline. When unset, the template renders back to `svc.Run("", ...)` and behavior is unchanged.

Files touched:
- `protobuf/clientpb/client.proto`: add `string service_name = 156;` to `ImplantConfig`.
- `protobuf/clientpb/client.pb.go`: regenerated.
- `client/command/generate/commands.go`: register `--service-name` string flag.
- `client/command/generate/generate.go`: read the flag in `parseCompileFlags` and set `config.ServiceName` when the format is service.
- `implant/sliver/runner/runner.go`: replace `svc.Run("", &sliverService{})` with `svc.Run("{{if .Config.ServiceName}}{{.Config.ServiceName}}{{else}}{{end}}", &sliverService{})`.
- `server/db/models/implant.go`: add `ServiceName` to the model struct and both conversion functions so the field round-trips through saved profiles and external builder builds.

### Scope
Only affects Windows `--format service` builds. No other format, platform, or command is touched. The `psexec` command and its existing `--service-name` flag are unchanged.

### Backwards compatibility
When `--service-name` is not passed, `Config.ServiceName` is empty and the template renders `svc.Run("", ...)` exactly as before. Existing builds behave identically. `OWN_PROCESS` services are unaffected either way, since SCM ignores the dispatch table name for that type.